### PR TITLE
feat: hover / definition / references / rename / documentSymbol / completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,20 +6,48 @@ language, built directly on the compiler-as-library editor surface
 
 ## Status
 
-This server implements the **diagnostics** vertical slice end-to-end:
+This server implements the **diagnostics** vertical slice plus the
+**language features** end-to-end, all on the `mach.lang.editor` surface:
 
 - LSP lifecycle: `initialize`, `initialized`, `shutdown`, `exit`.
 - Document synchronization (full-text): `textDocument/didOpen`,
   `didChange`, `didClose`.
-- On open/change, the buffer text is fed to `mach.lang.editor`
+- Diagnostics: on open/change the buffer text is fed to `mach.lang.editor`
   (`open` / `update` / `diagnostics`); every reported `diagnostic.Diagnostic`
   is mapped — its byte span through `source.position` to a 0-based LSP range,
   its severity to the LSP scale — and published via
   `textDocument/publishDiagnostics`.
+- Language features over the buffer's resolved analysis (`editor.resolve` +
+  `ast.offset_to_*` + the `resolve.ResolveResult` side tables):
+  - `textDocument/hover` — the declaration header (or kind + name) of the
+    symbol at the cursor, as a fenced `mach` code block.
+  - `textDocument/definition` — the resolved symbol's declaration `Location`.
+  - `textDocument/references` — every in-file position resolving to the same
+    symbol (declaration plus use-sites).
+  - `textDocument/rename` / `prepareRename` — a `WorkspaceEdit` renaming every
+    in-file reference; `prepareRename` returns the name range.
+  - `textDocument/documentSymbol` — the module's top-level declarations as a
+    `DocumentSymbol` list.
+  - `textDocument/completion` — the file's named declarations, `use` aliases,
+    and the primitive type names.
 
-Language features (`hover`, `definition`, `references`, `rename`,
-`completion`, `documentSymbol`) are **not yet implemented** — see
-[deferred](#deferred).
+### Single-file scope
+
+The editor resolves one buffer in isolation with an empty dependency set, so
+resolution is **single-file**. A reference to a locally declared symbol binds
+fully (its declaration is in the same buffer); a symbol imported through a
+`use` resolves against dependency modules this server never loaded, so:
+
+- hover/definition/references/rename are complete for **local** symbols;
+- a cross-module `use`d symbol does not resolve, so those features return
+  `null`/empty for it rather than a wrong answer — never a faked result;
+- completion is a flat list of the file's named symbols and the primitives,
+  not a lexically scoped view (the resolver's scope chain is not exposed by
+  the side tables).
+
+Full-project resolution (cross-module go-to-def, workspace symbols,
+scope-aware completion) needs the driver's dependency loading wired into the
+editor surface, tracked upstream.
 
 ## Building
 
@@ -51,28 +79,35 @@ remote dependencies tracking `branch/dev`.
 | `json` | minimal JSON field extraction and response assembly |
 | `documents` | URI ⇄ editor `FileId` registry |
 | `diagnostics` | run `editor.diagnostics`, map spans, publish |
+| `positions` | byte offset ⇄ LSP `(line, character)` and span text |
+| `features` | offset → id → symbol query core over the resolve side tables |
+| `language` | hover / definition / references / rename / documentSymbol / completion request bodies |
 | `trace` | append-only debug trace log (`/tmp/mach-lsp.log`) |
 
 ## Testing
 
-`smoke.py` drives the server over stdio with framed JSON-RPC and asserts the
-diagnostics behaviour (broken buffer → diagnostics with ranges; clean buffer →
-empty; `didChange`/`didClose` clear):
+Two stdio smoke tests drive the server with framed JSON-RPC:
+
+- `smoke.py` asserts diagnostics (broken buffer → diagnostics with ranges;
+  clean buffer → empty; `didChange`/`didClose` clear).
+- `smoke_features.py` asserts the language features against a small typed
+  source: hover renders signatures/types, definition lands on the decl,
+  references finds decl + use-sites, rename emits a `WorkspaceEdit`,
+  documentSymbol lists the top-level decls, completion includes the file's
+  functions and the primitives.
 
 ```sh
-mach build && python3 smoke.py
+mach build && python3 smoke.py && python3 smoke_features.py
 ```
 
 ## Deferred
 
-The following are tracked as a follow-up (see issue #33). They require an
-offset → `ExprId`/`DeclId`/`TypeId` lookup (`ast.offset_to_*`) plus the
-`resolve.ResolveResult` side tables, a from-scratch query layer against the
-new id-based AST:
+These need full-project resolution (the driver's dependency loading wired into
+the editor surface), which is out of scope for the single-file query layer:
 
-- `textDocument/hover`
-- `textDocument/definition`
-- `textDocument/references`
-- `textDocument/rename` / `prepareRename`
-- `textDocument/completion`
-- `textDocument/documentSymbol`
+- cross-module go-to-definition / hover / references (symbols imported via
+  `use` resolve against dependency modules the editor does not load);
+- workspace symbol search;
+- scope-aware completion (member access after `.`, lexically scoped locals)
+  — the resolver's scope chain is internal to the resolve pass and not
+  exposed by the side tables.

--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,7 @@
 [project]
 id = "mls"
 name = "Mach Language Server"
-version = "0.4.0"
+version = "0.5.0"
 dir_src = "src"
 dir_dep = "dep"
 dir_out = "out"

--- a/smoke_features.py
+++ b/smoke_features.py
@@ -72,6 +72,10 @@ requests = b"".join([
     # rename `x` -> `y`
     frame({"jsonrpc": "2.0", "id": 41, "method": "textDocument/rename",
            "params": {"textDocument": {"uri": URI}, "position": pos(2, 8), "newName": "y"}}),
+    # rename parameter `a` from its binding site (line 0, char 11) -> `arg`;
+    # must rewrite the binding plus the `ret a` use (a correct, compiling rename)
+    frame({"jsonrpc": "2.0", "id": 42, "method": "textDocument/rename",
+           "params": {"textDocument": {"uri": URI}, "position": pos(0, 11), "newName": "arg"}}),
     # documentSymbol
     frame({"jsonrpc": "2.0", "id": 50, "method": "textDocument/documentSymbol",
            "params": {"textDocument": {"uri": URI}}}),
@@ -93,7 +97,7 @@ def by_id(i):
 print("=== server exit code:", proc.returncode)
 print("=== messages received:", len(msgs))
 for m in msgs:
-    if m.get("id") in (10, 11, 20, 30, 40, 41, 50, 60):
+    if m.get("id") in (10, 11, 20, 30, 40, 41, 42, 50, 60):
         print(json.dumps(m))
 
 failures = []
@@ -155,6 +159,24 @@ else:
         failures.append(f"rename(x) produced {len(edits)} edits, expected >= 2")
     elif any(e.get("newText") != "y" for e in edits):
         failures.append("rename(x) edit newText is not 'y'")
+
+# rename of parameter `a` -> `arg`: binding site + the `ret a` use (>= 2 edits)
+rp2 = by_id(42)
+rp2v = (rp2 or {}).get("result")
+if not rp2v or "changes" not in rp2v:
+    failures.append("rename(param a) returned no WorkspaceEdit")
+else:
+    pedits = rp2v["changes"].get(URI, [])
+    if len(pedits) < 2:
+        failures.append(f"rename(param a) produced {len(pedits)} edits, expected >= 2 (binding + use)")
+    elif any(e.get("newText") != "arg" for e in pedits):
+        failures.append("rename(param a) edit newText is not 'arg'")
+    else:
+        # the binding site is on line 0 (the signature); a use is on line 0 too,
+        # but there must be an edit at the binding column (char 11)
+        cols = {e["range"]["start"]["character"] for e in pedits if e["range"]["start"]["line"] == 0}
+        if 11 not in cols:
+            failures.append(f"rename(param a) did not rewrite the binding at col 11 (cols {sorted(cols)})")
 
 # documentSymbol -> helper and main present
 ds = by_id(50)

--- a/smoke_features.py
+++ b/smoke_features.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+# smoke test: drive the mach-lsp server over stdio with framed JSON-RPC and
+# assert the language features (hover, definition, references, rename,
+# prepareRename, documentSymbol, completion) against a small typed source.
+import json
+import subprocess
+import sys
+
+BIN = "out/linux/bin/mach-lsp"
+
+SRC = (
+    "fun helper(a: i64) i64 { ret a; }\n"   # line 0
+    "fun main() i64 {\n"                     # line 1
+    "    val x: i64 = helper(7);\n"          # line 2
+    "    ret x;\n"                            # line 3
+    "}\n"                                     # line 4
+)
+URI = "file:///feat.mach"
+
+
+def frame(obj):
+    body = json.dumps(obj).encode()
+    return b"Content-Length: %d\r\n\r\n%s" % (len(body), body)
+
+
+def read_messages(data):
+    msgs = []
+    i = 0
+    while i < len(data):
+        hdr_end = data.find(b"\r\n\r\n", i)
+        if hdr_end < 0:
+            break
+        header = data[i:hdr_end].decode(errors="replace")
+        clen = None
+        for line in header.split("\r\n"):
+            if line.lower().startswith("content-length:"):
+                clen = int(line.split(":", 1)[1].strip())
+        if clen is None:
+            break
+        bstart = hdr_end + 4
+        body = data[bstart:bstart + clen]
+        msgs.append(json.loads(body.decode()))
+        i = bstart + clen
+    return msgs
+
+
+def pos(line, ch):
+    return {"line": line, "character": ch}
+
+
+requests = b"".join([
+    frame({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"capabilities": {}}}),
+    frame({"jsonrpc": "2.0", "method": "initialized", "params": {}}),
+    frame({"jsonrpc": "2.0", "method": "textDocument/didOpen",
+           "params": {"textDocument": {"uri": URI, "languageId": "mach", "version": 1, "text": SRC}}}),
+    # hover on `helper` at its call site (line 2, char ~17)
+    frame({"jsonrpc": "2.0", "id": 10, "method": "textDocument/hover",
+           "params": {"textDocument": {"uri": URI}, "position": pos(2, 17)}}),
+    # hover on `x` use at `ret x` (line 3, char 8)
+    frame({"jsonrpc": "2.0", "id": 11, "method": "textDocument/hover",
+           "params": {"textDocument": {"uri": URI}, "position": pos(3, 8)}}),
+    # definition of `helper` call (line 2) -> decl on line 0
+    frame({"jsonrpc": "2.0", "id": 20, "method": "textDocument/definition",
+           "params": {"textDocument": {"uri": URI}, "position": pos(2, 17)}}),
+    # references of `helper` (decl + the one call)
+    frame({"jsonrpc": "2.0", "id": 30, "method": "textDocument/references",
+           "params": {"textDocument": {"uri": URI}, "position": pos(0, 4),
+                      "context": {"includeDeclaration": True}}}),
+    # prepareRename on `x`
+    frame({"jsonrpc": "2.0", "id": 40, "method": "textDocument/prepareRename",
+           "params": {"textDocument": {"uri": URI}, "position": pos(2, 8)}}),
+    # rename `x` -> `y`
+    frame({"jsonrpc": "2.0", "id": 41, "method": "textDocument/rename",
+           "params": {"textDocument": {"uri": URI}, "position": pos(2, 8), "newName": "y"}}),
+    # documentSymbol
+    frame({"jsonrpc": "2.0", "id": 50, "method": "textDocument/documentSymbol",
+           "params": {"textDocument": {"uri": URI}}}),
+    # completion at statement position inside main
+    frame({"jsonrpc": "2.0", "id": 60, "method": "textDocument/completion",
+           "params": {"textDocument": {"uri": URI}, "position": pos(3, 4)}}),
+    frame({"jsonrpc": "2.0", "id": 2, "method": "shutdown", "params": None}),
+    frame({"jsonrpc": "2.0", "method": "exit", "params": None}),
+])
+
+proc = subprocess.run([BIN], input=requests, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=30)
+msgs = read_messages(proc.stdout)
+
+
+def by_id(i):
+    return next((m for m in msgs if m.get("id") == i), None)
+
+
+print("=== server exit code:", proc.returncode)
+print("=== messages received:", len(msgs))
+for m in msgs:
+    if m.get("id") in (10, 11, 20, 30, 40, 41, 50, 60):
+        print(json.dumps(m))
+
+failures = []
+
+# initialize capabilities
+init = by_id(1)
+caps = (init or {}).get("result", {}).get("capabilities", {})
+for cap in ["hoverProvider", "definitionProvider", "referencesProvider",
+            "renameProvider", "documentSymbolProvider", "completionProvider"]:
+    if cap not in caps:
+        failures.append(f"initialize missing capability {cap}")
+
+# hover on helper -> markdown mentioning helper signature
+h = by_id(10)
+hv = (h or {}).get("result")
+if not hv or "contents" not in hv:
+    failures.append("hover(helper) returned no contents")
+elif "helper" not in hv["contents"].get("value", ""):
+    failures.append("hover(helper) value does not mention 'helper'")
+
+# hover on x -> mentions x and i64
+h2 = by_id(11)
+hv2 = (h2 or {}).get("result")
+if not hv2 or "contents" not in hv2:
+    failures.append("hover(x) returned no contents")
+elif "i64" not in hv2["contents"].get("value", ""):
+    failures.append("hover(x) value does not mention type 'i64'")
+
+# definition of helper -> a Location on line 0
+d = by_id(20)
+dv = (d or {}).get("result")
+if not dv or "range" not in dv:
+    failures.append("definition(helper) returned no Location")
+elif dv["range"]["start"]["line"] != 0:
+    failures.append(f"definition(helper) points to line {dv['range']['start']['line']}, expected 0")
+
+# references of helper -> at least 2 (decl + call)
+r = by_id(30)
+rv = (r or {}).get("result")
+if not isinstance(rv, list):
+    failures.append("references(helper) result is not an array")
+elif len(rv) < 2:
+    failures.append(f"references(helper) found {len(rv)}, expected >= 2 (decl + call)")
+
+# prepareRename of x -> a range
+pr = by_id(40)
+prv = (pr or {}).get("result")
+if not prv or "start" not in prv:
+    failures.append("prepareRename(x) returned no range")
+
+# rename x -> y produces a WorkspaceEdit with >= 2 edits (decl + use)
+rn = by_id(41)
+rnv = (rn or {}).get("result")
+if not rnv or "changes" not in rnv:
+    failures.append("rename(x) returned no WorkspaceEdit")
+else:
+    edits = rnv["changes"].get(URI, [])
+    if len(edits) < 2:
+        failures.append(f"rename(x) produced {len(edits)} edits, expected >= 2")
+    elif any(e.get("newText") != "y" for e in edits):
+        failures.append("rename(x) edit newText is not 'y'")
+
+# documentSymbol -> helper and main present
+ds = by_id(50)
+dsv = (ds or {}).get("result")
+if not isinstance(dsv, list):
+    failures.append("documentSymbol result is not an array")
+else:
+    names = {s.get("name") for s in dsv}
+    for want in ("helper", "main"):
+        if want not in names:
+            failures.append(f"documentSymbol missing '{want}' (got {sorted(names)})")
+    # `x` is a local val inside main's body, not a module-level decl
+    if "x" in names:
+        failures.append("documentSymbol leaked the nested local 'x' as a top-level symbol")
+
+# completion -> includes helper and main
+cp = by_id(60)
+cpv = (cp or {}).get("result")
+items = (cpv or {}).get("items", []) if isinstance(cpv, dict) else []
+labels = {it.get("label") for it in items}
+for want in ("helper", "main"):
+    if want not in labels:
+        failures.append(f"completion missing '{want}' (got {sorted(labels)})")
+
+if proc.returncode != 0:
+    failures.append("non-zero exit code after clean shutdown")
+
+print()
+if failures:
+    print("FEATURES SMOKE TEST FAILED:")
+    for f in failures:
+        print("  -", f)
+    sys.exit(1)
+print("FEATURES SMOKE TEST PASSED")

--- a/src/features.mach
+++ b/src/features.mach
@@ -89,23 +89,100 @@ pub fun ref_at(a: *ast.Ast, rr: *res.ResolveResult, own: sess.ModuleId, offset: 
     # is not an expr or type node — resolve it through the decl_symbol table
     # when the offset falls inside the decl's name span.
     val did: id.DeclId = ast.offset_to_decl(a, offset);
-    if (did != id.DECL_NIL && rr.decl_symbol != nil && did::u32 < rr.decl_count) {
-        val sid: res.SymbolId = rr.decl_symbol[did];
-        if (sid != res.SYMBOL_NIL && sid < rr.symbol_count) {
-            val d_opt: Option[*decl.Decl] = ast.get_decl(a, did);
-            if (is_some[*decl.Decl](d_opt)) {
-                val nso: Option[token.Span] = decl_name_span(unwrap[*decl.Decl](d_opt));
-                if (is_some[token.Span](nso)) {
-                    val nspan: token.Span = unwrap[token.Span](nso);
-                    if (ast.span_contains(nspan, offset)) {
-                        ret some[SymbolRef](make_ref(rr, own, sid, nspan));
+    if (did != id.DECL_NIL) {
+        if (rr.decl_symbol != nil && did::u32 < rr.decl_count) {
+            val sid: res.SymbolId = rr.decl_symbol[did];
+            if (sid != res.SYMBOL_NIL && sid < rr.symbol_count) {
+                val d_opt: Option[*decl.Decl] = ast.get_decl(a, did);
+                if (is_some[*decl.Decl](d_opt)) {
+                    val nso: Option[token.Span] = decl_name_span(unwrap[*decl.Decl](d_opt));
+                    if (is_some[token.Span](nso)) {
+                        val nspan: token.Span = unwrap[token.Span](nso);
+                        if (ast.span_contains(nspan, offset)) {
+                            ret some[SymbolRef](make_ref(rr, own, sid, nspan));
+                        }
                     }
                 }
             }
         }
+
+        # a function's parameter and generic binding names are not decls — they
+        # bind SYM_PARAM / SYM_GENERIC symbols carrying (decl, slot). resolve a
+        # cursor on one of those binding names through the symbol table.
+        val bo: Option[SymbolRef] = binding_ref_in_decl(a, rr, own, did, offset);
+        if (is_some[SymbolRef](bo)) { ret bo; }
     }
 
     ret none[SymbolRef]();
+}
+
+# binding_ref_in_decl: a SymbolRef when `offset` falls on a function
+# parameter or generic binding name within decl `did`, or none. params and
+# generics carry no Decl node — their symbol is found by matching (decl, slot)
+# in the symbol table.
+fun binding_ref_in_decl(a: *ast.Ast, rr: *res.ResolveResult, own: sess.ModuleId, did: id.DeclId, offset: usize) Option[SymbolRef] {
+    val d_opt: Option[*decl.Decl] = ast.get_decl(a, did);
+    if (!is_some[*decl.Decl](d_opt)) { ret none[SymbolRef](); }
+    val d: *decl.Decl = unwrap[*decl.Decl](d_opt);
+    if (d.kind != decl.DECL_KIND_FUN) { ret none[SymbolRef](); }
+
+    var gi: u32 = 0;
+    for (gi < d.data.fun_.generics_len) {
+        val gname: token.Span = a.generic_names[d.data.fun_.generics_start + gi];
+        if (ast.span_contains(gname, offset)) {
+            val sid: res.SymbolId = find_binding_symbol(rr, res.SYM_GENERIC, did, gi);
+            if (sid != res.SYMBOL_NIL) { ret some[SymbolRef](make_ref(rr, own, sid, gname)); }
+        }
+        gi = gi + 1;
+    }
+
+    var pi: u32 = 0;
+    for (pi < d.data.fun_.params_len) {
+        val tn: *decl.TypedName = ?a.typed_names[d.data.fun_.params_start + pi];
+        if (ast.span_contains(tn.name, offset)) {
+            val sid: res.SymbolId = find_binding_symbol(rr, res.SYM_PARAM, did, pi);
+            if (sid != res.SYMBOL_NIL) { ret some[SymbolRef](make_ref(rr, own, sid, tn.name)); }
+        }
+        pi = pi + 1;
+    }
+
+    ret none[SymbolRef]();
+}
+
+# find_binding_symbol: the SymbolId of the `kind` symbol declared by decl
+# `did` at `slot` (the param / generic index), or SYMBOL_NIL.
+fun find_binding_symbol(rr: *res.ResolveResult, kind: res.SymKind, did: id.DeclId, slot: u32) res.SymbolId {
+    var i: u32 = 0;
+    for (i < rr.symbol_count) {
+        val sym: *res.Symbol = ?rr.symbols[i];
+        if (sym.kind == kind && sym.decl == did && sym.slot == slot) { ret i::res.SymbolId; }
+        i = i + 1;
+    }
+    ret res.SYMBOL_NIL;
+}
+
+# binding_name_span: the binding name span of a SYM_PARAM / SYM_GENERIC symbol
+# (looked up by its (decl, slot) in the function decl), or none. lets the
+# references / rename walk include a param / generic's binding site, which the
+# expr / type / decl side tables never record.
+# ---
+# a:   the Ast holding the function decl
+# sym: the param / generic symbol whose binding span is wanted
+# ret: some(name span) of the binding, or none
+pub fun binding_name_span(a: *ast.Ast, sym: *res.Symbol) Option[token.Span] {
+    if (sym.kind != res.SYM_PARAM && sym.kind != res.SYM_GENERIC) { ret none[token.Span](); }
+    if (sym.decl == id.DECL_NIL) { ret none[token.Span](); }
+    val d_opt: Option[*decl.Decl] = ast.get_decl(a, sym.decl);
+    if (!is_some[*decl.Decl](d_opt)) { ret none[token.Span](); }
+    val d: *decl.Decl = unwrap[*decl.Decl](d_opt);
+    if (d.kind != decl.DECL_KIND_FUN) { ret none[token.Span](); }
+
+    if (sym.kind == res.SYM_GENERIC) {
+        if (sym.slot >= d.data.fun_.generics_len) { ret none[token.Span](); }
+        ret some[token.Span](a.generic_names[d.data.fun_.generics_start + sym.slot]);
+    }
+    if (sym.slot >= d.data.fun_.params_len) { ret none[token.Span](); }
+    ret some[token.Span]((?a.typed_names[d.data.fun_.params_start + sym.slot]).name);
 }
 
 # make_ref: build a SymbolRef, flagging whether the symbol is local to this
@@ -194,6 +271,21 @@ pub fun decl_name_span_of(a: *ast.Ast, sym: *res.Symbol) Option[token.Span] {
     ret decl_name_span(unwrap[*decl.Decl](d_opt));
 }
 
+# definition_name_span: the span go-to-definition should land on for a local
+# symbol — the binding name. for a param / generic this is its binding site in
+# the function signature; for every other symbol it is the decl's name. none
+# when the symbol has no addressable binding in this Ast.
+# ---
+# a:   the Ast owning the symbol's declaration
+# sym: the symbol whose definition span is wanted
+# ret: some(span) of the binding name, or none
+pub fun definition_name_span(a: *ast.Ast, sym: *res.Symbol) Option[token.Span] {
+    if (sym.kind == res.SYM_PARAM || sym.kind == res.SYM_GENERIC) {
+        ret binding_name_span(a, sym);
+    }
+    ret decl_name_span_of(a, sym);
+}
+
 # decl_name_span: the name identifier span of a decl node, or none for a decl
 # without a single name (use / fwd / test / comptime / error).
 pub fun decl_name_span(d: *decl.Decl) Option[token.Span] {
@@ -216,6 +308,9 @@ pub fun decl_name_span(d: *decl.Decl) Option[token.Span] {
 # sym: the symbol whose signature span is wanted
 # ret: some(span) of the header text, or none
 pub fun signature_span(a: *ast.Ast, sym: *res.Symbol) Option[token.Span] {
+    if (sym.kind == res.SYM_GENERIC) { ret binding_name_span(a, sym); }
+    if (sym.kind == res.SYM_PARAM)   { ret param_signature_span(a, sym); }
+
     if (sym.decl == id.DECL_NIL) { ret none[token.Span](); }
     val d_opt: Option[*decl.Decl] = ast.get_decl(a, sym.decl);
     if (!is_some[*decl.Decl](d_opt)) { ret none[token.Span](); }
@@ -234,6 +329,33 @@ pub fun signature_span(a: *ast.Ast, sym: *res.Symbol) Option[token.Span] {
         }
     }
     ret some[token.Span](d.span);
+}
+
+# param_signature_span: the `name: type` span of a parameter symbol — from its
+# binding name through the end of its type annotation — for hover. falls back
+# to just the name span when the type node is unavailable. none for a non-param.
+fun param_signature_span(a: *ast.Ast, sym: *res.Symbol) Option[token.Span] {
+    val no: Option[token.Span] = binding_name_span(a, sym);
+    if (!is_some[token.Span](no)) { ret none[token.Span](); }
+    val name: token.Span = unwrap[token.Span](no);
+
+    val d_opt: Option[*decl.Decl] = ast.get_decl(a, sym.decl);
+    if (!is_some[*decl.Decl](d_opt)) { ret some[token.Span](name); }
+    val d: *decl.Decl = unwrap[*decl.Decl](d_opt);
+    if (d.kind != decl.DECL_KIND_FUN || sym.slot >= d.data.fun_.params_len) { ret some[token.Span](name); }
+
+    val tn: *decl.TypedName = ?a.typed_names[d.data.fun_.params_start + sym.slot];
+    if (tn.ty == id.TYPE_NIL) { ret some[token.Span](name); }
+    val to: Option[*atype.Type] = ast.get_type(a, tn.ty);
+    if (!is_some[*atype.Type](to)) { ret some[token.Span](name); }
+    val tspan: token.Span = unwrap[*atype.Type](to).span;
+
+    val end: usize = tspan.offset + tspan.len;
+    if (end <= name.offset) { ret some[token.Span](name); }
+    var sp: token.Span;
+    sp.offset = name.offset;
+    sp.len    = end - name.offset;
+    ret some[token.Span](sp);
 }
 
 # kind_label: a human-readable label for a symbol kind, for hover rendering.

--- a/src/features.mach
+++ b/src/features.mach
@@ -1,0 +1,384 @@
+# mls.features: offset -> id -> symbol queries over the editor resolve tables.
+#
+# the shared core of the language features (hover, definition, references,
+# rename, documentSymbol, completion). each starts from an `editor` buffer's
+# parsed `ast.Ast` and resolved `res.ResolveResult`, pivots on a byte offset
+# through `ast.offset_to_{expr,type}`, and reads the parallel side tables
+# (`expr_resolved` / `type_resolved` / `decl_symbol`) to recover the
+# `res.Symbol` a position references. this module owns that pivot and the
+# symbol-shaped helpers the per-feature renderers build on; the JSON shaping
+# lives in `server`.
+#
+# scope: resolution is single-file (the editor resolves a buffer in isolation
+# with an empty dep set), so a reference to a locally declared symbol binds
+# fully — its decl is in this same Ast — while a reference imported through a
+# `use` resolves to a symbol whose `decl` lives in a dependency Ast this server
+# never loaded. those are reported as cross-module: hover still renders the
+# name and kind, but definition / references that need the decl span are
+# confined to symbols whose `origin` is this buffer's module.
+
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.size.usize;
+use std.types.string.str;
+use std.types.option.Option;
+use std.types.option.some;
+use std.types.option.none;
+use std.types.option.is_some;
+use std.types.option.unwrap;
+
+use sess:   mach.lang.session;
+use intern: mach.lang.intern;
+use token:  mach.lang.fe.token;
+use ast:    mach.lang.fe.ast;
+use id:     mach.lang.fe.ast.id;
+use module: mach.lang.fe.ast.module;
+use decl:   mach.lang.fe.ast.decl;
+use stmt:   mach.lang.fe.ast.stmt;
+use expr:   mach.lang.fe.ast.expr;
+use atype:  mach.lang.fe.ast.type;
+use res:    mach.lang.fe.resolve;
+
+# SymbolRef: a symbol a position references, joined with the location of the
+# name token that referenced it.
+# ---
+# sym_id:    SymbolId into the ResolveResult symbol table
+# name_span: byte span of the referencing name token (the IDENT / type name)
+# local:     true when the symbol's decl lives in this buffer's Ast (origin is
+#            this module), false for a cross-module `use`d / imported symbol
+pub rec SymbolRef {
+    sym_id:    res.SymbolId;
+    name_span: token.Span;
+    local:     bool;
+}
+
+# ref_at: the symbol referenced at a byte offset, or none when no resolved
+# expression or type name covers it. prefers the tightest expression; falls
+# back to a type-name position (a type annotation, return type, field type).
+# ---
+# a:      the buffer's parsed Ast
+# rr:     the buffer's ResolveResult side tables
+# own:    this buffer's module id (Symbol.origin equals it for local symbols)
+# offset: byte offset into the buffer
+# ret:    some(SymbolRef) for a resolved position, or none
+pub fun ref_at(a: *ast.Ast, rr: *res.ResolveResult, own: sess.ModuleId, offset: usize) Option[SymbolRef] {
+    val eid: id.ExprId = ast.offset_to_expr(a, offset);
+    if (eid != id.EXPR_NIL && rr.expr_resolved != nil && eid::u32 < rr.expr_count) {
+        val sid: res.SymbolId = rr.expr_resolved[eid];
+        if (sid != res.SYMBOL_NIL && sid < rr.symbol_count) {
+            val eo: Option[*expr.Expr] = ast.get_expr(a, eid);
+            if (is_some[*expr.Expr](eo)) {
+                ret some[SymbolRef](make_ref(rr, own, sid, name_span_of_expr(unwrap[*expr.Expr](eo))));
+            }
+        }
+    }
+
+    val tid: id.TypeId = ast.offset_to_type(a, offset);
+    if (tid != id.TYPE_NIL && rr.type_resolved != nil && tid::u32 < rr.type_count) {
+        val sid: res.SymbolId = rr.type_resolved[tid];
+        if (sid != res.SYMBOL_NIL && sid < rr.symbol_count) {
+            val tno: Option[token.Span] = type_name_span(a, tid);
+            if (is_some[token.Span](tno)) {
+                ret some[SymbolRef](make_ref(rr, own, sid, unwrap[token.Span](tno)));
+            }
+        }
+    }
+
+    # the cursor may sit on a declaration's own name (the binding site), which
+    # is not an expr or type node — resolve it through the decl_symbol table
+    # when the offset falls inside the decl's name span.
+    val did: id.DeclId = ast.offset_to_decl(a, offset);
+    if (did != id.DECL_NIL && rr.decl_symbol != nil && did::u32 < rr.decl_count) {
+        val sid: res.SymbolId = rr.decl_symbol[did];
+        if (sid != res.SYMBOL_NIL && sid < rr.symbol_count) {
+            val d_opt: Option[*decl.Decl] = ast.get_decl(a, did);
+            if (is_some[*decl.Decl](d_opt)) {
+                val nso: Option[token.Span] = decl_name_span(unwrap[*decl.Decl](d_opt));
+                if (is_some[token.Span](nso)) {
+                    val nspan: token.Span = unwrap[token.Span](nso);
+                    if (ast.span_contains(nspan, offset)) {
+                        ret some[SymbolRef](make_ref(rr, own, sid, nspan));
+                    }
+                }
+            }
+        }
+    }
+
+    ret none[SymbolRef]();
+}
+
+# make_ref: build a SymbolRef, flagging whether the symbol is local to this
+# buffer's module.
+fun make_ref(rr: *res.ResolveResult, own: sess.ModuleId, sid: res.SymbolId, name_span: token.Span) SymbolRef {
+    var sr: SymbolRef;
+    sr.sym_id    = sid;
+    sr.name_span = name_span;
+    sr.local     = symbol_is_local(rr, own, sid);
+    ret sr;
+}
+
+# symbol_is_local: whether `sid`'s decl is owned by `own` (this buffer's
+# module) and so addressable in this Ast. primitives and imported / used
+# symbols originate elsewhere.
+pub fun symbol_is_local(rr: *res.ResolveResult, own: sess.ModuleId, sid: res.SymbolId) bool {
+    if (sid >= rr.symbol_count) { ret false; }
+    val sym: *res.Symbol = ?rr.symbols[sid];
+    if (sym.kind == res.SYM_PRIM) { ret false; }
+    if (sym.decl == id.DECL_NIL) { ret false; }
+    ret sym.origin == own;
+}
+
+# top_level_count: the number of declarations at the buffer's module scope —
+# the count documentSymbol enumerates. zero when the Ast has no root module.
+# ---
+# a:   the buffer's parsed Ast
+# ret: the module-scope decl count
+pub fun top_level_count(a: *ast.Ast) u32 {
+    val mo: Option[*module.Module] = ast.get_module(a, a.root_module);
+    if (!is_some[*module.Module](mo)) { ret 0; }
+    ret unwrap[*module.Module](mo).decls_len;
+}
+
+# top_level_decl: the DeclId of the `i`-th module-scope declaration, or DECL_NIL
+# when out of range. resolves through the module's decl-id list rather than the
+# flat `Ast.decls` array, so nested declarations (a `val` inside a function
+# body) are excluded.
+# ---
+# a: the buffer's parsed Ast
+# i: index into the module's top-level decl list
+# ret: the DeclId, or DECL_NIL
+pub fun top_level_decl(a: *ast.Ast, i: u32) id.DeclId {
+    val mo: Option[*module.Module] = ast.get_module(a, a.root_module);
+    if (!is_some[*module.Module](mo)) { ret id.DECL_NIL; }
+    val m: *module.Module = unwrap[*module.Module](mo);
+    if (i >= m.decls_len) { ret id.DECL_NIL; }
+    ret a.decl_ids[m.decls_start + i];
+}
+
+# symbol: the Symbol for a SymbolId, or none when out of range.
+# ---
+# rr:  the ResolveResult holding the symbol table
+# sid: symbol id to look up
+# ret: some(*Symbol) into rr.symbols, or none
+pub fun symbol(rr: *res.ResolveResult, sid: res.SymbolId) Option[*res.Symbol] {
+    if (sid >= rr.symbol_count) { ret none[*res.Symbol](); }
+    ret some[*res.Symbol](?rr.symbols[sid]);
+}
+
+# decl_span_of: the full declaration span of a local symbol's decl, or none
+# when the decl id is absent / out of range. drives go-to-definition.
+# ---
+# a:   the Ast owning the decl
+# sym: the symbol whose decl span is wanted
+# ret: some(span) of the decl, or none
+pub fun decl_span_of(a: *ast.Ast, sym: *res.Symbol) Option[token.Span] {
+    if (sym.decl == id.DECL_NIL) { ret none[token.Span](); }
+    val d_opt: Option[*decl.Decl] = ast.get_decl(a, sym.decl);
+    if (!is_some[*decl.Decl](d_opt)) { ret none[token.Span](); }
+    ret some[token.Span](unwrap[*decl.Decl](d_opt).span);
+}
+
+# decl_name_span_of: the span of a local symbol's declared name identifier (the
+# selection range for go-to-definition / documentSymbol), or none. for a decl
+# the resolver attached the symbol to, the symbol's name lives at a known span
+# within the decl node.
+# ---
+# a:   the Ast owning the decl
+# sym: the symbol whose name span is wanted
+# ret: some(span) of the name identifier, or none
+pub fun decl_name_span_of(a: *ast.Ast, sym: *res.Symbol) Option[token.Span] {
+    if (sym.decl == id.DECL_NIL) { ret none[token.Span](); }
+    val d_opt: Option[*decl.Decl] = ast.get_decl(a, sym.decl);
+    if (!is_some[*decl.Decl](d_opt)) { ret none[token.Span](); }
+    ret decl_name_span(unwrap[*decl.Decl](d_opt));
+}
+
+# decl_name_span: the name identifier span of a decl node, or none for a decl
+# without a single name (use / fwd / test / comptime / error).
+pub fun decl_name_span(d: *decl.Decl) Option[token.Span] {
+    if (d.kind == decl.DECL_KIND_FUN) { ret some[token.Span](d.data.fun_.name); }
+    if (d.kind == decl.DECL_KIND_REC) { ret some[token.Span](d.data.rec_.name); }
+    if (d.kind == decl.DECL_KIND_UNI) { ret some[token.Span](d.data.uni_.name); }
+    if (d.kind == decl.DECL_KIND_DEF) { ret some[token.Span](d.data.def_.name); }
+    if (d.kind == decl.DECL_KIND_VAL) { ret some[token.Span](d.data.bind.name); }
+    if (d.kind == decl.DECL_KIND_VAR) { ret some[token.Span](d.data.bind.name); }
+    ret none[token.Span]();
+}
+
+# signature_span: the byte span of a local symbol's declaration header — the
+# text to render on hover. for a function with a body it runs from the decl
+# start up to (not into) the body block, so the parameter list and return type
+# show without the body; for every other decl it is the whole decl span. none
+# when the decl id is absent / out of range.
+# ---
+# a:   the Ast owning the decl
+# sym: the symbol whose signature span is wanted
+# ret: some(span) of the header text, or none
+pub fun signature_span(a: *ast.Ast, sym: *res.Symbol) Option[token.Span] {
+    if (sym.decl == id.DECL_NIL) { ret none[token.Span](); }
+    val d_opt: Option[*decl.Decl] = ast.get_decl(a, sym.decl);
+    if (!is_some[*decl.Decl](d_opt)) { ret none[token.Span](); }
+    val d: *decl.Decl = unwrap[*decl.Decl](d_opt);
+
+    if (d.kind == decl.DECL_KIND_FUN && d.data.fun_.body != id.STMT_NIL) {
+        val so: Option[*stmt.Stmt] = ast.get_stmt(a, d.data.fun_.body);
+        if (is_some[*stmt.Stmt](so)) {
+            val body_off: usize = unwrap[*stmt.Stmt](so).span.offset;
+            if (body_off > d.span.offset) {
+                var sp: token.Span;
+                sp.offset = d.span.offset;
+                sp.len    = body_off - d.span.offset;
+                ret some[token.Span](sp);
+            }
+        }
+    }
+    ret some[token.Span](d.span);
+}
+
+# kind_label: a human-readable label for a symbol kind, for hover rendering.
+# ---
+# kind: a res.SYM_* value
+# ret:  a short lowercase keyword-like label
+pub fun kind_label(kind: res.SymKind) str {
+    if (kind == res.SYM_FUN)      { ret "fun"; }
+    if (kind == res.SYM_REC)      { ret "rec"; }
+    if (kind == res.SYM_UNI)      { ret "uni"; }
+    if (kind == res.SYM_DEF)      { ret "def"; }
+    if (kind == res.SYM_VAL)      { ret "val"; }
+    if (kind == res.SYM_VAR)      { ret "var"; }
+    if (kind == res.SYM_PARAM)    { ret "param"; }
+    if (kind == res.SYM_GENERIC)  { ret "generic"; }
+    if (kind == res.SYM_USE)      { ret "module"; }
+    if (kind == res.SYM_IMPORTED) { ret "import"; }
+    if (kind == res.SYM_TEST)     { ret "test"; }
+    if (kind == res.SYM_PRIM)     { ret "type"; }
+    ret "symbol";
+}
+
+# lsp_symbol_kind: the LSP SymbolKind number for a symbol kind (documentSymbol).
+# 12 = Function, 23 = Struct, 10 = Enum, 13 = Variable, 14 = Constant,
+# 26 = TypeParameter, 5 = Method, 8 = Field, 2 = Module, 6 = Property.
+# ---
+# kind: a res.SYM_* value
+# ret:  the LSP SymbolKind code
+pub fun lsp_symbol_kind(kind: res.SymKind) i64 {
+    if (kind == res.SYM_FUN)      { ret 12; }
+    if (kind == res.SYM_REC)      { ret 23; }
+    if (kind == res.SYM_UNI)      { ret 10; }
+    if (kind == res.SYM_DEF)      { ret 26; }
+    if (kind == res.SYM_VAL)      { ret 14; }
+    if (kind == res.SYM_VAR)      { ret 13; }
+    if (kind == res.SYM_PARAM)    { ret 13; }
+    if (kind == res.SYM_GENERIC)  { ret 26; }
+    if (kind == res.SYM_TEST)     { ret 12; }
+    ret 13;
+}
+
+# lsp_completion_kind: the LSP CompletionItemKind number for a symbol kind.
+# 3 = Function, 22 = Struct, 13 = Enum, 6 = Variable, 21 = Constant,
+# 25 = TypeParameter, 9 = Module, 5 = Field.
+# ---
+# kind: a res.SYM_* value
+# ret:  the LSP CompletionItemKind code
+pub fun lsp_completion_kind(kind: res.SymKind) i64 {
+    if (kind == res.SYM_FUN)      { ret 3; }
+    if (kind == res.SYM_REC)      { ret 22; }
+    if (kind == res.SYM_UNI)      { ret 13; }
+    if (kind == res.SYM_DEF)      { ret 25; }
+    if (kind == res.SYM_VAL)      { ret 21; }
+    if (kind == res.SYM_VAR)      { ret 6; }
+    if (kind == res.SYM_PARAM)    { ret 6; }
+    if (kind == res.SYM_GENERIC)  { ret 25; }
+    if (kind == res.SYM_USE)      { ret 9; }
+    if (kind == res.SYM_IMPORTED) { ret 3; }
+    if (kind == res.SYM_PRIM)     { ret 25; }
+    ret 6;
+}
+
+# expr_ref_span: the name span of expr `eid` when it resolves to `target`, or
+# none. used to enumerate every reference to a symbol (references / rename):
+# the server walks all expr ids and collects the spans this returns.
+# ---
+# a:      the Ast holding the expr
+# rr:     the ResolveResult side tables
+# eid:    expr id to test
+# target: the symbol every reference must resolve to
+# ret:    some(name span) when eid references target, or none
+pub fun expr_ref_span(a: *ast.Ast, rr: *res.ResolveResult, eid: id.ExprId, target: res.SymbolId) Option[token.Span] {
+    if (rr.expr_resolved == nil || eid::u32 >= rr.expr_count) { ret none[token.Span](); }
+    if (rr.expr_resolved[eid] != target) { ret none[token.Span](); }
+    val eo: Option[*expr.Expr] = ast.get_expr(a, eid);
+    if (!is_some[*expr.Expr](eo)) { ret none[token.Span](); }
+    ret some[token.Span](name_span_of_expr(unwrap[*expr.Expr](eo)));
+}
+
+# type_ref_span: the name span of type `tid` when it resolves to `target`, or
+# none. the type-position analogue of expr_ref_span.
+# ---
+# a:      the Ast holding the type
+# rr:     the ResolveResult side tables
+# tid:    type id to test
+# target: the symbol every reference must resolve to
+# ret:    some(name span) when tid references target, or none
+pub fun type_ref_span(a: *ast.Ast, rr: *res.ResolveResult, tid: id.TypeId, target: res.SymbolId) Option[token.Span] {
+    if (rr.type_resolved == nil || tid::u32 >= rr.type_count) { ret none[token.Span](); }
+    if (rr.type_resolved[tid] != target) { ret none[token.Span](); }
+    ret type_name_span(a, tid);
+}
+
+# completion_candidate: whether symbol `sid` should be offered as a top-level
+# completion, i.e. a name a statement/expression position could reference. the
+# editor resolves a single file with no exposed scope chain, so completion
+# offers the file's module-level declarations, its `use` aliases and imports,
+# and the primitive type names — not lexically scoped locals, which need the
+# resolver's scope stack. duplicate-name symbols are deduped by the caller.
+# ---
+# rr:  the ResolveResult holding the symbol table
+# sid: symbol id to test
+# ret: true when the symbol is a top-level completion candidate
+pub fun completion_candidate(rr: *res.ResolveResult, sid: res.SymbolId) bool {
+    if (sid >= rr.symbol_count) { ret false; }
+    val sym: *res.Symbol = ?rr.symbols[sid];
+    if (sym.name == intern.STR_NIL) { ret false; }
+    if (sym.kind == res.SYM_PARAM)   { ret false; }
+    if (sym.kind == res.SYM_GENERIC) { ret false; }
+    if (sym.kind == res.SYM_TEST)    { ret false; }
+    ret true;
+}
+
+# decl_ref_span: the name span of decl `did` when its declared symbol is
+# `target`, or none. lets the references / rename walk include the declaration
+# site itself, which the expr / type side tables never record (a decl binds its
+# name through `decl_symbol`, not `expr_resolved`).
+# ---
+# a:      the Ast holding the decl
+# rr:     the ResolveResult side tables
+# did:    decl id to test
+# target: the symbol the decl must declare
+# ret:    some(name span) when did declares target, or none
+pub fun decl_ref_span(a: *ast.Ast, rr: *res.ResolveResult, did: id.DeclId, target: res.SymbolId) Option[token.Span] {
+    if (rr.decl_symbol == nil || did::u32 >= rr.decl_count) { ret none[token.Span](); }
+    if (rr.decl_symbol[did] != target) { ret none[token.Span](); }
+    val d_opt: Option[*decl.Decl] = ast.get_decl(a, did);
+    if (!is_some[*decl.Decl](d_opt)) { ret none[token.Span](); }
+    ret decl_name_span(unwrap[*decl.Decl](d_opt));
+}
+
+# name_span_of_expr: the span identifying an expression's referenced name. for
+# an IDENT the whole expr span is the name; for a member access the name is the
+# leaf after the dot. other expressions fall back to their own span.
+fun name_span_of_expr(e: *expr.Expr) token.Span {
+    if (e.kind == expr.EXPR_KIND_MEMBER) { ret e.data.member.name; }
+    ret e.span;
+}
+
+# type_name_span: the name span of a named type node, or none when the type at
+# `tid` is not a named reference (a pointer / array / fun type wrapping it).
+fun type_name_span(a: *ast.Ast, tid: id.TypeId) Option[token.Span] {
+    val t_opt: Option[*atype.Type] = ast.get_type(a, tid);
+    if (!is_some[*atype.Type](t_opt)) { ret none[token.Span](); }
+    val t: *atype.Type = unwrap[*atype.Type](t_opt);
+    if (t.kind == atype.TYPE_KIND_NAMED) { ret some[token.Span](t.data.named.name); }
+    ret none[token.Span]();
+}

--- a/src/features.mach
+++ b/src/features.mach
@@ -124,11 +124,12 @@ fun binding_ref_in_decl(a: *ast.Ast, rr: *res.ResolveResult, own: sess.ModuleId,
     val d_opt: Option[*decl.Decl] = ast.get_decl(a, did);
     if (!is_some[*decl.Decl](d_opt)) { ret none[SymbolRef](); }
     val d: *decl.Decl = unwrap[*decl.Decl](d_opt);
-    if (d.kind != decl.DECL_KIND_FUN) { ret none[SymbolRef](); }
 
+    val gstart: u32 = generics_start_of(d);
+    val glen:   u32 = generics_len_of(d);
     var gi: u32 = 0;
-    for (gi < d.data.fun_.generics_len) {
-        val gname: token.Span = a.generic_names[d.data.fun_.generics_start + gi];
+    for (gi < glen) {
+        val gname: token.Span = a.generic_names[gstart + gi];
         if (ast.span_contains(gname, offset)) {
             val sid: res.SymbolId = find_binding_symbol(rr, res.SYM_GENERIC, did, gi);
             if (sid != res.SYMBOL_NIL) { ret some[SymbolRef](make_ref(rr, own, sid, gname)); }
@@ -136,17 +137,35 @@ fun binding_ref_in_decl(a: *ast.Ast, rr: *res.ResolveResult, own: sess.ModuleId,
         gi = gi + 1;
     }
 
-    var pi: u32 = 0;
-    for (pi < d.data.fun_.params_len) {
-        val tn: *decl.TypedName = ?a.typed_names[d.data.fun_.params_start + pi];
-        if (ast.span_contains(tn.name, offset)) {
-            val sid: res.SymbolId = find_binding_symbol(rr, res.SYM_PARAM, did, pi);
-            if (sid != res.SYMBOL_NIL) { ret some[SymbolRef](make_ref(rr, own, sid, tn.name)); }
+    # only functions bind value parameters; rec / uni generics are handled above.
+    if (d.kind == decl.DECL_KIND_FUN) {
+        var pi: u32 = 0;
+        for (pi < d.data.fun_.params_len) {
+            val tn: *decl.TypedName = ?a.typed_names[d.data.fun_.params_start + pi];
+            if (ast.span_contains(tn.name, offset)) {
+                val sid: res.SymbolId = find_binding_symbol(rr, res.SYM_PARAM, did, pi);
+                if (sid != res.SYMBOL_NIL) { ret some[SymbolRef](make_ref(rr, own, sid, tn.name)); }
+            }
+            pi = pi + 1;
         }
-        pi = pi + 1;
     }
 
     ret none[SymbolRef]();
+}
+
+# generics_start_of / generics_len_of: the generic-name pool slice of a decl
+# that may declare generics (fun / rec / uni), or 0 otherwise.
+fun generics_start_of(d: *decl.Decl) u32 {
+    if (d.kind == decl.DECL_KIND_FUN) { ret d.data.fun_.generics_start; }
+    if (d.kind == decl.DECL_KIND_REC) { ret d.data.rec_.generics_start; }
+    if (d.kind == decl.DECL_KIND_UNI) { ret d.data.uni_.generics_start; }
+    ret 0;
+}
+fun generics_len_of(d: *decl.Decl) u32 {
+    if (d.kind == decl.DECL_KIND_FUN) { ret d.data.fun_.generics_len; }
+    if (d.kind == decl.DECL_KIND_REC) { ret d.data.rec_.generics_len; }
+    if (d.kind == decl.DECL_KIND_UNI) { ret d.data.uni_.generics_len; }
+    ret 0;
 }
 
 # find_binding_symbol: the SymbolId of the `kind` symbol declared by decl
@@ -162,11 +181,12 @@ fun find_binding_symbol(rr: *res.ResolveResult, kind: res.SymKind, did: id.DeclI
 }
 
 # binding_name_span: the binding name span of a SYM_PARAM / SYM_GENERIC symbol
-# (looked up by its (decl, slot) in the function decl), or none. lets the
+# (looked up by its (decl, slot) in the owning decl), or none. lets the
 # references / rename walk include a param / generic's binding site, which the
-# expr / type / decl side tables never record.
+# expr / type / decl side tables never record. value parameters belong to a
+# function; generics may belong to a function, record, or union.
 # ---
-# a:   the Ast holding the function decl
+# a:   the Ast holding the declaration
 # sym: the param / generic symbol whose binding span is wanted
 # ret: some(name span) of the binding, or none
 pub fun binding_name_span(a: *ast.Ast, sym: *res.Symbol) Option[token.Span] {
@@ -175,13 +195,12 @@ pub fun binding_name_span(a: *ast.Ast, sym: *res.Symbol) Option[token.Span] {
     val d_opt: Option[*decl.Decl] = ast.get_decl(a, sym.decl);
     if (!is_some[*decl.Decl](d_opt)) { ret none[token.Span](); }
     val d: *decl.Decl = unwrap[*decl.Decl](d_opt);
-    if (d.kind != decl.DECL_KIND_FUN) { ret none[token.Span](); }
 
     if (sym.kind == res.SYM_GENERIC) {
-        if (sym.slot >= d.data.fun_.generics_len) { ret none[token.Span](); }
-        ret some[token.Span](a.generic_names[d.data.fun_.generics_start + sym.slot]);
+        if (sym.slot >= generics_len_of(d)) { ret none[token.Span](); }
+        ret some[token.Span](a.generic_names[generics_start_of(d) + sym.slot]);
     }
-    if (sym.slot >= d.data.fun_.params_len) { ret none[token.Span](); }
+    if (d.kind != decl.DECL_KIND_FUN || sym.slot >= d.data.fun_.params_len) { ret none[token.Span](); }
     ret some[token.Span]((?a.typed_names[d.data.fun_.params_start + sym.slot]).name);
 }
 

--- a/src/language.mach
+++ b/src/language.mach
@@ -1,0 +1,912 @@
+# mls.language: the rich language-feature request handlers.
+#
+# hover, definition, references, rename, prepareRename, documentSymbol, and
+# completion, each driven off the editor's single-buffer analysis. every
+# request resolves the document's buffer (`editor.resolve`), pivots the cursor
+# position to a byte offset, joins it against the resolve side tables through
+# `features`, and shapes the LSP result with `json`. lifecycle and dispatch
+# stay in `server`; this module is the request bodies it routes to.
+#
+# single-file scope: the editor resolves one buffer in isolation, so
+# definition / references / rename only reach symbols declared in the same
+# file. a symbol imported through a `use` resolves to a decl in a dependency
+# Ast this server never loaded, so those requests return an empty / null
+# result for it rather than a wrong one. hover still renders an imported
+# symbol's name and kind. completion offers the file's module-level names,
+# `use` aliases, and the primitive types (see `features.completion_candidate`).
+
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.size.usize;
+use std.types.string.str;
+use std.types.string.str_len;
+use std.types.string.str_equals;
+use std.types.option.Option;
+use std.types.option.is_some;
+use std.types.option.unwrap;
+use std.types.result.Result;
+use std.types.result.ok;
+use std.types.result.err;
+use std.types.result.is_err;
+use std.types.result.unwrap_ok;
+
+use std.allocator.Allocator;
+use std.allocator.allocate;
+use std.allocator.deallocate;
+
+use mem: std.memory;
+
+use sess:   mach.lang.session;
+use src:    mach.lang.source;
+use intern: mach.lang.intern;
+use editor: mach.lang.editor;
+use token:  mach.lang.fe.token;
+use ast:    mach.lang.fe.ast;
+use id:     mach.lang.fe.ast.id;
+use decl:   mach.lang.fe.ast.decl;
+use res:    mach.lang.fe.resolve;
+
+use transport: mls.transport;
+use json:      mls.json;
+use documents: mls.documents;
+use features:  mls.features;
+use positions: mls.positions;
+
+# Analyzed: the resolved analysis of one request's target document.
+# ---
+# s:    the compiler session (interner for symbol names, sources)
+# file: the document's SourceFile (text + line index for offset/position)
+# a:    the buffer's parsed Ast
+# rr:   the buffer's ResolveResult side tables
+# own:  this buffer's module id (Symbol.origin equals it for local symbols)
+rec Analyzed {
+    s:    *sess.Session;
+    file: *src.SourceFile;
+    a:    *ast.Ast;
+    rr:   *res.ResolveResult;
+    own:  sess.ModuleId;
+}
+
+# hover: answer textDocument/hover with the type / declaration of the symbol at
+# the cursor, or null when the position is not on a resolved symbol.
+pub fun hover(es: *editor.EditorSession, s: *sess.Session, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
+    val id_raw: str = json.extract_raw(body, "\"id\"", alloc);
+    if (id_raw == nil) { ret; }
+
+    var an: Analyzed;
+    val off_r: Result[usize, str] = locate(es, s, alloc, docs, body, uri, ?an);
+    if (is_err[usize, str](off_r)) { reply_null(alloc, id_raw); ret; }
+    val offset: usize = unwrap_ok[usize, str](off_r);
+
+    val ro: Option[features.SymbolRef] = features.ref_at(an.a, an.rr, an.own, offset);
+    if (!is_some[features.SymbolRef](ro)) { reply_null(alloc, id_raw); ret; }
+    val sr: features.SymbolRef = unwrap[features.SymbolRef](ro);
+
+    val so: Option[*res.Symbol] = features.symbol(an.rr, sr.sym_id);
+    if (!is_some[*res.Symbol](so)) { reply_null(alloc, id_raw); ret; }
+    val sym: *res.Symbol = unwrap[*res.Symbol](so);
+
+    val md: str = hover_markdown(an, sym, alloc);
+    if (md == nil) { reply_null(alloc, id_raw); ret; }
+
+    val qmd: str = json.quote(md, alloc);
+    json.free_str(md, alloc);
+    if (qmd == nil) { reply_null(alloc, id_raw); ret; }
+
+    val range: positions.LspRange = positions.range_of(an.file, sr.name_span);
+    val rng: str = range_json(range, alloc);
+
+    val p1: str = "{\"jsonrpc\":\"2.0\",\"id\":";
+    val p2: str = ",\"result\":{\"contents\":{\"kind\":\"markdown\",\"value\":";
+    val p3: str = "},\"range\":";
+    val p4: str = "}}";
+    send6(alloc, p1, id_raw, p2, qmd, p3, rng, p4);
+
+    json.free_str(rng, alloc);
+    json.free_str(qmd, alloc);
+    json.free_str(id_raw, alloc);
+}
+
+# hover_markdown: a fenced `mach` code block rendering the symbol at hover. for
+# a local symbol it shows the declaration header as written; otherwise the
+# symbol kind and name.
+fun hover_markdown(an: Analyzed, sym: *res.Symbol, alloc: *Allocator) str {
+    var sig: str = nil;
+    if (sym.origin == an.own && sym.decl != id.DECL_NIL) {
+        val sso: Option[token.Span] = features.signature_span(an.a, sym);
+        if (is_some[token.Span](sso)) {
+            sig = positions.span_text(an.file, unwrap[token.Span](sso), alloc);
+        }
+    }
+    if (sig == nil) {
+        sig = compose_kind_name(sym, ?an.s.interner, alloc);
+    }
+    if (sig == nil) { ret nil; }
+
+    val pre: str = "```mach\n";
+    val post: str = "\n```";
+    val total: usize = str_len(pre) + str_len(sig) + str_len(post);
+    val r: Result[*u8, str] = allocate[u8](alloc, total + 1);
+    if (is_err[*u8, str](r)) { json.free_str(sig, alloc); ret nil; }
+    val buf: *u8 = unwrap_ok[*u8, str](r);
+    var off: usize = 0;
+    off = append(buf, off, pre);
+    off = append(buf, off, sig);
+    off = append(buf, off, post);
+    buf[off] = 0;
+    json.free_str(sig, alloc);
+    ret buf::str;
+}
+
+# compose_kind_name: a `<kind> <name>` rendering for a symbol with no local
+# decl header (an imported symbol or primitive), or nil.
+fun compose_kind_name(sym: *res.Symbol, interner: *intern.Interner, alloc: *Allocator) str {
+    val no: Option[str] = intern.lookup(interner, sym.name);
+    if (!is_some[str](no)) { ret nil; }
+    val name: str = unwrap[str](no);
+    val kind: str = features.kind_label(sym.kind);
+
+    val total: usize = str_len(kind) + 1 + str_len(name);
+    val r: Result[*u8, str] = allocate[u8](alloc, total + 1);
+    if (is_err[*u8, str](r)) { ret nil; }
+    val buf: *u8 = unwrap_ok[*u8, str](r);
+    var off: usize = 0;
+    off = append(buf, off, kind);
+    buf[off] = ' '; off = off + 1;
+    off = append(buf, off, name);
+    buf[off] = 0;
+    ret buf::str;
+}
+
+# definition: answer textDocument/definition with the Location of the resolved
+# symbol's declaration, or null when the position is not on a local symbol.
+pub fun definition(es: *editor.EditorSession, s: *sess.Session, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
+    val id_raw: str = json.extract_raw(body, "\"id\"", alloc);
+    if (id_raw == nil) { ret; }
+
+    var an: Analyzed;
+    val off_r: Result[usize, str] = locate(es, s, alloc, docs, body, uri, ?an);
+    if (is_err[usize, str](off_r)) { reply_null(alloc, id_raw); ret; }
+    val offset: usize = unwrap_ok[usize, str](off_r);
+
+    val ro: Option[features.SymbolRef] = features.ref_at(an.a, an.rr, an.own, offset);
+    if (!is_some[features.SymbolRef](ro)) { reply_null(alloc, id_raw); ret; }
+    val sr: features.SymbolRef = unwrap[features.SymbolRef](ro);
+    if (!sr.local) { reply_null(alloc, id_raw); ret; }
+
+    val so: Option[*res.Symbol] = features.symbol(an.rr, sr.sym_id);
+    if (!is_some[*res.Symbol](so)) { reply_null(alloc, id_raw); ret; }
+    val sym: *res.Symbol = unwrap[*res.Symbol](so);
+
+    val spo: Option[token.Span] = features.decl_name_span_of(an.a, sym);
+    if (!is_some[token.Span](spo)) { reply_null(alloc, id_raw); ret; }
+    val span: token.Span = unwrap[token.Span](spo);
+
+    val loc: str = location_json(an.file, uri, span, alloc);
+    if (loc == nil) { reply_null(alloc, id_raw); ret; }
+
+    val p1: str = "{\"jsonrpc\":\"2.0\",\"id\":";
+    val p2: str = ",\"result\":";
+    val p3: str = "}";
+    send6(alloc, p1, id_raw, p2, loc, p3, nil, nil);
+
+    json.free_str(loc, alloc);
+    json.free_str(id_raw, alloc);
+}
+
+# references: answer textDocument/references with every Location in this file
+# that resolves to the symbol at the cursor (the decl plus all use-sites).
+# empty for a non-local symbol.
+pub fun references(es: *editor.EditorSession, s: *sess.Session, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
+    val id_raw: str = json.extract_raw(body, "\"id\"", alloc);
+    if (id_raw == nil) { ret; }
+
+    var an: Analyzed;
+    val off_r: Result[usize, str] = locate(es, s, alloc, docs, body, uri, ?an);
+    if (is_err[usize, str](off_r)) { reply_empty_array(alloc, id_raw); ret; }
+    val offset: usize = unwrap_ok[usize, str](off_r);
+
+    val ro: Option[features.SymbolRef] = features.ref_at(an.a, an.rr, an.own, offset);
+    if (!is_some[features.SymbolRef](ro)) { reply_empty_array(alloc, id_raw); ret; }
+    val sr: features.SymbolRef = unwrap[features.SymbolRef](ro);
+    if (!sr.local) { reply_empty_array(alloc, id_raw); ret; }
+
+    emit_locations(an, alloc, id_raw, uri, sr.sym_id, true);
+    json.free_str(id_raw, alloc);
+}
+
+# rename: answer textDocument/rename with a WorkspaceEdit replacing every
+# reference to the symbol at the cursor with the requested new name, across
+# this file. empty edit for a non-local symbol.
+pub fun rename(es: *editor.EditorSession, s: *sess.Session, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
+    val id_raw: str = json.extract_raw(body, "\"id\"", alloc);
+    if (id_raw == nil) { ret; }
+
+    val new_name: str = json.extract_string(body, "\"newName\"", alloc);
+    if (new_name == nil) { reply_null(alloc, id_raw); ret; }
+
+    var an: Analyzed;
+    val off_r: Result[usize, str] = locate(es, s, alloc, docs, body, uri, ?an);
+    if (is_err[usize, str](off_r)) { reply_empty_edit(alloc, id_raw); json.free_str(new_name, alloc); ret; }
+    val offset: usize = unwrap_ok[usize, str](off_r);
+
+    val ro: Option[features.SymbolRef] = features.ref_at(an.a, an.rr, an.own, offset);
+    if (!is_some[features.SymbolRef](ro)) { reply_empty_edit(alloc, id_raw); json.free_str(new_name, alloc); ret; }
+    val sr: features.SymbolRef = unwrap[features.SymbolRef](ro);
+    if (!sr.local) { reply_empty_edit(alloc, id_raw); json.free_str(new_name, alloc); ret; }
+
+    emit_rename(an, alloc, id_raw, uri, sr.sym_id, new_name);
+    json.free_str(new_name, alloc);
+    json.free_str(id_raw, alloc);
+}
+
+# prepare_rename: answer textDocument/prepareRename with the range of the name
+# token at the cursor when it is a renameable local symbol, or null.
+pub fun prepare_rename(es: *editor.EditorSession, s: *sess.Session, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
+    val id_raw: str = json.extract_raw(body, "\"id\"", alloc);
+    if (id_raw == nil) { ret; }
+
+    var an: Analyzed;
+    val off_r: Result[usize, str] = locate(es, s, alloc, docs, body, uri, ?an);
+    if (is_err[usize, str](off_r)) { reply_null(alloc, id_raw); ret; }
+    val offset: usize = unwrap_ok[usize, str](off_r);
+
+    val ro: Option[features.SymbolRef] = features.ref_at(an.a, an.rr, an.own, offset);
+    if (!is_some[features.SymbolRef](ro)) { reply_null(alloc, id_raw); ret; }
+    val sr: features.SymbolRef = unwrap[features.SymbolRef](ro);
+    if (!sr.local) { reply_null(alloc, id_raw); ret; }
+
+    val range: positions.LspRange = positions.range_of(an.file, sr.name_span);
+    val rng: str = range_json(range, alloc);
+
+    val p1: str = "{\"jsonrpc\":\"2.0\",\"id\":";
+    val p2: str = ",\"result\":";
+    val p3: str = "}";
+    send6(alloc, p1, id_raw, p2, rng, p3, nil, nil);
+
+    json.free_str(rng, alloc);
+    json.free_str(id_raw, alloc);
+}
+
+# document_symbol: answer textDocument/documentSymbol with a flat list of the
+# file's top-level declarations as DocumentSymbol nodes (name, kind, range,
+# selectionRange).
+pub fun document_symbol(es: *editor.EditorSession, s: *sess.Session, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
+    val id_raw: str = json.extract_raw(body, "\"id\"", alloc);
+    if (id_raw == nil) { ret; }
+
+    var an: Analyzed;
+    val okd: bool = analyze(es, s, docs, uri, ?an);
+    if (!okd) { reply_empty_array(alloc, id_raw); ret; }
+
+    emit_document_symbols(an, s, alloc, id_raw);
+    json.free_str(id_raw, alloc);
+}
+
+# completion: answer textDocument/completion with the in-scope top-level names
+# (module decls, `use` aliases / imports, primitives) as CompletionItems.
+pub fun completion(es: *editor.EditorSession, s: *sess.Session, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
+    val id_raw: str = json.extract_raw(body, "\"id\"", alloc);
+    if (id_raw == nil) { ret; }
+
+    var an: Analyzed;
+    val okc: bool = analyze(es, s, docs, uri, ?an);
+    if (!okc) { reply_empty_array(alloc, id_raw); ret; }
+
+    emit_completions(an, s, alloc, id_raw);
+    json.free_str(id_raw, alloc);
+}
+
+# analyze: resolve the document named by `uri` and populate `out` with its
+# session, file, Ast, ResolveResult, and module id. false when the document is
+# unknown or resolution fails.
+fun analyze(es: *editor.EditorSession, s: *sess.Session, docs: *documents.Store, uri: str, out: *Analyzed) bool {
+    if (uri == nil) { ret false; }
+    val doc: *documents.Document = documents.find(docs, uri);
+    if (doc == nil) { ret false; }
+
+    val rr_r: Result[*res.ResolveResult, str] = editor.resolve(es, doc.file_id);
+    if (is_err[*res.ResolveResult, str](rr_r)) { ret false; }
+    out.rr = unwrap_ok[*res.ResolveResult, str](rr_r);
+    out.a  = editor.ast_of(es, doc.file_id);
+    if (out.a == nil) { ret false; }
+
+    val fo: Option[*src.SourceFile] = src.get(?s.sources, doc.file_id);
+    if (!is_some[*src.SourceFile](fo)) { ret false; }
+    out.s    = s;
+    out.file = unwrap[*src.SourceFile](fo);
+    out.own  = doc.file_id::sess.ModuleId;
+    ret true;
+}
+
+# locate: analyze the target document and resolve the request's cursor position
+# to a byte offset. the error string is unused by callers (they fall back to a
+# null / empty reply) but distinguishes failure from a real offset of 0.
+fun locate(es: *editor.EditorSession, s: *sess.Session, alloc: *Allocator, docs: *documents.Store, body: str, uri: str, out: *Analyzed) Result[usize, str] {
+    if (!analyze(es, s, docs, uri, out)) { ret r_err("document not analyzable"); }
+
+    val line: i64 = json.extract_number_after(body, "\"position\"", "\"line\"", alloc);
+    val ch:   i64 = json.extract_number_after(body, "\"position\"", "\"character\"", alloc);
+    if (line < 0 || ch < 0) { ret r_err("invalid position"); }
+
+    val oo: Option[usize] = positions.offset_at(out.file, line::usize, ch::usize);
+    if (!is_some[usize](oo)) { ret r_err("position out of range"); }
+    ret r_ok(unwrap[usize](oo));
+}
+
+# emit_locations: send a Location[] result of every in-file reference to
+# `target`. when `include_decl` is set, the decl name span is included too.
+fun emit_locations(an: Analyzed, alloc: *Allocator, id_raw: str, uri: str, target: res.SymbolId, include_decl: bool) {
+    val prefix: str = "{\"jsonrpc\":\"2.0\",\"id\":";
+    val mid:    str = ",\"result\":[";
+    val suffix: str = "]}";
+
+    var total: usize = str_len(prefix) + str_len(id_raw) + str_len(mid) + str_len(suffix);
+    var count: usize = 0;
+
+    # first pass: size
+    var ei: usize = 0;
+    for (ei < an.a.expr_len) {
+        val so: Option[token.Span] = features.expr_ref_span(an.a, an.rr, ei::id.ExprId, target);
+        if (is_some[token.Span](so)) { total = total + loc_len(an.file, uri, unwrap[token.Span](so), alloc, count); count = count + 1; }
+        ei = ei + 1;
+    }
+    var ti: usize = 0;
+    for (ti < an.a.type_len) {
+        val so: Option[token.Span] = features.type_ref_span(an.a, an.rr, ti::id.TypeId, target);
+        if (is_some[token.Span](so)) { total = total + loc_len(an.file, uri, unwrap[token.Span](so), alloc, count); count = count + 1; }
+        ti = ti + 1;
+    }
+    if (include_decl) {
+        var di: usize = 0;
+        for (di < an.a.decl_len) {
+            val so: Option[token.Span] = features.decl_ref_span(an.a, an.rr, di::id.DeclId, target);
+            if (is_some[token.Span](so)) { total = total + loc_len(an.file, uri, unwrap[token.Span](so), alloc, count); count = count + 1; }
+            di = di + 1;
+        }
+    }
+
+    val br: Result[*u8, str] = allocate[u8](alloc, total + 1);
+    if (is_err[*u8, str](br)) { reply_empty_array(alloc, id_raw); ret; }
+    val buf: *u8 = unwrap_ok[*u8, str](br);
+
+    var off: usize = 0;
+    off = append(buf, off, prefix);
+    off = append(buf, off, id_raw);
+    off = append(buf, off, mid);
+
+    var emitted: usize = 0;
+    var e2: usize = 0;
+    for (e2 < an.a.expr_len) {
+        val so: Option[token.Span] = features.expr_ref_span(an.a, an.rr, e2::id.ExprId, target);
+        if (is_some[token.Span](so)) { off = put_loc(buf, off, an.file, uri, unwrap[token.Span](so), alloc, emitted); emitted = emitted + 1; }
+        e2 = e2 + 1;
+    }
+    var t2: usize = 0;
+    for (t2 < an.a.type_len) {
+        val so: Option[token.Span] = features.type_ref_span(an.a, an.rr, t2::id.TypeId, target);
+        if (is_some[token.Span](so)) { off = put_loc(buf, off, an.file, uri, unwrap[token.Span](so), alloc, emitted); emitted = emitted + 1; }
+        t2 = t2 + 1;
+    }
+    if (include_decl) {
+        var d2: usize = 0;
+        for (d2 < an.a.decl_len) {
+            val so: Option[token.Span] = features.decl_ref_span(an.a, an.rr, d2::id.DeclId, target);
+            if (is_some[token.Span](so)) { off = put_loc(buf, off, an.file, uri, unwrap[token.Span](so), alloc, emitted); emitted = emitted + 1; }
+            d2 = d2 + 1;
+        }
+    }
+
+    off = append(buf, off, suffix);
+    buf[off] = 0;
+    transport.send_message(buf::str, alloc);
+    deallocate[u8](alloc, buf, total + 1);
+}
+
+# emit_rename: send a WorkspaceEdit with one TextEdit per in-file reference to
+# `target`, each replacing the reference's range with `new_name`.
+fun emit_rename(an: Analyzed, alloc: *Allocator, id_raw: str, uri: str, target: res.SymbolId, new_name: str) {
+    val quri: str = json.quote(uri, alloc);
+    val qname: str = json.quote(new_name, alloc);
+    if (quri == nil || qname == nil) {
+        json.free_str(quri, alloc); json.free_str(qname, alloc);
+        reply_empty_edit(alloc, id_raw); ret;
+    }
+
+    val prefix: str = "{\"jsonrpc\":\"2.0\",\"id\":";
+    val mid1:   str = ",\"result\":{\"changes\":{";
+    val mid2:   str = ":[";
+    val suffix: str = "]}}}";
+
+    var total: usize = str_len(prefix) + str_len(id_raw) + str_len(mid1) + str_len(quri) + str_len(mid2) + str_len(suffix);
+    var count: usize = 0;
+
+    var e1: usize = 0;
+    for (e1 < an.a.expr_len) {
+        val so: Option[token.Span] = features.expr_ref_span(an.a, an.rr, e1::id.ExprId, target);
+        if (is_some[token.Span](so)) { total = total + edit_len(an.file, unwrap[token.Span](so), qname, alloc, count); count = count + 1; }
+        e1 = e1 + 1;
+    }
+    var ty1: usize = 0;
+    for (ty1 < an.a.type_len) {
+        val so: Option[token.Span] = features.type_ref_span(an.a, an.rr, ty1::id.TypeId, target);
+        if (is_some[token.Span](so)) { total = total + edit_len(an.file, unwrap[token.Span](so), qname, alloc, count); count = count + 1; }
+        ty1 = ty1 + 1;
+    }
+    var d1: usize = 0;
+    for (d1 < an.a.decl_len) {
+        val so: Option[token.Span] = features.decl_ref_span(an.a, an.rr, d1::id.DeclId, target);
+        if (is_some[token.Span](so)) { total = total + edit_len(an.file, unwrap[token.Span](so), qname, alloc, count); count = count + 1; }
+        d1 = d1 + 1;
+    }
+
+    val br: Result[*u8, str] = allocate[u8](alloc, total + 1);
+    if (is_err[*u8, str](br)) {
+        json.free_str(quri, alloc); json.free_str(qname, alloc);
+        reply_empty_edit(alloc, id_raw); ret;
+    }
+    val buf: *u8 = unwrap_ok[*u8, str](br);
+
+    var off: usize = 0;
+    off = append(buf, off, prefix);
+    off = append(buf, off, id_raw);
+    off = append(buf, off, mid1);
+    off = append(buf, off, quri);
+    off = append(buf, off, mid2);
+
+    var emitted: usize = 0;
+    var e2: usize = 0;
+    for (e2 < an.a.expr_len) {
+        val so: Option[token.Span] = features.expr_ref_span(an.a, an.rr, e2::id.ExprId, target);
+        if (is_some[token.Span](so)) { off = put_edit(buf, off, an.file, unwrap[token.Span](so), qname, alloc, emitted); emitted = emitted + 1; }
+        e2 = e2 + 1;
+    }
+    var t2: usize = 0;
+    for (t2 < an.a.type_len) {
+        val so: Option[token.Span] = features.type_ref_span(an.a, an.rr, t2::id.TypeId, target);
+        if (is_some[token.Span](so)) { off = put_edit(buf, off, an.file, unwrap[token.Span](so), qname, alloc, emitted); emitted = emitted + 1; }
+        t2 = t2 + 1;
+    }
+    var d2: usize = 0;
+    for (d2 < an.a.decl_len) {
+        val so: Option[token.Span] = features.decl_ref_span(an.a, an.rr, d2::id.DeclId, target);
+        if (is_some[token.Span](so)) { off = put_edit(buf, off, an.file, unwrap[token.Span](so), qname, alloc, emitted); emitted = emitted + 1; }
+        d2 = d2 + 1;
+    }
+
+    off = append(buf, off, suffix);
+    buf[off] = 0;
+    transport.send_message(buf::str, alloc);
+    deallocate[u8](alloc, buf, total + 1);
+    json.free_str(quri, alloc);
+    json.free_str(qname, alloc);
+}
+
+# emit_document_symbols: send a DocumentSymbol[] of the file's top-level decls.
+fun emit_document_symbols(an: Analyzed, s: *sess.Session, alloc: *Allocator, id_raw: str) {
+    val prefix: str = "{\"jsonrpc\":\"2.0\",\"id\":";
+    val mid:    str = ",\"result\":[";
+    val suffix: str = "]}";
+
+    val n: u32 = features.top_level_count(an.a);
+
+    var total: usize = str_len(prefix) + str_len(id_raw) + str_len(mid) + str_len(suffix);
+    var count: usize = 0;
+
+    var d1: u32 = 0;
+    for (d1 < n) {
+        val entry: str = doc_symbol_json(an, s, features.top_level_decl(an.a, d1), alloc);
+        if (entry != nil) {
+            if (count > 0) { total = total + 1; }
+            total = total + str_len(entry);
+            json.free_str(entry, alloc);
+            count = count + 1;
+        }
+        d1 = d1 + 1;
+    }
+
+    val br: Result[*u8, str] = allocate[u8](alloc, total + 1);
+    if (is_err[*u8, str](br)) { reply_empty_array(alloc, id_raw); ret; }
+    val buf: *u8 = unwrap_ok[*u8, str](br);
+
+    var off: usize = 0;
+    off = append(buf, off, prefix);
+    off = append(buf, off, id_raw);
+    off = append(buf, off, mid);
+
+    var emitted: usize = 0;
+    var d2: u32 = 0;
+    for (d2 < n) {
+        val entry: str = doc_symbol_json(an, s, features.top_level_decl(an.a, d2), alloc);
+        if (entry != nil) {
+            if (emitted > 0) { buf[off] = ','; off = off + 1; }
+            off = append(buf, off, entry);
+            json.free_str(entry, alloc);
+            emitted = emitted + 1;
+        }
+        d2 = d2 + 1;
+    }
+
+    off = append(buf, off, suffix);
+    buf[off] = 0;
+    transport.send_message(buf::str, alloc);
+    deallocate[u8](alloc, buf, total + 1);
+}
+
+# doc_symbol_json: render decl `did` as a DocumentSymbol object, or nil when the
+# decl has no nameable symbol (use / fwd / test / comptime / error).
+fun doc_symbol_json(an: Analyzed, s: *sess.Session, did: id.DeclId, alloc: *Allocator) str {
+    val d_opt: Option[*decl.Decl] = ast.get_decl(an.a, did);
+    if (!is_some[*decl.Decl](d_opt)) { ret nil; }
+    val d: *decl.Decl = unwrap[*decl.Decl](d_opt);
+
+    val nso: Option[token.Span] = features.decl_name_span(d);
+    if (!is_some[token.Span](nso)) { ret nil; }
+    val name_span: token.Span = unwrap[token.Span](nso);
+    if (name_span.len == 0) { ret nil; }
+
+    val name: str = positions.span_text(an.file, name_span, alloc);
+    if (name == nil) { ret nil; }
+    val qname: str = json.quote(name, alloc);
+    json.free_str(name, alloc);
+    if (qname == nil) { ret nil; }
+
+    val kind: i64 = decl_lsp_kind(d.kind);
+    val kstr: str = json.format_i64(kind, alloc);
+    val full: str = range_json(positions.range_of(an.file, d.span), alloc);
+    val sel:  str = range_json(positions.range_of(an.file, name_span), alloc);
+
+    val p1: str = "{\"name\":";
+    val p2: str = ",\"kind\":";
+    val p3: str = ",\"range\":";
+    val p4: str = ",\"selectionRange\":";
+    val p5: str = "}";
+    val total: usize = str_len(p1) + slen(qname) + str_len(p2) + slen(kstr) + str_len(p3) + slen(full) + str_len(p4) + slen(sel) + str_len(p5);
+
+    val r: Result[*u8, str] = allocate[u8](alloc, total + 1);
+    if (is_err[*u8, str](r)) {
+        json.free_str(qname, alloc); json.free_str(kstr, alloc); json.free_str(full, alloc); json.free_str(sel, alloc);
+        ret nil;
+    }
+    val buf: *u8 = unwrap_ok[*u8, str](r);
+    var off: usize = 0;
+    off = append(buf, off, p1);
+    off = append(buf, off, qname);
+    off = append(buf, off, p2);
+    off = append(buf, off, kstr);
+    off = append(buf, off, p3);
+    off = append(buf, off, full);
+    off = append(buf, off, p4);
+    off = append(buf, off, sel);
+    off = append(buf, off, p5);
+    buf[off] = 0;
+
+    json.free_str(qname, alloc);
+    json.free_str(kstr, alloc);
+    json.free_str(full, alloc);
+    json.free_str(sel, alloc);
+    ret buf::str;
+}
+
+# decl_lsp_kind: the LSP SymbolKind for a decl kind (documentSymbol).
+fun decl_lsp_kind(kind: decl.DeclKind) i64 {
+    if (kind == decl.DECL_KIND_FUN) { ret 12; }
+    if (kind == decl.DECL_KIND_REC) { ret 23; }
+    if (kind == decl.DECL_KIND_UNI) { ret 10; }
+    if (kind == decl.DECL_KIND_DEF) { ret 26; }
+    if (kind == decl.DECL_KIND_VAL) { ret 14; }
+    if (kind == decl.DECL_KIND_VAR) { ret 13; }
+    ret 13;
+}
+
+# emit_completions: send a CompletionItem[] of the file's top-level names, each
+# deduped by spelling so a name declared once appears once.
+fun emit_completions(an: Analyzed, s: *sess.Session, alloc: *Allocator, id_raw: str) {
+    val prefix: str = "{\"jsonrpc\":\"2.0\",\"id\":";
+    val mid:    str = ",\"result\":{\"isIncomplete\":false,\"items\":[";
+    val suffix: str = "]}}";
+
+    var total: usize = str_len(prefix) + str_len(id_raw) + str_len(mid) + str_len(suffix);
+    var count: usize = 0;
+
+    var i1: u32 = 0;
+    for (i1 < an.rr.symbol_count) {
+        if (completion_first(an, i1)) {
+            val entry: str = completion_json(an, s, i1, alloc);
+            if (entry != nil) {
+                if (count > 0) { total = total + 1; }
+                total = total + str_len(entry);
+                json.free_str(entry, alloc);
+                count = count + 1;
+            }
+        }
+        i1 = i1 + 1;
+    }
+
+    val br: Result[*u8, str] = allocate[u8](alloc, total + 1);
+    if (is_err[*u8, str](br)) { reply_empty_array(alloc, id_raw); ret; }
+    val buf: *u8 = unwrap_ok[*u8, str](br);
+
+    var off: usize = 0;
+    off = append(buf, off, prefix);
+    off = append(buf, off, id_raw);
+    off = append(buf, off, mid);
+
+    var emitted: usize = 0;
+    var i2: u32 = 0;
+    for (i2 < an.rr.symbol_count) {
+        if (completion_first(an, i2)) {
+            val entry: str = completion_json(an, s, i2, alloc);
+            if (entry != nil) {
+                if (emitted > 0) { buf[off] = ','; off = off + 1; }
+                off = append(buf, off, entry);
+                json.free_str(entry, alloc);
+                emitted = emitted + 1;
+            }
+        }
+        i2 = i2 + 1;
+    }
+
+    off = append(buf, off, suffix);
+    buf[off] = 0;
+    transport.send_message(buf::str, alloc);
+    deallocate[u8](alloc, buf, total + 1);
+}
+
+# completion_first: whether symbol `sid` is a completion candidate AND the first
+# symbol with its name, so a name bound more than once is offered only once.
+fun completion_first(an: Analyzed, sid: res.SymbolId) bool {
+    if (!features.completion_candidate(an.rr, sid)) { ret false; }
+    val name: intern.StrId = an.rr.symbols[sid].name;
+    var j: u32 = 0;
+    for (j < sid) {
+        if (features.completion_candidate(an.rr, j) && an.rr.symbols[j].name == name) { ret false; }
+        j = j + 1;
+    }
+    ret true;
+}
+
+# completion_json: render symbol `sid` as a CompletionItem, or nil.
+fun completion_json(an: Analyzed, s: *sess.Session, sid: res.SymbolId, alloc: *Allocator) str {
+    val sym: *res.Symbol = ?an.rr.symbols[sid];
+    val no: Option[str] = intern.lookup(?s.interner, sym.name);
+    if (!is_some[str](no)) { ret nil; }
+    val qname: str = json.quote(unwrap[str](no), alloc);
+    if (qname == nil) { ret nil; }
+
+    val kind: i64 = features.lsp_completion_kind(sym.kind);
+    val kstr: str = json.format_i64(kind, alloc);
+    val qdetail: str = json.quote(features.kind_label(sym.kind), alloc);
+
+    val p1: str = "{\"label\":";
+    val p2: str = ",\"kind\":";
+    val p3: str = ",\"detail\":";
+    val p4: str = "}";
+    val total: usize = str_len(p1) + slen(qname) + str_len(p2) + slen(kstr) + str_len(p3) + slen(qdetail) + str_len(p4);
+
+    val r: Result[*u8, str] = allocate[u8](alloc, total + 1);
+    if (is_err[*u8, str](r)) {
+        json.free_str(qname, alloc); json.free_str(kstr, alloc); json.free_str(qdetail, alloc);
+        ret nil;
+    }
+    val buf: *u8 = unwrap_ok[*u8, str](r);
+    var off: usize = 0;
+    off = append(buf, off, p1);
+    off = append(buf, off, qname);
+    off = append(buf, off, p2);
+    off = append(buf, off, kstr);
+    off = append(buf, off, p3);
+    off = append(buf, off, qdetail);
+    off = append(buf, off, p4);
+    buf[off] = 0;
+
+    json.free_str(qname, alloc);
+    json.free_str(kstr, alloc);
+    json.free_str(qdetail, alloc);
+    ret buf::str;
+}
+
+# location_json: a Location object `{ uri, range }` for a span, or nil.
+fun location_json(file: *src.SourceFile, uri: str, span: token.Span, alloc: *Allocator) str {
+    val quri: str = json.quote(uri, alloc);
+    if (quri == nil) { ret nil; }
+    val rng: str = range_json(positions.range_of(file, span), alloc);
+
+    val p1: str = "{\"uri\":";
+    val p2: str = ",\"range\":";
+    val p3: str = "}";
+    val total: usize = str_len(p1) + slen(quri) + str_len(p2) + slen(rng) + str_len(p3);
+
+    val r: Result[*u8, str] = allocate[u8](alloc, total + 1);
+    if (is_err[*u8, str](r)) { json.free_str(quri, alloc); json.free_str(rng, alloc); ret nil; }
+    val buf: *u8 = unwrap_ok[*u8, str](r);
+    var off: usize = 0;
+    off = append(buf, off, p1);
+    off = append(buf, off, quri);
+    off = append(buf, off, p2);
+    off = append(buf, off, rng);
+    off = append(buf, off, p3);
+    buf[off] = 0;
+
+    json.free_str(quri, alloc);
+    json.free_str(rng, alloc);
+    ret buf::str;
+}
+
+# range_json: a `{ start: {...}, end: {...} }` range object, or nil.
+fun range_json(range: positions.LspRange, alloc: *Allocator) str {
+    val sl: str = json.format_usize(range.start_line, alloc);
+    val sc: str = json.format_usize(range.start_char, alloc);
+    val el: str = json.format_usize(range.end_line, alloc);
+    val ec: str = json.format_usize(range.end_char, alloc);
+
+    val p1: str = "{\"start\":{\"line\":";
+    val p2: str = ",\"character\":";
+    val p3: str = "},\"end\":{\"line\":";
+    val p4: str = ",\"character\":";
+    val p5: str = "}}";
+    val total: usize = str_len(p1) + slen(sl) + str_len(p2) + slen(sc) + str_len(p3) + slen(el) + str_len(p4) + slen(ec) + str_len(p5);
+
+    val r: Result[*u8, str] = allocate[u8](alloc, total + 1);
+    if (is_err[*u8, str](r)) { free4(sl, sc, el, ec, alloc); ret nil; }
+    val buf: *u8 = unwrap_ok[*u8, str](r);
+    var off: usize = 0;
+    off = append(buf, off, p1);
+    off = append(buf, off, sl);
+    off = append(buf, off, p2);
+    off = append(buf, off, sc);
+    off = append(buf, off, p3);
+    off = append(buf, off, el);
+    off = append(buf, off, p4);
+    off = append(buf, off, ec);
+    off = append(buf, off, p5);
+    buf[off] = 0;
+
+    free4(sl, sc, el, ec, alloc);
+    ret buf::str;
+}
+
+# loc_len: the JSON length one Location entry adds (plus a separating comma when
+# it is not the first), without retaining the rendering.
+fun loc_len(file: *src.SourceFile, uri: str, span: token.Span, alloc: *Allocator, index: usize) usize {
+    val loc: str = location_json(file, uri, span, alloc);
+    if (loc == nil) { ret 0; }
+    var n: usize = str_len(loc);
+    if (index > 0) { n = n + 1; }
+    json.free_str(loc, alloc);
+    ret n;
+}
+
+# put_loc: write one Location entry (comma-separated) into `buf`, returning the
+# new offset.
+fun put_loc(buf: *u8, off: usize, file: *src.SourceFile, uri: str, span: token.Span, alloc: *Allocator, index: usize) usize {
+    val loc: str = location_json(file, uri, span, alloc);
+    if (loc == nil) { ret off; }
+    var o: usize = off;
+    if (index > 0) { buf[o] = ','; o = o + 1; }
+    o = append(buf, o, loc);
+    json.free_str(loc, alloc);
+    ret o;
+}
+
+# edit_len: the JSON length one TextEdit adds (plus a separating comma when not
+# first), without retaining the rendering.
+fun edit_len(file: *src.SourceFile, span: token.Span, qname: str, alloc: *Allocator, index: usize) usize {
+    val ed: str = text_edit_json(file, span, qname, alloc);
+    if (ed == nil) { ret 0; }
+    var n: usize = str_len(ed);
+    if (index > 0) { n = n + 1; }
+    json.free_str(ed, alloc);
+    ret n;
+}
+
+# put_edit: write one TextEdit entry (comma-separated) into `buf`.
+fun put_edit(buf: *u8, off: usize, file: *src.SourceFile, span: token.Span, qname: str, alloc: *Allocator, index: usize) usize {
+    val ed: str = text_edit_json(file, span, qname, alloc);
+    if (ed == nil) { ret off; }
+    var o: usize = off;
+    if (index > 0) { buf[o] = ','; o = o + 1; }
+    o = append(buf, o, ed);
+    json.free_str(ed, alloc);
+    ret o;
+}
+
+# text_edit_json: a `{ range, newText }` TextEdit replacing a span's range with
+# the already-quoted `qname`, or nil.
+fun text_edit_json(file: *src.SourceFile, span: token.Span, qname: str, alloc: *Allocator) str {
+    val rng: str = range_json(positions.range_of(file, span), alloc);
+    if (rng == nil) { ret nil; }
+
+    val p1: str = "{\"range\":";
+    val p2: str = ",\"newText\":";
+    val p3: str = "}";
+    val total: usize = str_len(p1) + slen(rng) + str_len(p2) + slen(qname) + str_len(p3);
+
+    val r: Result[*u8, str] = allocate[u8](alloc, total + 1);
+    if (is_err[*u8, str](r)) { json.free_str(rng, alloc); ret nil; }
+    val buf: *u8 = unwrap_ok[*u8, str](r);
+    var off: usize = 0;
+    off = append(buf, off, p1);
+    off = append(buf, off, rng);
+    off = append(buf, off, p2);
+    off = append(buf, off, qname);
+    off = append(buf, off, p3);
+    buf[off] = 0;
+
+    json.free_str(rng, alloc);
+    ret buf::str;
+}
+
+# reply_null: send a `result: null` response for the request id.
+fun reply_null(alloc: *Allocator, id_raw: str) {
+    val p1: str = "{\"jsonrpc\":\"2.0\",\"id\":";
+    val p2: str = ",\"result\":null}";
+    send6(alloc, p1, id_raw, p2, nil, nil, nil, nil);
+    json.free_str(id_raw, alloc);
+}
+
+# reply_empty_array: send a `result: []` response for the request id.
+fun reply_empty_array(alloc: *Allocator, id_raw: str) {
+    val p1: str = "{\"jsonrpc\":\"2.0\",\"id\":";
+    val p2: str = ",\"result\":[]}";
+    send6(alloc, p1, id_raw, p2, nil, nil, nil, nil);
+    json.free_str(id_raw, alloc);
+}
+
+# reply_empty_edit: send an empty WorkspaceEdit (`changes: {}`) for the id.
+fun reply_empty_edit(alloc: *Allocator, id_raw: str) {
+    val p1: str = "{\"jsonrpc\":\"2.0\",\"id\":";
+    val p2: str = ",\"result\":{\"changes\":{}}}";
+    send6(alloc, p1, id_raw, p2, nil, nil, nil, nil);
+    json.free_str(id_raw, alloc);
+}
+
+# send6: frame and send the concatenation of up to six fragments (nil skipped).
+fun send6(alloc: *Allocator, a: str, b: str, c: str, d: str, e: str, f: str, g: str) {
+    val total: usize = slen(a) + slen(b) + slen(c) + slen(d) + slen(e) + slen(f) + slen(g);
+    val r: Result[*u8, str] = allocate[u8](alloc, total + 1);
+    if (is_err[*u8, str](r)) { ret; }
+    val buf: *u8 = unwrap_ok[*u8, str](r);
+    var off: usize = 0;
+    off = append(buf, off, a);
+    off = append(buf, off, b);
+    off = append(buf, off, c);
+    off = append(buf, off, d);
+    off = append(buf, off, e);
+    off = append(buf, off, f);
+    off = append(buf, off, g);
+    buf[off] = 0;
+    transport.send_message(buf::str, alloc);
+    deallocate[u8](alloc, buf, total + 1);
+}
+
+# slen: length of `s`, treating nil as 0.
+fun slen(s: str) usize {
+    if (s == nil) { ret 0; }
+    ret str_len(s);
+}
+
+# append: copy `s` into `buf` at `offset`, returning the new offset.
+fun append(buf: *u8, offset: usize, s: str) usize {
+    if (s == nil) { ret offset; }
+    val n: usize = str_len(s);
+    if (n > 0) { mem.raw_copy((buf::usize + offset)::ptr, s::ptr, n); }
+    ret offset + n;
+}
+
+# free4: free four owned strings.
+fun free4(a: str, b: str, c: str, d: str, alloc: *Allocator) {
+    json.free_str(a, alloc);
+    json.free_str(b, alloc);
+    json.free_str(c, alloc);
+    json.free_str(d, alloc);
+}
+
+# r_ok / r_err: Result[usize, str] constructors for `locate`.
+fun r_ok(v: usize) Result[usize, str] {
+    ret ok[usize, str](v);
+}
+fun r_err(m: str) Result[usize, str] {
+    ret err[usize, str](m);
+}

--- a/src/language.mach
+++ b/src/language.mach
@@ -179,7 +179,7 @@ pub fun definition(es: *editor.EditorSession, s: *sess.Session, alloc: *Allocato
     if (!is_some[*res.Symbol](so)) { reply_null(alloc, id_raw); ret; }
     val sym: *res.Symbol = unwrap[*res.Symbol](so);
 
-    val spo: Option[token.Span] = features.decl_name_span_of(an.a, sym);
+    val spo: Option[token.Span] = features.definition_name_span(an.a, sym);
     if (!is_some[token.Span](spo)) { reply_null(alloc, id_raw); ret; }
     val span: token.Span = unwrap[token.Span](spo);
 
@@ -212,7 +212,9 @@ pub fun references(es: *editor.EditorSession, s: *sess.Session, alloc: *Allocato
     val sr: features.SymbolRef = unwrap[features.SymbolRef](ro);
     if (!sr.local) { reply_empty_array(alloc, id_raw); ret; }
 
-    emit_locations(an, alloc, id_raw, uri, sr.sym_id, true);
+    var bind: token.Span;
+    val has_bind: bool = binding_span(an, sr.sym_id, ?bind);
+    emit_locations(an, alloc, id_raw, uri, sr.sym_id, bind, has_bind);
     json.free_str(id_raw, alloc);
 }
 
@@ -236,7 +238,9 @@ pub fun rename(es: *editor.EditorSession, s: *sess.Session, alloc: *Allocator, d
     val sr: features.SymbolRef = unwrap[features.SymbolRef](ro);
     if (!sr.local) { reply_empty_edit(alloc, id_raw); json.free_str(new_name, alloc); ret; }
 
-    emit_rename(an, alloc, id_raw, uri, sr.sym_id, new_name);
+    var bind: token.Span;
+    val has_bind: bool = binding_span(an, sr.sym_id, ?bind);
+    emit_rename(an, alloc, id_raw, uri, sr.sym_id, new_name, bind, has_bind);
     json.free_str(new_name, alloc);
     json.free_str(id_raw, alloc);
 }
@@ -298,6 +302,19 @@ pub fun completion(es: *editor.EditorSession, s: *sess.Session, alloc: *Allocato
     json.free_str(id_raw, alloc);
 }
 
+# binding_span: write the binding name span of a param / generic symbol into
+# `out` and return true, or false when the symbol binds at a Decl node (whose
+# site the decl walk already covers). lets references / rename include the one
+# binding site a param / generic has, which no side table records.
+fun binding_span(an: Analyzed, sid: res.SymbolId, out: *token.Span) bool {
+    val so: Option[*res.Symbol] = features.symbol(an.rr, sid);
+    if (!is_some[*res.Symbol](so)) { ret false; }
+    val bo: Option[token.Span] = features.binding_name_span(an.a, unwrap[*res.Symbol](so));
+    if (!is_some[token.Span](bo)) { ret false; }
+    @out = unwrap[token.Span](bo);
+    ret true;
+}
+
 # analyze: resolve the document named by `uri` and populate `out` with its
 # session, file, Ast, ResolveResult, and module id. false when the document is
 # unknown or resolution fails.
@@ -336,14 +353,17 @@ fun locate(es: *editor.EditorSession, s: *sess.Session, alloc: *Allocator, docs:
 }
 
 # emit_locations: send a Location[] result of every in-file reference to
-# `target`. when `include_decl` is set, the decl name span is included too.
-fun emit_locations(an: Analyzed, alloc: *Allocator, id_raw: str, uri: str, target: res.SymbolId, include_decl: bool) {
+# `target`. the decl name span is included via decl_ref_span; a param / generic
+# binding site, which has no Decl node, is passed in `bind` when `has_bind`.
+fun emit_locations(an: Analyzed, alloc: *Allocator, id_raw: str, uri: str, target: res.SymbolId, bind: token.Span, has_bind: bool) {
     val prefix: str = "{\"jsonrpc\":\"2.0\",\"id\":";
     val mid:    str = ",\"result\":[";
     val suffix: str = "]}";
 
     var total: usize = str_len(prefix) + str_len(id_raw) + str_len(mid) + str_len(suffix);
     var count: usize = 0;
+
+    if (has_bind) { total = total + loc_len(an.file, uri, bind, alloc, count); count = count + 1; }
 
     # first pass: size
     var ei: usize = 0;
@@ -358,13 +378,11 @@ fun emit_locations(an: Analyzed, alloc: *Allocator, id_raw: str, uri: str, targe
         if (is_some[token.Span](so)) { total = total + loc_len(an.file, uri, unwrap[token.Span](so), alloc, count); count = count + 1; }
         ti = ti + 1;
     }
-    if (include_decl) {
-        var di: usize = 0;
-        for (di < an.a.decl_len) {
-            val so: Option[token.Span] = features.decl_ref_span(an.a, an.rr, di::id.DeclId, target);
-            if (is_some[token.Span](so)) { total = total + loc_len(an.file, uri, unwrap[token.Span](so), alloc, count); count = count + 1; }
-            di = di + 1;
-        }
+    var di: usize = 0;
+    for (di < an.a.decl_len) {
+        val so: Option[token.Span] = features.decl_ref_span(an.a, an.rr, di::id.DeclId, target);
+        if (is_some[token.Span](so)) { total = total + loc_len(an.file, uri, unwrap[token.Span](so), alloc, count); count = count + 1; }
+        di = di + 1;
     }
 
     val br: Result[*u8, str] = allocate[u8](alloc, total + 1);
@@ -377,6 +395,7 @@ fun emit_locations(an: Analyzed, alloc: *Allocator, id_raw: str, uri: str, targe
     off = append(buf, off, mid);
 
     var emitted: usize = 0;
+    if (has_bind) { off = put_loc(buf, off, an.file, uri, bind, alloc, emitted); emitted = emitted + 1; }
     var e2: usize = 0;
     for (e2 < an.a.expr_len) {
         val so: Option[token.Span] = features.expr_ref_span(an.a, an.rr, e2::id.ExprId, target);
@@ -389,13 +408,11 @@ fun emit_locations(an: Analyzed, alloc: *Allocator, id_raw: str, uri: str, targe
         if (is_some[token.Span](so)) { off = put_loc(buf, off, an.file, uri, unwrap[token.Span](so), alloc, emitted); emitted = emitted + 1; }
         t2 = t2 + 1;
     }
-    if (include_decl) {
-        var d2: usize = 0;
-        for (d2 < an.a.decl_len) {
-            val so: Option[token.Span] = features.decl_ref_span(an.a, an.rr, d2::id.DeclId, target);
-            if (is_some[token.Span](so)) { off = put_loc(buf, off, an.file, uri, unwrap[token.Span](so), alloc, emitted); emitted = emitted + 1; }
-            d2 = d2 + 1;
-        }
+    var d2: usize = 0;
+    for (d2 < an.a.decl_len) {
+        val so: Option[token.Span] = features.decl_ref_span(an.a, an.rr, d2::id.DeclId, target);
+        if (is_some[token.Span](so)) { off = put_loc(buf, off, an.file, uri, unwrap[token.Span](so), alloc, emitted); emitted = emitted + 1; }
+        d2 = d2 + 1;
     }
 
     off = append(buf, off, suffix);
@@ -405,8 +422,9 @@ fun emit_locations(an: Analyzed, alloc: *Allocator, id_raw: str, uri: str, targe
 }
 
 # emit_rename: send a WorkspaceEdit with one TextEdit per in-file reference to
-# `target`, each replacing the reference's range with `new_name`.
-fun emit_rename(an: Analyzed, alloc: *Allocator, id_raw: str, uri: str, target: res.SymbolId, new_name: str) {
+# `target`, each replacing the reference's range with `new_name`. a param /
+# generic binding site is passed in `bind` when `has_bind`.
+fun emit_rename(an: Analyzed, alloc: *Allocator, id_raw: str, uri: str, target: res.SymbolId, new_name: str, bind: token.Span, has_bind: bool) {
     val quri: str = json.quote(uri, alloc);
     val qname: str = json.quote(new_name, alloc);
     if (quri == nil || qname == nil) {
@@ -421,6 +439,8 @@ fun emit_rename(an: Analyzed, alloc: *Allocator, id_raw: str, uri: str, target: 
 
     var total: usize = str_len(prefix) + str_len(id_raw) + str_len(mid1) + str_len(quri) + str_len(mid2) + str_len(suffix);
     var count: usize = 0;
+
+    if (has_bind) { total = total + edit_len(an.file, bind, qname, alloc, count); count = count + 1; }
 
     var e1: usize = 0;
     for (e1 < an.a.expr_len) {
@@ -456,6 +476,7 @@ fun emit_rename(an: Analyzed, alloc: *Allocator, id_raw: str, uri: str, target: 
     off = append(buf, off, mid2);
 
     var emitted: usize = 0;
+    if (has_bind) { off = put_edit(buf, off, an.file, bind, qname, alloc, emitted); emitted = emitted + 1; }
     var e2: usize = 0;
     for (e2 < an.a.expr_len) {
         val so: Option[token.Span] = features.expr_ref_span(an.a, an.rr, e2::id.ExprId, target);

--- a/src/positions.mach
+++ b/src/positions.mach
@@ -1,0 +1,115 @@
+# mls.positions: byte-offset <-> LSP position conversions and span helpers.
+#
+# the LSP addresses text by 0-based (line, character); the compiler addresses
+# it by byte offset (and reports 1-based line/col via `source.position`). the
+# language features pivot on byte offset — `ast.offset_to_*` takes an offset
+# and the resolve side tables index by node id — so every request first maps
+# the incoming LSP position to an offset, and every response maps a `token.Span`
+# back to an LSP range. these helpers are the single conversion point.
+#
+# columns are treated as byte columns, matching the diagnostics slice: the
+# editor protocol nominally measures characters in UTF-16 code units, but the
+# whole server (parser spans, `source.position`) is byte-oriented, so a
+# consistent byte interpretation keeps offsets and ranges aligned for ASCII
+# source. multi-byte handling lands with a column-encoding negotiation.
+
+use std.types.bool.bool;
+use std.types.size.usize;
+use std.types.string.str;
+use std.types.string.str_len;
+use std.types.option.Option;
+use std.types.option.some;
+use std.types.option.none;
+use std.types.option.is_some;
+use std.types.option.unwrap;
+use std.types.result.Result;
+use std.types.result.is_err;
+use std.types.result.unwrap_ok;
+
+use std.allocator.Allocator;
+use std.allocator.allocate;
+
+use mem: std.memory;
+
+use src:   mach.lang.source;
+use token: mach.lang.fe.token;
+
+# LspRange: a 0-based LSP range, the form a `Location` / hover range needs.
+# ---
+# start_line: 0-based start line
+# start_char: 0-based start character (byte column)
+# end_line:   0-based end line
+# end_char:   0-based end character (byte column)
+pub rec LspRange {
+    start_line: usize;
+    start_char: usize;
+    end_line:   usize;
+    end_char:   usize;
+}
+
+# offset_at: the byte offset of a 0-based LSP (line, character) in `file`, or
+# none when the line is out of range. the character is added to the line's
+# start offset and clamped to the file length.
+# ---
+# file: the source file the position addresses
+# line: 0-based LSP line
+# ch:   0-based LSP character (byte column)
+# ret:  some(offset) within the file, or none for an out-of-range line
+pub fun offset_at(file: *src.SourceFile, line: usize, ch: usize) Option[usize] {
+    val ls: Option[usize] = src.line_start(file, line + 1);
+    if (!is_some[usize](ls)) { ret none[usize](); }
+    var off: usize = unwrap[usize](ls) + ch;
+    val text_len: usize = str_len(file.text);
+    if (off > text_len) { off = text_len; }
+    ret some[usize](off);
+}
+
+# range_of: the LSP range covering a byte span in `file`. a zero-length span
+# yields an empty range at its offset.
+# ---
+# file: the source file the span addresses
+# span: the byte range to convert
+# ret:  the equivalent 0-based LSP range
+pub fun range_of(file: *src.SourceFile, span: token.Span) LspRange {
+    var r: LspRange;
+    val sp: src.Position = src.position(file, span.offset);
+    r.start_line = dec(sp.line);
+    r.start_char = dec(sp.col);
+
+    var end_off: usize = span.offset + span.len;
+    if (span.len == 0) { end_off = span.offset; }
+    val ep: src.Position = src.position(file, end_off);
+    r.end_line = dec(ep.line);
+    r.end_char = dec(ep.col);
+    if (r.end_line == r.start_line && r.end_char < r.start_char) { r.end_char = r.start_char; }
+    ret r;
+}
+
+# span_text: an owned copy of the source text a span covers, nil-terminated, or
+# nil on an empty span / allocation failure. used to render the spelling of a
+# decl name or type as written.
+# ---
+# file:  the source file the span addresses
+# span:  the byte range to copy
+# alloc: allocator backing the returned string
+# ret:   owned copy of the span text, or nil
+pub fun span_text(file: *src.SourceFile, span: token.Span, alloc: *Allocator) str {
+    if (span.len == 0) { ret nil; }
+    val text_len: usize = str_len(file.text);
+    if (span.offset >= text_len) { ret nil; }
+    var len: usize = span.len;
+    if (span.offset + len > text_len) { len = text_len - span.offset; }
+
+    val r: Result[*u8, str] = allocate[u8](alloc, len + 1);
+    if (is_err[*u8, str](r)) { ret nil; }
+    val buf: *u8 = unwrap_ok[*u8, str](r);
+    mem.raw_copy(buf::ptr, (file.text::usize + span.offset)::ptr, len);
+    buf[len] = 0;
+    ret buf::str;
+}
+
+# dec: clamp `n - 1` at 0 (1-based compiler position -> 0-based LSP position).
+fun dec(n: usize) usize {
+    if (n == 0) { ret 0; }
+    ret n - 1;
+}

--- a/src/server.mach
+++ b/src/server.mach
@@ -34,6 +34,7 @@ use transport: mls.transport;
 use json:      mls.json;
 use documents: mls.documents;
 use diagnostics: mls.diagnostics;
+use language:  mls.language;
 use trace:     mls.trace;
 
 # lifecycle statuses.
@@ -173,6 +174,42 @@ fun dispatch(srv: *Server, msg: *transport.Message) {
         ret;
     }
 
+    if (str_equals(method, "textDocument/hover")) {
+        json.free_str(method, srv.alloc);
+        handle_feature(srv, body, 0);
+        ret;
+    }
+    if (str_equals(method, "textDocument/definition")) {
+        json.free_str(method, srv.alloc);
+        handle_feature(srv, body, 1);
+        ret;
+    }
+    if (str_equals(method, "textDocument/references")) {
+        json.free_str(method, srv.alloc);
+        handle_feature(srv, body, 2);
+        ret;
+    }
+    if (str_equals(method, "textDocument/rename")) {
+        json.free_str(method, srv.alloc);
+        handle_feature(srv, body, 3);
+        ret;
+    }
+    if (str_equals(method, "textDocument/prepareRename")) {
+        json.free_str(method, srv.alloc);
+        handle_feature(srv, body, 4);
+        ret;
+    }
+    if (str_equals(method, "textDocument/documentSymbol")) {
+        json.free_str(method, srv.alloc);
+        handle_feature(srv, body, 5);
+        ret;
+    }
+    if (str_equals(method, "textDocument/completion")) {
+        json.free_str(method, srv.alloc);
+        handle_feature(srv, body, 6);
+        ret;
+    }
+
     trace.log("unhandled method: ");
     trace.log(method);
     trace.log("\n");
@@ -187,7 +224,7 @@ fun handle_initialize(srv: *Server, body: str) {
     if (id == nil) { ret; }
 
     val prefix: str = "{\"jsonrpc\":\"2.0\",\"id\":";
-    val result: str = ",\"result\":{\"capabilities\":{\"textDocumentSync\":1},\"serverInfo\":{\"name\":\"mach-lsp\"}}}";
+    val result: str = ",\"result\":{\"capabilities\":{\"textDocumentSync\":1,\"hoverProvider\":true,\"definitionProvider\":true,\"referencesProvider\":true,\"renameProvider\":{\"prepareProvider\":true},\"documentSymbolProvider\":true,\"completionProvider\":{\"triggerCharacters\":[\".\"]}},\"serverInfo\":{\"name\":\"mach-lsp\"}}}";
     send_concat2(srv, prefix, id, result);
     json.free_str(id, srv.alloc);
 
@@ -249,6 +286,26 @@ fun handle_did_close(srv: *Server, body: str) {
     documents.close(?srv.docs, uri);
     diagnostics.clear(srv.alloc, uri);
     json.free_str(uri, srv.alloc);
+}
+
+# handle_feature: route a language-feature request to its handler in `language`.
+# the document uri is extracted once here and passed through; the feature code
+# resolves the buffer, pivots the cursor, and replies. `which` selects the
+# feature: 0 hover, 1 definition, 2 references, 3 rename, 4 prepareRename,
+# 5 documentSymbol, 6 completion. an unknown / unopened uri still gets a
+# null / empty reply from the feature so the client is never left waiting.
+fun handle_feature(srv: *Server, body: str, which: i64) {
+    val uri: str = json.extract_after(body, "\"textDocument\"", "\"uri\"", srv.alloc);
+
+    if (which == 0) { language.hover(?srv.es, ?srv.s, srv.alloc, ?srv.docs, body, uri); }
+    or (which == 1) { language.definition(?srv.es, ?srv.s, srv.alloc, ?srv.docs, body, uri); }
+    or (which == 2) { language.references(?srv.es, ?srv.s, srv.alloc, ?srv.docs, body, uri); }
+    or (which == 3) { language.rename(?srv.es, ?srv.s, srv.alloc, ?srv.docs, body, uri); }
+    or (which == 4) { language.prepare_rename(?srv.es, ?srv.s, srv.alloc, ?srv.docs, body, uri); }
+    or (which == 5) { language.document_symbol(?srv.es, ?srv.s, srv.alloc, ?srv.docs, body, uri); }
+    or (which == 6) { language.completion(?srv.es, ?srv.s, srv.alloc, ?srv.docs, body, uri); }
+
+    if (uri != nil) { json.free_str(uri, srv.alloc); }
 }
 
 # publish_for: register/update `uri`'s buffer and publish its diagnostics.


### PR DESCRIPTION
Implements the rich LSP language features on top of the working diagnostics slice (PR #34), built against the `mach.lang.editor` query surface (`open` / `update` / `resolve`), `ast.offset_to_{expr,stmt,decl,type}`, and the `resolve.ResolveResult` side tables (`expr_resolved` / `type_resolved` / `decl_symbol` → `Symbol.{decl, origin}`), now on dep/mach's dev tip.

Closes #3
Closes #5
Closes #8
Closes #35

## Features

All advertised in `initialize` server capabilities and smoke-tested over stdio (`smoke_features.py`):

| Feature | Status | Notes |
|---|---|---|
| `textDocument/hover` (#3) | ✅ | fenced `mach` block: the decl header for a local symbol, the `name: type` for a param, `kind name` for a primitive |
| `textDocument/definition` | ✅ | the resolved symbol's binding-name `Location` (decl name, or param/generic binding site) |
| `textDocument/references` | ✅ (single-file) | every in-file expr / type / decl position + a param/generic binding site resolving to the same symbol |
| `textDocument/rename` + `prepareRename` | ✅ (single-file) | `WorkspaceEdit` over every in-file reference incl. the binding site (a compiling rename); `prepareRename` returns the name range |
| `textDocument/documentSymbol` (#5) | ✅ | the module's **top-level** decls as `DocumentSymbol` (nested locals excluded) |
| `textDocument/completion` (#8) | ✅ (partial) | the file's named decls, `use` aliases, and primitives — not lexically scoped (see below) |

## Single-file vs. deferred

The editor resolves one buffer in isolation with an empty dependency set, so resolution is **single-file**:

- hover / definition / references / rename are **complete for local symbols** (declared in the same buffer), including function parameters and generic type params resolved at their binding sites.
- a symbol imported through a `use` does not resolve single-file (its decl lives in a dependency Ast the editor never loaded), so the local features return `null`/empty for it rather than a wrong answer — **never a faked result** (verified: hover/definition on a `use`d std type → `null`).
- completion is a flat list of the file's named symbols + primitives, **not** scope-aware (member access after `.`, lexically scoped locals) — the resolver's scope chain is internal to the resolve pass and not exposed by the side tables.

**Deferred** (needs full-project resolution — the driver's dependency loading wired into the editor surface): cross-module go-to-def / hover / references, workspace symbols, scope-aware / member completion. Noted in the README.

## Smoke-test output (excerpt)

Against `fun helper(a: i64) i64 { ret a; }` / `fun main() i64 { val x: i64 = helper(7); ret x; }`:

- hover on `helper` call → ```` ```mach\nfun helper(a: i64) i64 \n``` ````
- hover on `x` → ```` ```mach\nval x: i64 = helper(7);\n``` ````
- definition of `helper` → `Location` at line 0
- references of `helper` → 2 (call + decl); rename `x`→`y` → 2 edits; param rename `a`→`arg` → binding + use
- documentSymbol → `helper`, `main` (no nested `x`)
- completion → primitives + `helper`, `main`

## Compiler dependency

`dep/mach` advanced to the current dev tip (55286bc) carrying the editor surface, `ast.offset_to_*`, and the resolve side tables; `dep/mach-std` was already at its dev tip. `mach.toml` `[deps.*]` track `branch/dev`. Built and tested with the v1.0.0 mach binary.

## Modules

- `positions` — byte offset ⇄ LSP `(line, character)`, span → range, span text.
- `features` — the offset → id → symbol query core over the resolve side tables.
- `language` — the seven request bodies + LSP JSON shaping.
- `server` — advertises the capabilities and routes each method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)