### PR TITLE
feat(hover): include doc comments in textDocument/hover

### DIFF
--- a/smoke_features.py
+++ b/smoke_features.py
@@ -6,14 +6,17 @@ import json
 import subprocess
 import sys
 
-BIN = "out/linux/bin/mach-lsp"
+BIN = "out/linux/debug/bin/mls"
 
+DOC = "helper returns its argument unchanged."
 SRC = (
-    "fun helper(a: i64) i64 { ret a; }\n"   # line 0
-    "fun main() i64 {\n"                     # line 1
-    "    val x: i64 = helper(7);\n"          # line 2
-    "    ret x;\n"                            # line 3
-    "}\n"                                     # line 4
+    "# helper returns its argument unchanged.\n"      # line 0 (doc comment)
+    "# exercised by the hover doc-comment assertion.\n"  # line 1 (doc comment)
+    "fun helper(a: i64) i64 { ret a; }\n"   # line 2
+    "fun main() i64 {\n"                     # line 3
+    "    val x: i64 = helper(7);\n"          # line 4
+    "    ret x;\n"                            # line 5
+    "}\n"                                     # line 6
 )
 URI = "file:///feat.mach"
 
@@ -53,35 +56,35 @@ requests = b"".join([
     frame({"jsonrpc": "2.0", "method": "initialized", "params": {}}),
     frame({"jsonrpc": "2.0", "method": "textDocument/didOpen",
            "params": {"textDocument": {"uri": URI, "languageId": "mach", "version": 1, "text": SRC}}}),
-    # hover on `helper` at its call site (line 2, char ~17)
+    # hover on `helper` at its call site (line 4, char ~17)
     frame({"jsonrpc": "2.0", "id": 10, "method": "textDocument/hover",
-           "params": {"textDocument": {"uri": URI}, "position": pos(2, 17)}}),
-    # hover on `x` use at `ret x` (line 3, char 8)
+           "params": {"textDocument": {"uri": URI}, "position": pos(4, 17)}}),
+    # hover on `x` use at `ret x` (line 5, char 8)
     frame({"jsonrpc": "2.0", "id": 11, "method": "textDocument/hover",
-           "params": {"textDocument": {"uri": URI}, "position": pos(3, 8)}}),
-    # definition of `helper` call (line 2) -> decl on line 0
+           "params": {"textDocument": {"uri": URI}, "position": pos(5, 8)}}),
+    # definition of `helper` call (line 4) -> decl on line 2
     frame({"jsonrpc": "2.0", "id": 20, "method": "textDocument/definition",
-           "params": {"textDocument": {"uri": URI}, "position": pos(2, 17)}}),
+           "params": {"textDocument": {"uri": URI}, "position": pos(4, 17)}}),
     # references of `helper` (decl + the one call)
     frame({"jsonrpc": "2.0", "id": 30, "method": "textDocument/references",
-           "params": {"textDocument": {"uri": URI}, "position": pos(0, 4),
+           "params": {"textDocument": {"uri": URI}, "position": pos(2, 4),
                       "context": {"includeDeclaration": True}}}),
     # prepareRename on `x`
     frame({"jsonrpc": "2.0", "id": 40, "method": "textDocument/prepareRename",
-           "params": {"textDocument": {"uri": URI}, "position": pos(2, 8)}}),
+           "params": {"textDocument": {"uri": URI}, "position": pos(4, 8)}}),
     # rename `x` -> `y`
     frame({"jsonrpc": "2.0", "id": 41, "method": "textDocument/rename",
-           "params": {"textDocument": {"uri": URI}, "position": pos(2, 8), "newName": "y"}}),
-    # rename parameter `a` from its binding site (line 0, char 11) -> `arg`;
+           "params": {"textDocument": {"uri": URI}, "position": pos(4, 8), "newName": "y"}}),
+    # rename parameter `a` from its binding site (line 2, char 11) -> `arg`;
     # must rewrite the binding plus the `ret a` use (a correct, compiling rename)
     frame({"jsonrpc": "2.0", "id": 42, "method": "textDocument/rename",
-           "params": {"textDocument": {"uri": URI}, "position": pos(0, 11), "newName": "arg"}}),
+           "params": {"textDocument": {"uri": URI}, "position": pos(2, 11), "newName": "arg"}}),
     # documentSymbol
     frame({"jsonrpc": "2.0", "id": 50, "method": "textDocument/documentSymbol",
            "params": {"textDocument": {"uri": URI}}}),
     # completion at statement position inside main
     frame({"jsonrpc": "2.0", "id": 60, "method": "textDocument/completion",
-           "params": {"textDocument": {"uri": URI}, "position": pos(3, 4)}}),
+           "params": {"textDocument": {"uri": URI}, "position": pos(5, 4)}}),
     frame({"jsonrpc": "2.0", "id": 2, "method": "shutdown", "params": None}),
     frame({"jsonrpc": "2.0", "method": "exit", "params": None}),
 ])
@@ -110,13 +113,17 @@ for cap in ["hoverProvider", "definitionProvider", "referencesProvider",
     if cap not in caps:
         failures.append(f"initialize missing capability {cap}")
 
-# hover on helper -> markdown mentioning helper signature
+# hover on helper -> markdown mentioning helper signature and its doc comment
 h = by_id(10)
 hv = (h or {}).get("result")
 if not hv or "contents" not in hv:
     failures.append("hover(helper) returned no contents")
-elif "helper" not in hv["contents"].get("value", ""):
-    failures.append("hover(helper) value does not mention 'helper'")
+else:
+    hval = hv["contents"].get("value", "")
+    if "helper" not in hval:
+        failures.append("hover(helper) value does not mention 'helper'")
+    if DOC not in hval:
+        failures.append(f"hover(helper) value does not include the doc comment {DOC!r}")
 
 # hover on x -> mentions x and i64
 h2 = by_id(11)
@@ -126,13 +133,13 @@ if not hv2 or "contents" not in hv2:
 elif "i64" not in hv2["contents"].get("value", ""):
     failures.append("hover(x) value does not mention type 'i64'")
 
-# definition of helper -> a Location on line 0
+# definition of helper -> a Location on line 2 (its decl)
 d = by_id(20)
 dv = (d or {}).get("result")
 if not dv or "range" not in dv:
     failures.append("definition(helper) returned no Location")
-elif dv["range"]["start"]["line"] != 0:
-    failures.append(f"definition(helper) points to line {dv['range']['start']['line']}, expected 0")
+elif dv["range"]["start"]["line"] != 2:
+    failures.append(f"definition(helper) points to line {dv['range']['start']['line']}, expected 2")
 
 # references of helper -> at least 2 (decl + call)
 r = by_id(30)
@@ -172,9 +179,9 @@ else:
     elif any(e.get("newText") != "arg" for e in pedits):
         failures.append("rename(param a) edit newText is not 'arg'")
     else:
-        # the binding site is on line 0 (the signature); a use is on line 0 too,
+        # the binding site is on line 2 (the signature); a use is on line 2 too,
         # but there must be an edit at the binding column (char 11)
-        cols = {e["range"]["start"]["character"] for e in pedits if e["range"]["start"]["line"] == 0}
+        cols = {e["range"]["start"]["character"] for e in pedits if e["range"]["start"]["line"] == 2}
         if 11 not in cols:
             failures.append(f"rename(param a) did not rewrite the binding at col 11 (cols {sorted(cols)})")
 

--- a/smoke_features.py
+++ b/smoke_features.py
@@ -10,7 +10,7 @@ BIN = "out/linux/debug/bin/mls"
 
 DOC = "helper returns its argument unchanged."
 SRC = (
-    "# helper returns its argument unchanged.\n"      # line 0 (doc comment)
+    f"# {DOC}\n"                                         # line 0 (doc comment)
     "# exercised by the hover doc-comment assertion.\n"  # line 1 (doc comment)
     "fun helper(a: i64) i64 { ret a; }\n"   # line 2
     "fun main() i64 {\n"                     # line 3

--- a/src/features.mach
+++ b/src/features.mach
@@ -29,6 +29,7 @@ use std.types.option.is_some;
 use std.types.option.unwrap;
 
 use sess:   mach.lang.session;
+use src:    mach.lang.source;
 use intern: mach.lang.intern;
 use token:  mach.lang.fe.token;
 use ast:    mach.lang.fe.ast;
@@ -379,53 +380,52 @@ fun param_signature_span(a: *ast.Ast, sym: *res.Symbol) Option[token.Span] {
 
 # doc_comment_span: the byte span of the contiguous run of `#` comment lines
 # immediately above a local symbol's declaration — its doc comment. the lexer
-# discards comment tokens, so this back-scans the raw source the way `mach doc`
-# does: from the decl's first line it walks backward over comment lines
-# (tolerating leading whitespace before the `#`), stopping at the first
-# non-comment line. none for a param / generic, a decl with no comment run
-# flush above it, or a decl at the file start.
+# discards comment tokens, so this back-scans the file's line index the way
+# `mach doc` scans raw text: from the decl's line it walks backward over
+# comment lines (tolerating leading whitespace before the `#`), stopping at
+# the first non-comment line. none for a param / generic, a decl with no
+# comment run flush above it, or a decl on the first line.
 # ---
 # a:    the Ast owning the decl
 # sym:  the symbol whose doc comment is wanted
-# text: the full source text of the file owning the decl
-# ret:  some(span) covering the comment run (its trailing newline included), or
-#       none
-pub fun doc_comment_span(a: *ast.Ast, sym: *res.Symbol, text: str) Option[token.Span] {
+# file: the source file owning the decl
+# ret:  some(span) covering the comment run (its line endings included), or none
+pub fun doc_comment_span(a: *ast.Ast, sym: *res.Symbol, file: *src.SourceFile) Option[token.Span] {
     if (sym.kind == res.SYM_PARAM || sym.kind == res.SYM_GENERIC) { ret none[token.Span](); }
     val dso: Option[token.Span] = decl_span_of(a, sym);
     if (!is_some[token.Span](dso)) { ret none[token.Span](); }
+    val decl_line: usize = src.position(file, unwrap[token.Span](dso).offset).line;
 
-    val s: *u8 = text::*u8;
-    val decl_line: usize = line_start_back(s, unwrap[token.Span](dso).offset);
+    var first: usize = decl_line;
+    for (first > 1 && comment_line(file, first - 1)) { first = first - 1; }
+    if (first == decl_line) { ret none[token.Span](); }
 
-    var run: usize = decl_line;
-    for (run > 0) {
-        val prev: usize = line_start_back(s, run - 1);
-        if (!is_comment_line(s, prev)) { brk; }
-        run = prev;
-    }
-    if (run == decl_line) { ret none[token.Span](); }
+    val so: Option[usize] = src.line_start(file, first);
+    val eo: Option[usize] = src.line_start(file, decl_line);
+    if (!is_some[usize](so) || !is_some[usize](eo)) { ret none[token.Span](); }
 
     var sp: token.Span;
-    sp.offset = run;
-    sp.len    = decl_line - run;
+    sp.offset = unwrap[usize](so);
+    sp.len    = unwrap[usize](eo) - sp.offset;
     ret some[token.Span](sp);
 }
 
-# line_start_back: the byte offset of the start of the line containing `pos`,
-# found by scanning back to just past the preceding newline (or the file start).
-fun line_start_back(s: *u8, pos: usize) usize {
+# first_nonspace: index of the first non-space, non-tab byte in `s` at or after
+# `pos`, clamped to `end`. shared by the doc-comment scan and its renderer.
+pub fun first_nonspace(s: *u8, pos: usize, end: usize) usize {
     var i: usize = pos;
-    for (i > 0 && s[i - 1] != '\n') { i = i - 1; }
+    for (i < end && (s[i] == ' ' || s[i] == '\t')) { i = i + 1; }
     ret i;
 }
 
-# is_comment_line: true when the first significant byte of the line at `pos` is
-# `#`, tolerating leading spaces / tabs.
-fun is_comment_line(s: *u8, pos: usize) bool {
-    var i: usize = pos;
-    for (s[i] == ' ' || s[i] == '\t') { i = i + 1; }
-    ret s[i] == '#';
+# comment_line: true when the 1-based `line`'s first significant byte is `#`.
+fun comment_line(file: *src.SourceFile, line: usize) bool {
+    val bo: Option[src.LineSpan] = src.line_bounds(file, line);
+    if (!is_some[src.LineSpan](bo)) { ret false; }
+    val lb: src.LineSpan = unwrap[src.LineSpan](bo);
+    val s: *u8 = file.text::*u8;
+    val i: usize = first_nonspace(s, lb.start, lb.end);
+    ret i < lb.end && s[i] == '#';
 }
 
 # kind_label: a human-readable label for a symbol kind, for hover rendering.

--- a/src/features.mach
+++ b/src/features.mach
@@ -377,6 +377,57 @@ fun param_signature_span(a: *ast.Ast, sym: *res.Symbol) Option[token.Span] {
     ret some[token.Span](sp);
 }
 
+# doc_comment_span: the byte span of the contiguous run of `#` comment lines
+# immediately above a local symbol's declaration — its doc comment. the lexer
+# discards comment tokens, so this back-scans the raw source the way `mach doc`
+# does: from the decl's first line it walks backward over comment lines
+# (tolerating leading whitespace before the `#`), stopping at the first
+# non-comment line. none for a param / generic, a decl with no comment run
+# flush above it, or a decl at the file start.
+# ---
+# a:    the Ast owning the decl
+# sym:  the symbol whose doc comment is wanted
+# text: the full source text of the file owning the decl
+# ret:  some(span) covering the comment run (its trailing newline included), or
+#       none
+pub fun doc_comment_span(a: *ast.Ast, sym: *res.Symbol, text: str) Option[token.Span] {
+    if (sym.kind == res.SYM_PARAM || sym.kind == res.SYM_GENERIC) { ret none[token.Span](); }
+    val dso: Option[token.Span] = decl_span_of(a, sym);
+    if (!is_some[token.Span](dso)) { ret none[token.Span](); }
+
+    val s: *u8 = text::*u8;
+    val decl_line: usize = line_start_back(s, unwrap[token.Span](dso).offset);
+
+    var run: usize = decl_line;
+    for (run > 0) {
+        val prev: usize = line_start_back(s, run - 1);
+        if (!is_comment_line(s, prev)) { brk; }
+        run = prev;
+    }
+    if (run == decl_line) { ret none[token.Span](); }
+
+    var sp: token.Span;
+    sp.offset = run;
+    sp.len    = decl_line - run;
+    ret some[token.Span](sp);
+}
+
+# line_start_back: the byte offset of the start of the line containing `pos`,
+# found by scanning back to just past the preceding newline (or the file start).
+fun line_start_back(s: *u8, pos: usize) usize {
+    var i: usize = pos;
+    for (i > 0 && s[i - 1] != '\n') { i = i - 1; }
+    ret i;
+}
+
+# is_comment_line: true when the first significant byte of the line at `pos` is
+# `#`, tolerating leading spaces / tabs.
+fun is_comment_line(s: *u8, pos: usize) bool {
+    var i: usize = pos;
+    for (s[i] == ' ' || s[i] == '\t') { i = i + 1; }
+    ret s[i] == '#';
+}
+
 # kind_label: a human-readable label for a symbol kind, for hover rendering.
 # ---
 # kind: a res.SYM_* value

--- a/src/language.mach
+++ b/src/language.mach
@@ -110,7 +110,8 @@ pub fun hover(es: *editor.EditorSession, s: *sess.Session, alloc: *Allocator, do
 
 # hover_markdown: a fenced `mach` code block rendering the symbol at hover. for
 # a local symbol it shows the declaration header as written; otherwise the
-# symbol kind and name.
+# symbol kind and name. a local symbol's doc comment, if any, follows the block
+# as prose.
 fun hover_markdown(an: Analyzed, sym: *res.Symbol, alloc: *Allocator) str {
     var sig: str = nil;
     if (sym.origin == an.own && sym.decl != id.DECL_NIL) {
@@ -124,19 +125,100 @@ fun hover_markdown(an: Analyzed, sym: *res.Symbol, alloc: *Allocator) str {
     }
     if (sig == nil) { ret nil; }
 
-    val pre: str = "```mach\n";
+    var doc: str = nil;
+    if (sym.origin == an.own) {
+        val dso: Option[token.Span] = features.doc_comment_span(an.a, sym, an.file.text);
+        if (is_some[token.Span](dso)) { doc = doc_prose(an.file, unwrap[token.Span](dso), alloc); }
+    }
+
+    val pre:  str = "```mach\n";
     val post: str = "\n```";
-    val total: usize = str_len(pre) + str_len(sig) + str_len(post);
+    val sep:  str = "\n\n";
+    var total: usize = str_len(pre) + str_len(sig) + str_len(post);
+    if (doc != nil) { total = total + str_len(sep) + str_len(doc); }
     val r: Result[*u8, str] = allocate[u8](alloc, total + 1);
-    if (is_err[*u8, str](r)) { json.free_str(sig, alloc); ret nil; }
+    if (is_err[*u8, str](r)) { json.free_str(sig, alloc); json.free_str(doc, alloc); ret nil; }
     val buf: *u8 = unwrap_ok[*u8, str](r);
     var off: usize = 0;
     off = append(buf, off, pre);
     off = append(buf, off, sig);
     off = append(buf, off, post);
+    if (doc != nil) {
+        off = append(buf, off, sep);
+        off = append(buf, off, doc);
+    }
     buf[off] = 0;
     json.free_str(sig, alloc);
+    json.free_str(doc, alloc);
     ret buf::str;
+}
+
+# doc_prose: render a doc-comment span (the contiguous `#` run above a decl) as
+# Markdown prose. each line is stripped of its leading `#` and a single
+# following space, a `# ---` separator line renders as a blank line (matching
+# `mach doc`), and lines are joined by newlines. nil on an empty span,
+# allocation failure, or a run carrying no text.
+fun doc_prose(file: *src.SourceFile, span: token.Span, alloc: *Allocator) str {
+    if (span.len == 0) { ret nil; }
+    val s: *u8 = file.text::*u8;
+    val end: usize = span.offset + span.len;
+
+    val r: Result[*u8, str] = allocate[u8](alloc, span.len + 1);
+    if (is_err[*u8, str](r)) { ret nil; }
+    val buf: *u8 = unwrap_ok[*u8, str](r);
+
+    var off: usize = 0;
+    var pos: usize = span.offset;
+    var first: bool = true;
+    for (pos < end) {
+        val hash: usize = first_nonspace(s, pos);
+        var body: usize = hash + 1;
+        if (s[body] == ' ') { body = body + 1; }
+        val le: usize = line_end(s, pos);
+
+        if (!first) { buf[off] = '\n'; off = off + 1; }
+        first = false;
+        if (!starts_with(s, body, "---")) {
+            val n: usize = le - body;
+            if (n > 0) { mem.raw_copy((buf::usize + off)::ptr, (s::usize + body)::ptr, n); off = off + n; }
+        }
+        pos = next_line(s, le);
+    }
+    buf[off] = 0;
+    if (off == 0) { deallocate[u8](alloc, buf, span.len + 1); ret nil; }
+    ret buf::str;
+}
+
+# first_nonspace: index of the first non-space, non-tab byte on the line at
+# `pos`, stopping at the line end.
+fun first_nonspace(s: *u8, pos: usize) usize {
+    var i: usize = pos;
+    for (s[i] == ' ' || s[i] == '\t') { i = i + 1; }
+    ret i;
+}
+
+# line_end: index of the line-ending '\n' (or the terminator) at or after `pos`.
+fun line_end(s: *u8, pos: usize) usize {
+    var i: usize = pos;
+    for (s[i] != 0 && s[i] != '\n') { i = i + 1; }
+    ret i;
+}
+
+# next_line: index of the start of the line following the one whose end is `le`.
+fun next_line(s: *u8, le: usize) usize {
+    if (s[le] == 0) { ret le; }
+    ret le + 1;
+}
+
+# starts_with: true when the bytes at `s[pos..]` begin with the literal `lit`.
+fun starts_with(s: *u8, pos: usize, lit: str) bool {
+    val l: *u8 = lit::*u8;
+    var i: usize = 0;
+    for (l[i] != 0) {
+        if (s[pos + i] != l[i]) { ret false; }
+        i = i + 1;
+    }
+    ret true;
 }
 
 # compose_kind_name: a `<kind> <name>` rendering for a symbol with no local

--- a/src/language.mach
+++ b/src/language.mach
@@ -22,6 +22,7 @@ use std.types.size.usize;
 use std.types.string.str;
 use std.types.string.str_len;
 use std.types.string.str_equals;
+use std.types.string.str_starts_with;
 use std.types.option.Option;
 use std.types.option.is_some;
 use std.types.option.unwrap;
@@ -114,22 +115,19 @@ pub fun hover(es: *editor.EditorSession, s: *sess.Session, alloc: *Allocator, do
 # as prose.
 fun hover_markdown(an: Analyzed, sym: *res.Symbol, alloc: *Allocator) str {
     var sig: str = nil;
+    var doc: str = nil;
     if (sym.origin == an.own && sym.decl != id.DECL_NIL) {
         val sso: Option[token.Span] = features.signature_span(an.a, sym);
         if (is_some[token.Span](sso)) {
             sig = positions.span_text(an.file, unwrap[token.Span](sso), alloc);
         }
+        val dso: Option[token.Span] = features.doc_comment_span(an.a, sym, an.file);
+        if (is_some[token.Span](dso)) { doc = doc_prose(an.file, unwrap[token.Span](dso), alloc); }
     }
     if (sig == nil) {
         sig = compose_kind_name(sym, ?an.s.interner, alloc);
     }
-    if (sig == nil) { ret nil; }
-
-    var doc: str = nil;
-    if (sym.origin == an.own) {
-        val dso: Option[token.Span] = features.doc_comment_span(an.a, sym, an.file.text);
-        if (is_some[token.Span](dso)) { doc = doc_prose(an.file, unwrap[token.Span](dso), alloc); }
-    }
+    if (sig == nil) { json.free_str(doc, alloc); ret nil; }
 
     val pre:  str = "```mach\n";
     val post: str = "\n```";
@@ -156,69 +154,60 @@ fun hover_markdown(an: Analyzed, sym: *res.Symbol, alloc: *Allocator) str {
 # doc_prose: render a doc-comment span (the contiguous `#` run above a decl) as
 # Markdown prose. each line is stripped of its leading `#` and a single
 # following space, a `# ---` separator line renders as a blank line (matching
-# `mach doc`), and lines are joined by newlines. nil on an empty span,
-# allocation failure, or a run carrying no text.
+# `mach doc`), and lines are joined by newlines. a measure pass sizes the
+# buffer exactly, so the allocation is str_len + 1 as `json.free_str` expects.
+# nil on an empty span, a run carrying no text, or allocation failure.
 fun doc_prose(file: *src.SourceFile, span: token.Span, alloc: *Allocator) str {
     if (span.len == 0) { ret nil; }
-    val s: *u8 = file.text::*u8;
-    val end: usize = span.offset + span.len;
+    val first: usize = src.position(file, span.offset).line;
+    val last:  usize = src.position(file, span.offset + span.len - 1).line;
 
-    val r: Result[*u8, str] = allocate[u8](alloc, span.len + 1);
+    var total: usize = 0;
+    var l1: usize = first;
+    for (l1 <= last) {
+        if (l1 > first) { total = total + 1; }
+        total = total + doc_body(file, l1).len;
+        l1 = l1 + 1;
+    }
+    if (total == 0) { ret nil; }
+
+    val r: Result[*u8, str] = allocate[u8](alloc, total + 1);
     if (is_err[*u8, str](r)) { ret nil; }
     val buf: *u8 = unwrap_ok[*u8, str](r);
 
     var off: usize = 0;
-    var pos: usize = span.offset;
-    var first: bool = true;
-    for (pos < end) {
-        val hash: usize = first_nonspace(s, pos);
-        var body: usize = hash + 1;
-        if (s[body] == ' ') { body = body + 1; }
-        val le: usize = line_end(s, pos);
-
-        if (!first) { buf[off] = '\n'; off = off + 1; }
-        first = false;
-        if (!starts_with(s, body, "---")) {
-            val n: usize = le - body;
-            if (n > 0) { mem.raw_copy((buf::usize + off)::ptr, (s::usize + body)::ptr, n); off = off + n; }
+    var l2: usize = first;
+    for (l2 <= last) {
+        if (l2 > first) { buf[off] = '\n'; off = off + 1; }
+        val body: token.Span = doc_body(file, l2);
+        if (body.len > 0) {
+            mem.raw_copy((buf::usize + off)::ptr, (file.text::usize + body.offset)::ptr, body.len);
+            off = off + body.len;
         }
-        pos = next_line(s, le);
+        l2 = l2 + 1;
     }
     buf[off] = 0;
-    if (off == 0) { deallocate[u8](alloc, buf, span.len + 1); ret nil; }
     ret buf::str;
 }
 
-# first_nonspace: index of the first non-space, non-tab byte on the line at
-# `pos`, stopping at the line end.
-fun first_nonspace(s: *u8, pos: usize) usize {
-    var i: usize = pos;
-    for (s[i] == ' ' || s[i] == '\t') { i = i + 1; }
-    ret i;
-}
-
-# line_end: index of the line-ending '\n' (or the terminator) at or after `pos`.
-fun line_end(s: *u8, pos: usize) usize {
-    var i: usize = pos;
-    for (s[i] != 0 && s[i] != '\n') { i = i + 1; }
-    ret i;
-}
-
-# next_line: index of the start of the line following the one whose end is `le`.
-fun next_line(s: *u8, le: usize) usize {
-    if (s[le] == 0) { ret le; }
-    ret le + 1;
-}
-
-# starts_with: true when the bytes at `s[pos..]` begin with the literal `lit`.
-fun starts_with(s: *u8, pos: usize, lit: str) bool {
-    val l: *u8 = lit::*u8;
-    var i: usize = 0;
-    for (l[i] != 0) {
-        if (s[pos + i] != l[i]) { ret false; }
-        i = i + 1;
-    }
-    ret true;
+# doc_body: the rendered slice of comment line `line` (1-based) as a byte span
+# into the file text — past the leading whitespace, `#`, and a single following
+# space. zero-length for a `# ---` separator row or an out-of-range line.
+fun doc_body(file: *src.SourceFile, line: usize) token.Span {
+    var sp: token.Span;
+    sp.offset = 0;
+    sp.len    = 0;
+    val bo: Option[src.LineSpan] = src.line_bounds(file, line);
+    if (!is_some[src.LineSpan](bo)) { ret sp; }
+    val lb: src.LineSpan = unwrap[src.LineSpan](bo);
+    val s: *u8 = file.text::*u8;
+    var i: usize = features.first_nonspace(s, lb.start, lb.end);
+    if (i < lb.end && s[i] == '#') { i = i + 1; }
+    if (i < lb.end && s[i] == ' ') { i = i + 1; }
+    if (str_starts_with((s::usize + i)::str, "---")) { ret sp; }
+    sp.offset = i;
+    sp.len    = lb.end - i;
+    ret sp;
 }
 
 # compose_kind_name: a `<kind> <name>` rendering for a symbol with no local


### PR DESCRIPTION
## Summary

Hover now appends a local symbol's `#` doc comment below the fenced signature block, rendered as Markdown prose.

The Mach lexer discards `#` comment tokens (no doc field on AST decls), so this replicates the textual back-scan `mach doc` uses:

- `features.doc_comment_span` walks backward from a local decl's first line over the contiguous run of `#` comment lines (tolerating leading whitespace), returning the run's byte span — `none` for params/generics, decls with no comment run flush above them, or decls at file start.
- `language.doc_prose` renders that span as prose: strips each line's leading `#` and one following space, renders a `# ---` separator as a blank line (matching `mach doc`), and joins lines with newlines. The result is appended after the signature block.

Scope: this works for symbols whose decl is in the open buffer. Cross-module decls aren't loaded yet (#39, in flight separately) and are not attempted here.

## Test

`smoke_features.py` gains a doc comment above `helper` and an assertion that `hover(helper)` contains the doc text; its stale `BIN` path is corrected to `out/linux/debug/bin/mls`. Verified end-to-end with `mach build` + `python3 smoke_features.py`.

Closes #40