### PR TITLE
feat: workspace-wide use-site indexing — complete references and cross-file rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,13 @@ This server implements the **diagnostics** vertical slice plus the
     comment as trailing prose.
   - `textDocument/definition` — the resolved symbol's declaration `Location`.
   - `textDocument/references` — the symbol's declaration (which may live in a
-    dependency file) plus every use-site **in the requesting buffer**;
-    workspace-wide use-site search is tracked in #47.
-  - `textDocument/rename` / `prepareRename` — a `WorkspaceEdit` renaming every
-    in-file reference; `prepareRename` returns the name range.
+    dependency file) plus every use-site **across the loaded project graph**
+    (the requesting buffer and every other module that references the symbol).
+  - `textDocument/rename` / `prepareRename` — a **cross-file** `WorkspaceEdit`
+    renaming the declaration, every importer's references, and each importer's
+    `use` path leaf; confined to symbols declared in the user's own project.
+    `prepareRename` returns the name range for a renameable symbol, null for a
+    dependency-declared one.
   - `textDocument/documentSymbol` — the module's top-level declarations as a
     `DocumentSymbol` list.
   - `textDocument/completion` — the file's named declarations, `use` aliases,
@@ -41,15 +44,22 @@ and `dep/` tree) and snapshots every loaded module's exports into a dependency
 set, then re-resolves the open buffer against it. So a symbol imported through
 a `use` binds to its declaration in a dependency module, and:
 
-- hover / definition / references reach **cross-module and cross-file** symbols,
-  pointing at the defining module's source file on disk (a `file://` location);
-- rename / prepareRename stay confined to symbols **local** to the buffer — a
-  dependency's declaration is not the editor's to rewrite;
+- hover / definition reach **cross-module and cross-file** symbols, pointing at
+  the defining module's source file on disk (a `file://` location);
+- references and rename walk a shared use-site index over the loaded module
+  graph (`build_refs` over `mls.project`'s `module_view`): references reports
+  every use-site across all modules; rename rewrites the declaring file, every
+  importer's body references, and each importer's `use` path leaf (guarded by
+  the declared name, so an aliased import's references are left intact).
+  Cross-file rename is confined to symbols declared in the user's own project —
+  a dependency's declaration is not the editor's to rewrite — and reflects the
+  on-disk state of files other than the active buffer, since the project graph
+  is a load-time snapshot not rebuilt on `didChange`;
 - completion is a flat list of the file's named symbols and the primitives, not
   a lexically scoped view (the resolver's scope chain is not exposed by the
   side tables);
 - a document outside any project (no ancestor `mach.toml`) resolves single-file
-  with an empty dependency set.
+  with an empty dependency set — references and rename then stay buffer-local.
 
 > **Known limitation (#45):** the vendored `dep/mach` only parses the old
 > `[targets.<name>]` manifest format, so cross-module resolution is currently
@@ -89,7 +99,7 @@ and fetched by `mach dep pull`; `mach-std` tracks `branch/dev` and `mach` is pin
 | `diagnostics` | run `editor.diagnostics`, map spans, publish |
 | `positions` | byte offset ⇄ LSP `(line, character)` and span text |
 | `features` | offset → id → symbol query core over the resolve side tables |
-| `project` | load the project module graph; re-resolve a buffer against its dependency set; map a symbol to its declaring file's `file://` URI |
+| `project` | load the project module graph; re-resolve a buffer against its dependency set; map a symbol to its declaring file's `file://` URI; expose the loaded modules for the workspace-wide use-site walk |
 | `language` | hover / definition / references / rename / documentSymbol / completion request bodies |
 | `trace` | append-only debug trace log (`/tmp/mach-lsp.log`) |
 
@@ -108,8 +118,13 @@ each scenario module asserts one surface:
   file's functions.
 - `test_crossmodule.py` — against `test/fixture` (which depends on the vendored
   `mach-std`): definition / references / hover on a `use`d std symbol reach a
-  `file://` location inside `dep/mach-std`, and a local symbol still resolves in
-  the buffer.
+  `file://` location inside `dep/mach-std`, a local symbol still resolves in the
+  buffer, and renaming a dependency symbol is refused (prepareRename null, empty
+  edit).
+- `test_workspace.py` — against `test/fixture-ws`, a depless two-module project:
+  references on a `pub` symbol used across files returns use-sites in both
+  modules, and rename rewrites the declaration, the importer's `use` path leaf,
+  and every use-site across both files — invoked from either buffer.
 
 ```sh
 make test          # builds, then runs test/run.py

--- a/README.md
+++ b/README.md
@@ -52,14 +52,24 @@ a `use` binds to its declaration in a dependency module, and:
   importer's body references, and each importer's `use` path leaf (guarded by
   the declared name, so an aliased import's references are left intact).
   Cross-file rename is confined to symbols declared in the user's own project —
-  a dependency's declaration is not the editor's to rewrite — and reflects the
-  on-disk state of files other than the active buffer, since the project graph
-  is a load-time snapshot not rebuilt on `didChange`;
+  a dependency's declaration is not the editor's to rewrite, whether referenced
+  cross-module or opened directly as the buffer — and reflects the on-disk
+  state of files other than the active buffer, since the project graph is a
+  load-time snapshot not rebuilt on `didChange`. When a module-scope `pub`
+  symbol's cross-file identity cannot be recovered from its stale on-disk twin
+  (unsaved edits renamed the declaration), rename refuses with an empty edit
+  rather than emit a partial, compile-breaking one;
 - completion is a flat list of the file's named symbols and the primitives, not
   a lexically scoped view (the resolver's scope chain is not exposed by the
   side tables);
 - a document outside any project (no ancestor `mach.toml`) resolves single-file
   with an empty dependency set — references and rename then stay buffer-local.
+
+> **Scope note:** the loader builds the import-reachable module closure of the
+> manifest's default target (the compiler's own DFS load), so project files
+> outside that closure — secondary `bin` targets, modules nothing imports — are
+> not in the graph: references cannot see their use-sites and rename silently
+> leaves them untouched. Per-root multi-graph loading is tracked in #46.
 
 > **Known limitation (#45):** the vendored `dep/mach` only parses the old
 > `[targets.<name>]` manifest format, so cross-module resolution is currently
@@ -120,11 +130,15 @@ each scenario module asserts one surface:
   `mach-std`): definition / references / hover on a `use`d std symbol reach a
   `file://` location inside `dep/mach-std`, a local symbol still resolves in the
   buffer, and renaming a dependency symbol is refused (prepareRename null, empty
-  edit).
+  edit) — whether referenced cross-module or with the dependency source itself
+  opened as the buffer.
 - `test_workspace.py` — against `test/fixture-ws`, a depless two-module project:
   references on a `pub` symbol used across files returns use-sites in both
   modules, and rename rewrites the declaration, the importer's `use` path leaf,
-  and every use-site across both files — invoked from either buffer.
+  and every use-site across both files — invoked from either buffer. a
+  block-local binding shadowing a pub name renames buffer-local without touching
+  importers, and a pub declaration renamed by unsaved edits refuses (empty edit)
+  instead of emitting a partial rename.
 
 ```sh
 make test          # builds, then runs test/run.py

--- a/src/features.mach
+++ b/src/features.mach
@@ -22,6 +22,7 @@ use std.types.bool.true;
 use std.types.bool.false;
 use std.types.size.usize;
 use std.types.string.str;
+use std.types.string.str_len;
 use std.types.option.Option;
 use std.types.option.some;
 use std.types.option.none;
@@ -224,6 +225,53 @@ pub fun symbol_is_local(rr: *res.ResolveResult, own: sess.ModuleId, sid: res.Sym
     if (sym.kind == res.SYM_PRIM) { ret false; }
     if (sym.decl == id.DECL_NIL) { ret false; }
     ret sym.origin == own;
+}
+
+# symbol_by_decl: the SymbolId in `rr` whose declaration is the module-scoped
+# pair (origin, decl) — the identity the same logical symbol shares across every
+# module's resolve result, since an imported reference copies its referent's
+# origin ModuleId and DeclId. lets the workspace-wide references / rename walk
+# find a module's own id for a symbol declared elsewhere. param / generic
+# bindings (whose decl is their owning function) are skipped so a module-scope
+# decl resolves to its declaration, not one of its parameters. SYMBOL_NIL when
+# no symbol in `rr` resolves to that declaration.
+# ---
+# rr:     the module's resolve side tables
+# origin: ModuleId owning the declaration
+# decl:   DeclId of the declaration in `origin`'s Ast
+# ret:    the local SymbolId, or SYMBOL_NIL
+pub fun symbol_by_decl(rr: *res.ResolveResult, origin: sess.ModuleId, decl: id.DeclId) res.SymbolId {
+    if (decl == id.DECL_NIL) { ret res.SYMBOL_NIL; }
+    var i: u32 = 0;
+    for (i < rr.symbol_count) {
+        val sym: *res.Symbol = ?rr.symbols[i];
+        if (sym.kind != res.SYM_PARAM && sym.kind != res.SYM_GENERIC
+            && sym.decl == decl && sym.origin == origin) { ret i::res.SymbolId; }
+        i = i + 1;
+    }
+    ret res.SYMBOL_NIL;
+}
+
+# export_decl_of: the DeclId of the pub symbol in `rr` named `name` with kind
+# `kind`, or DECL_NIL. translates a buffer-local pub declaration to the canonical
+# (origin, decl) identity in the on-disk module the buffer mirrors, so the
+# workspace walk can locate importers of that symbol. pub symbols occupy the
+# front of the table ([0, pub_count)); a non-pub symbol has no cross-file
+# use-sites and yields DECL_NIL.
+# ---
+# rr:   the on-disk module's resolve side tables
+# name: interned identifier of the declaration
+# kind: the declaration's symbol kind
+# ret:  the declaration's DeclId, or DECL_NIL
+pub fun export_decl_of(rr: *res.ResolveResult, name: intern.StrId, kind: res.SymKind) id.DeclId {
+    if (name == intern.STR_NIL) { ret id.DECL_NIL; }
+    var i: u32 = 0;
+    for (i < rr.pub_count) {
+        val sym: *res.Symbol = ?rr.symbols[i];
+        if (sym.name == name && sym.kind == kind && sym.decl != id.DECL_NIL) { ret sym.decl; }
+        i = i + 1;
+    }
+    ret id.DECL_NIL;
 }
 
 # top_level_count: the number of declarations at the buffer's module scope —
@@ -555,6 +603,78 @@ pub fun decl_ref_span(a: *ast.Ast, rr: *res.ResolveResult, did: id.DeclId, targe
     val d_opt: Option[*decl.Decl] = ast.get_decl(a, did);
     if (!is_some[*decl.Decl](d_opt)) { ret none[token.Span](); }
     ret decl_name_span(unwrap[*decl.Decl](d_opt));
+}
+
+# import_leaf_span: the byte span of the final dotted segment of import `path`
+# (the leaf component that names the imported symbol), or the whole span for a
+# single-segment path. mirrors the resolver's own leaf computation so a
+# cross-file rename can rewrite an imported name inside a `use` / `fwd` path
+# without touching its module prefix or an alias.
+# ---
+# file: the source file backing the path span
+# path: byte span covering the dotted import path
+# ret:  the leaf segment span
+pub fun import_leaf_span(file: *src.SourceFile, path: token.Span) token.Span {
+    val s: *u8 = file.text::*u8;
+    val start: usize = path.offset;
+    val end:   usize = path.offset + path.len;
+    var dot:   usize = start;
+    var found: bool  = false;
+    var i:     usize = start;
+    for (i < end) {
+        if (s[i] == '.') { dot = i; found = true; }
+        i = i + 1;
+    }
+    var out: token.Span;
+    if (!found) { out.offset = path.offset; out.len = path.len; ret out; }
+    out.offset = dot + 1;
+    out.len    = end - (dot + 1);
+    ret out;
+}
+
+# import_ref_span: the leaf-name span of import decl `did` (a `use` or `fwd`)
+# when it imports `target`, or none. the resolver binds a single-symbol import
+# under the path's leaf and records the imported symbol in `decl_symbol`, but
+# `decl_name_span` has no name for an import decl, so this recovers the leaf the
+# references / rename walk must include to keep an importer compiling.
+# ---
+# a:      the Ast holding the decl
+# rr:     the ResolveResult side tables
+# did:    decl id to test
+# target: the symbol the import must bind
+# file:   the source file backing the import path
+# ret:    some(leaf span) when did imports target, or none
+pub fun import_ref_span(a: *ast.Ast, rr: *res.ResolveResult, did: id.DeclId, target: res.SymbolId, file: *src.SourceFile) Option[token.Span] {
+    if (rr.decl_symbol == nil || did::u32 >= rr.decl_count) { ret none[token.Span](); }
+    if (rr.decl_symbol[did] != target) { ret none[token.Span](); }
+    val d_opt: Option[*decl.Decl] = ast.get_decl(a, did);
+    if (!is_some[*decl.Decl](d_opt)) { ret none[token.Span](); }
+    val d: *decl.Decl = unwrap[*decl.Decl](d_opt);
+    if (d.kind == decl.DECL_KIND_USE) { ret some[token.Span](import_leaf_span(file, d.data.use_.path)); }
+    if (d.kind == decl.DECL_KIND_FWD) { ret some[token.Span](import_leaf_span(file, d.data.fwd_.path)); }
+    ret none[token.Span]();
+}
+
+# span_text_equals: true when the bytes of `span` in `file` exactly equal the
+# identifier `name`. the rename walk guards body references with it so a symbol
+# bound under an alias — whose references are spelled with the alias, not the
+# declared name — is not rewritten when the declaration is renamed.
+# ---
+# file: the source file backing the span
+# span: byte span to compare
+# name: identifier text to match
+# ret:  true on an exact byte match
+pub fun span_text_equals(file: *src.SourceFile, span: token.Span, name: str) bool {
+    if (name == nil) { ret false; }
+    val nlen: usize = str_len(name);
+    if (span.len != nlen) { ret false; }
+    val s: *u8 = file.text::*u8;
+    var i: usize = 0;
+    for (i < nlen) {
+        if (s[span.offset + i] != name[i]) { ret false; }
+        i = i + 1;
+    }
+    ret true;
 }
 
 # name_span_of_expr: the span identifying an expression's referenced name. for

--- a/src/language.mach
+++ b/src/language.mach
@@ -451,7 +451,10 @@ pub fun references(ws: *project.Workspace, es: *editor.EditorSession, s: *sess.S
     if (is_err[*XRef, str](ra)) { reply_empty_array(alloc, id_raw); ret; }
     val refs: *XRef = unwrap_ok[*XRef, str](ra);
 
-    val n: usize = build_refs(ws, an, uri, sym, sr.sym_id, false, refs, cap);
+    # a failed bridge only degrades references to buffer-local results; rename
+    # is where it must refuse (see build_refs / BRIDGE_FAILED).
+    var status: i64 = BRIDGE_LOCAL;
+    val n: usize = build_refs(ws, an, uri, sym, sr.sym_id, false, refs, cap, ?status);
     emit_locations(alloc, id_raw, refs, n, bind, has_bind);
     free_refs(ws, refs, n);
     deallocate[XRef](alloc, refs, cap);
@@ -462,8 +465,10 @@ pub fun references(ws: *project.Workspace, es: *editor.EditorSession, s: *sess.S
 # whole project graph — the declaring file plus every module that imports or
 # uses it (including each importer's `use` path leaf). confined to symbols
 # declared in the user's own project: a dependency's declaration is not the
-# editor's to rewrite, so renaming a cross-module dependency symbol yields an
-# empty edit.
+# editor's to rewrite (whether referenced cross-module or opened as the buffer
+# itself), so those yield an empty edit. an empty edit is also returned when a
+# module-scope pub symbol's cross-file identity cannot be recovered from its
+# stale on-disk twin — a buffer-local edit there would be a partial rename.
 pub fun rename(ws: *project.Workspace, es: *editor.EditorSession, s: *sess.Session, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
     val id_raw: str = json.extract_raw(body, "\"id\"", alloc);
     if (id_raw == nil) { ret; }
@@ -483,7 +488,7 @@ pub fun rename(ws: *project.Workspace, es: *editor.EditorSession, s: *sess.Sessi
     val so: Option[*res.Symbol] = features.symbol(an.rr, sr.sym_id);
     if (!is_some[*res.Symbol](so)) { reply_empty_edit(alloc, id_raw); json.free_str(new_name, alloc); ret; }
     val sym: *res.Symbol = unwrap[*res.Symbol](so);
-    if (!renameable(ws, sym, sr)) { reply_empty_edit(alloc, id_raw); json.free_str(new_name, alloc); ret; }
+    if (!renameable(ws, uri, sym, sr)) { reply_empty_edit(alloc, id_raw); json.free_str(new_name, alloc); ret; }
 
     # the declared name guards the cross-file walk: only occurrences spelled with
     # it are rewritten, so an aliased import's references are left untouched.
@@ -499,7 +504,17 @@ pub fun rename(ws: *project.Workspace, es: *editor.EditorSession, s: *sess.Sessi
     if (is_err[*XRef, str](ra)) { reply_empty_edit(alloc, id_raw); json.free_str(new_name, alloc); ret; }
     val refs: *XRef = unwrap_ok[*XRef, str](ra);
 
-    val n: usize = build_refs(ws, an, uri, sym, sr.sym_id, true, refs, cap);
+    var status: i64 = BRIDGE_LOCAL;
+    val n: usize = build_refs(ws, an, uri, sym, sr.sym_id, true, refs, cap, ?status);
+    if (status == BRIDGE_FAILED) {
+        # the pub declaration's cross-file identity is unrecoverable (stale
+        # twin); a buffer-local edit would be the partial rename #47 forbids.
+        free_refs(ws, refs, n);
+        deallocate[XRef](alloc, refs, cap);
+        json.free_str(new_name, alloc);
+        reply_empty_edit(alloc, id_raw);
+        ret;
+    }
     emit_rename(alloc, id_raw, refs, n, new_name, name, bind, has_bind);
     free_refs(ws, refs, n);
     deallocate[XRef](alloc, refs, cap);
@@ -524,7 +539,7 @@ pub fun prepare_rename(ws: *project.Workspace, es: *editor.EditorSession, s: *se
 
     val so: Option[*res.Symbol] = features.symbol(an.rr, sr.sym_id);
     if (!is_some[*res.Symbol](so)) { reply_null(alloc, id_raw); ret; }
-    if (!renameable(ws, unwrap[*res.Symbol](so), sr)) { reply_null(alloc, id_raw); ret; }
+    if (!renameable(ws, uri, unwrap[*res.Symbol](so), sr)) { reply_null(alloc, id_raw); ret; }
 
     val range: positions.LspRange = positions.range_of(an.file, sr.name_span);
     val rng: str = range_json(range, alloc);
@@ -580,28 +595,48 @@ fun binding_span(an: Analyzed, sid: res.SymbolId, out: *token.Span) bool {
     ret true;
 }
 
-# renameable: whether the symbol at the cursor may be renamed — a buffer-local
-# symbol always, a cross-module symbol only when declared in a project-owned
-# module (a dependency's declaration is not the editor's to rewrite). primitives
-# and unresolved positions are excluded upstream (sr.local is false for them).
-fun renameable(ws: *project.Workspace, sym: *res.Symbol, sr: features.SymbolRef) bool {
-    if (sr.local) { ret true; }
-    ret project.is_project_module(ws, sym.origin);
+# renameable: whether the symbol at the cursor may be renamed. a cross-module
+# symbol must be declared in a project-owned module, and a buffer-local symbol
+# is only renameable when the buffer itself is the editor's to rewrite: its
+# on-disk twin (when the buffer is a loaded module's file — e.g. a dependency
+# source opened via go-to-definition, whose symbols all resolve buffer-locally)
+# must also be project-owned. a buffer with no twin (a scratch file, or one
+# outside the loaded graph) renames buffer-local.
+fun renameable(ws: *project.Workspace, uri: str, sym: *res.Symbol, sr: features.SymbolRef) bool {
+    if (!sr.local) { ret project.is_project_module(ws, sym.origin); }
+    val twin_o: Option[sess.ModuleId] = project.module_for_uri(ws, uri);
+    if (!is_some[sess.ModuleId](twin_o)) { ret true; }
+    ret project.is_project_module(ws, unwrap[sess.ModuleId](twin_o));
 }
 
 # XRef: one file contributing references to a target symbol — its Ast, resolve
 # tables, source file, document URI, and the local SymbolId every reference in
-# it resolves to. the active buffer is the first XRef (live resolve, borrowed
-# URI); each other loaded module that references the symbol is another (graph
-# snapshot, an owned `file://` URI freed by free_refs). see build_refs.
+# it resolves to. the active buffer is always the first XRef (live resolve,
+# borrowed URI); each other loaded module that references the symbol is another
+# (graph snapshot, an owned `file://` URI freed by free_refs). see build_refs.
 rec XRef {
-    a:         *ast.Ast;
-    rr:        *res.ResolveResult;
-    file:      *src.SourceFile;
-    uri:       str;
-    owned_uri: bool;
-    target:    res.SymbolId;
+    a:      *ast.Ast;
+    rr:     *res.ResolveResult;
+    file:   *src.SourceFile;
+    uri:    str;
+    target: res.SymbolId;
 }
+
+# bridge status of build_refs' buffer -> on-disk-twin identity translation.
+# ---
+# BRIDGE_LOCAL:  the symbol has no cross-file identity (block-local, non-pub,
+#                or the buffer has no loaded twin); buffer-local results are
+#                complete on their own terms.
+# BRIDGE_OK:     a canonical (origin, decl) identity resolved; the graph walk
+#                ran and cross-file results are included.
+# BRIDGE_FAILED: the symbol is a module-scope pub declaration but its identity
+#                could not be recovered from the on-disk twin — e.g. unsaved
+#                edits renamed the declaration, so the stale twin does not
+#                export the name. rename must refuse rather than emit the
+#                compile-breaking partial edit a buffer-local fallback would be.
+val BRIDGE_LOCAL:  i64 = 0;
+val BRIDGE_OK:     i64 = 1;
+val BRIDGE_FAILED: i64 = 2;
 
 # build_refs: populate `out` with the files that reference the symbol at the
 # cursor and return the count. `out[0]` is always the active buffer (resolved
@@ -609,10 +644,13 @@ rec XRef {
 # whose resolve result contains the symbol's canonical (origin, decl) identity,
 # skipping the buffer's on-disk twin so its live edits are not double-counted.
 # `project_only` restricts the walk to project-owned modules (rename); references
-# passes false to include dependency modules. the symbol's canonical identity is
-# read directly for a cross-module reference, or recovered from the buffer's
-# on-disk module for a buffer-local pub declaration; a buffer-local non-pub
-# symbol has no cross-file use-sites, so only the active buffer is returned.
+# passes false to include dependency modules. the canonical identity is read
+# directly for a cross-module reference; for a buffer-local symbol it is bridged
+# through the buffer's on-disk twin, but only when the symbol is a module-scope
+# pub declaration — a block-local binding that shadows a pub symbol's name, or a
+# non-pub declaration, has no importers and must not bridge to one. the bridge
+# outcome is reported in `status` (see BRIDGE_*) so rename can refuse on a
+# failed bridge instead of degrading to a partial buffer-local edit.
 # ---
 # ws:          the workspace
 # an:          the active buffer's analysis
@@ -622,15 +660,16 @@ rec XRef {
 # project_only:restrict the graph walk to project-owned modules
 # out:         array of at least `cap` XRef slots
 # cap:         capacity of `out` (module_count + 1)
+# status:      receives the BRIDGE_* outcome
 # ret:         number of populated entries (>= 1)
-fun build_refs(ws: *project.Workspace, an: Analyzed, uri: str, sym: *res.Symbol, self_target: res.SymbolId, project_only: bool, out: *XRef, cap: usize) usize {
-    out[0].a         = an.a;
-    out[0].rr        = an.rr;
-    out[0].file      = an.file;
-    out[0].uri       = uri;
-    out[0].owned_uri = false;
-    out[0].target    = self_target;
+fun build_refs(ws: *project.Workspace, an: Analyzed, uri: str, sym: *res.Symbol, self_target: res.SymbolId, project_only: bool, out: *XRef, cap: usize, status: *i64) usize {
+    out[0].a      = an.a;
+    out[0].rr     = an.rr;
+    out[0].file   = an.file;
+    out[0].uri    = uri;
+    out[0].target = self_target;
     var n: usize = 1;
+    @status = BRIDGE_LOCAL;
 
     val self_o: Option[sess.ModuleId] = project.module_for_uri(ws, uri);
     val have_self: bool = is_some[sess.ModuleId](self_o);
@@ -640,13 +679,16 @@ fun build_refs(ws: *project.Workspace, an: Analyzed, uri: str, sym: *res.Symbol,
     var canon_origin: sess.ModuleId = sym.origin;
     var canon_decl:   id.DeclId     = sym.decl;
     if (sym.origin == an.own) {
+        if ((sym.flags & res.SYM_FLAG_MODULE) == 0 || (sym.flags & res.SYM_FLAG_PUB) == 0) { ret n; }
         if (!have_self) { ret n; }
         val mv_o: Option[project.ModuleView] = project.module_view(ws, self_mid);
-        if (!is_some[project.ModuleView](mv_o)) { ret n; }
+        if (!is_some[project.ModuleView](mv_o)) { @status = BRIDGE_FAILED; ret n; }
         canon_decl   = features.export_decl_of(unwrap[project.ModuleView](mv_o).rr, sym.name, sym.kind);
         canon_origin = self_mid;
+        if (canon_decl == id.DECL_NIL) { @status = BRIDGE_FAILED; ret n; }
     }
     if (canon_decl == id.DECL_NIL) { ret n; }
+    @status = BRIDGE_OK;
 
     val mc: u32 = project.module_count(ws);
     var mid: u32 = 0;
@@ -661,12 +703,11 @@ fun build_refs(ws: *project.Workspace, an: Analyzed, uri: str, sym: *res.Symbol,
         if (tgt == res.SYMBOL_NIL) { mid = mid + 1; cnt; }
         val muri: str = project.module_uri(ws, cur);
         if (muri == nil) { mid = mid + 1; cnt; }
-        out[n].a         = mv.a;
-        out[n].rr        = mv.rr;
-        out[n].file      = mv.file;
-        out[n].uri       = muri;
-        out[n].owned_uri = true;
-        out[n].target    = tgt;
+        out[n].a      = mv.a;
+        out[n].rr     = mv.rr;
+        out[n].file   = mv.file;
+        out[n].uri    = muri;
+        out[n].target = tgt;
         n = n + 1;
         mid = mid + 1;
     }
@@ -674,11 +715,11 @@ fun build_refs(ws: *project.Workspace, an: Analyzed, uri: str, sym: *res.Symbol,
 }
 
 # free_refs: release the owned `file://` URIs of the graph-module entries in a
-# built XRef array. the active buffer's borrowed URI is left untouched.
+# built XRef array. refs[0] borrows the request's URI and is skipped.
 fun free_refs(ws: *project.Workspace, refs: *XRef, n: usize) {
-    var i: usize = 0;
+    var i: usize = 1;
     for (i < n) {
-        if (refs[i].owned_uri && refs[i].uri != nil) { json.free_str(refs[i].uri, ws.alloc); }
+        if (refs[i].uri != nil) { json.free_str(refs[i].uri, ws.alloc); }
         i = i + 1;
     }
 }
@@ -720,22 +761,104 @@ fun locate(ws: *project.Workspace, es: *editor.EditorSession, s: *sess.Session, 
     ret positions.offset_at(out.file, line::usize, ch::usize);
 }
 
+# WalkSink: the size-or-write accumulator behind the shared reference walk.
+# one walk (walk_refs) feeds it: with `buf` nil it totals JSON byte lengths
+# into `total`; pointed at the output buffer it writes entries at `off`. the
+# same walk drives both passes, so the sizing and writing can never diverge.
+# `qname` nil emits Location entries; non-nil emits TextEdit entries replacing
+# each span with that quoted name. `guard`, when non-nil, drops body (expr /
+# type) spans not spelled exactly `guard`, so rename skips alias-spelled
+# references while references reports them. `count` sequences the separating
+# commas across everything fed to the sink.
+rec WalkSink {
+    alloc: *Allocator;
+    buf:   *u8;
+    off:   usize;
+    total: usize;
+    count: usize;
+    qname: str;
+    guard: str;
+}
+
+# sink_init: a sizing WalkSink; point `buf` at the output (and reset `count`)
+# to switch it to the write pass.
+fun sink_init(alloc: *Allocator, qname: str, guard: str) WalkSink {
+    var k: WalkSink;
+    k.alloc = alloc;
+    k.buf   = nil;
+    k.off   = 0;
+    k.total = 0;
+    k.count = 0;
+    k.qname = qname;
+    k.guard = guard;
+    ret k;
+}
+
+# sink_emit: size or write one Location / TextEdit for `span` of source `s`,
+# per the sink's mode.
+fun sink_emit(k: *WalkSink, s: *XRef, span: token.Span) {
+    if (k.qname == nil) {
+        if (k.buf == nil) { k.total = k.total + loc_len(s.file, s.uri, span, k.alloc, k.count); }
+        or                { k.off   = put_loc(k.buf, k.off, s.file, s.uri, span, k.alloc, k.count); }
+    }
+    or {
+        if (k.buf == nil) { k.total = k.total + edit_len(s.file, span, k.qname, k.alloc, k.count); }
+        or                { k.off   = put_edit(k.buf, k.off, s.file, span, k.qname, k.alloc, k.count); }
+    }
+    k.count = k.count + 1;
+}
+
+# walk_refs: feed every reference to `s.target` in source `s` to the sink — the
+# declaration name, `use` / `fwd` import-path leaves, and the body (expr / type)
+# use-sites, plus the active buffer's param / generic binding when
+# `include_bind`. body spans pass the sink's spelling guard (see WalkSink);
+# declaration and import leaves always carry the declared name and are exempt.
+fun walk_refs(s: *XRef, include_bind: bool, bind: token.Span, k: *WalkSink) {
+    if (s.target == res.SYMBOL_NIL) { ret; }
+    if (include_bind) { sink_emit(k, s, bind); }
+    var di: usize = 0;
+    for (di < s.a.decl_len) {
+        val dso: Option[token.Span] = features.decl_ref_span(s.a, s.rr, di::id.DeclId, s.target);
+        if (is_some[token.Span](dso)) { sink_emit(k, s, unwrap[token.Span](dso)); }
+        val iso: Option[token.Span] = features.import_ref_span(s.a, s.rr, di::id.DeclId, s.target, s.file);
+        if (is_some[token.Span](iso)) { sink_emit(k, s, unwrap[token.Span](iso)); }
+        di = di + 1;
+    }
+    var ei: usize = 0;
+    for (ei < s.a.expr_len) {
+        val so: Option[token.Span] = features.expr_ref_span(s.a, s.rr, ei::id.ExprId, s.target);
+        if (is_some[token.Span](so) && guard_admits(s, k, unwrap[token.Span](so))) { sink_emit(k, s, unwrap[token.Span](so)); }
+        ei = ei + 1;
+    }
+    var ti: usize = 0;
+    for (ti < s.a.type_len) {
+        val so: Option[token.Span] = features.type_ref_span(s.a, s.rr, ti::id.TypeId, s.target);
+        if (is_some[token.Span](so) && guard_admits(s, k, unwrap[token.Span](so))) { sink_emit(k, s, unwrap[token.Span](so)); }
+        ti = ti + 1;
+    }
+}
+
+# guard_admits: whether a body span passes the sink's spelling guard.
+fun guard_admits(s: *XRef, k: *WalkSink, span: token.Span) bool {
+    if (k.guard == nil) { ret true; }
+    ret features.span_text_equals(s.file, span, k.guard);
+}
+
 # emit_locations: send a Location[] of every reference to the symbol across the
-# files in `refs`. each XRef contributes its declaration, import-path leaves, and
-# every body use-site of its local target; the active buffer's param / generic
-# binding (which has no Decl node) is `refs[0]`'s and is passed in `bind` when
-# `has_bind`. takes ownership of `id_raw` and frees it.
+# files in `refs` (declaration, import leaves, body use-sites; see walk_refs).
+# the active buffer's param / generic binding (which has no Decl node) is
+# `refs[0]`'s and is included when `has_bind`. takes ownership of `id_raw` and
+# frees it.
 fun emit_locations(alloc: *Allocator, id_raw: str, refs: *XRef, nref: usize, bind: token.Span, has_bind: bool) {
     val prefix: str = "{\"jsonrpc\":\"2.0\",\"id\":";
     val mid:    str = ",\"result\":[";
     val suffix: str = "]}";
 
-    var total: usize = str_len(prefix) + str_len(id_raw) + str_len(mid) + str_len(suffix);
-    var count: usize = 0;
-    if (nref > 0 && has_bind) { total = total + loc_len(refs[0].file, refs[0].uri, bind, alloc, count); count = count + 1; }
+    var k: WalkSink = sink_init(alloc, nil, nil);
     var si: usize = 0;
-    for (si < nref) { size_locations(?refs[si], alloc, ?total, ?count); si = si + 1; }
+    for (si < nref) { walk_refs(?refs[si], si == 0 && has_bind, bind, ?k); si = si + 1; }
 
+    val total: usize = str_len(prefix) + str_len(id_raw) + str_len(mid) + k.total + str_len(suffix);
     val br: Result[*u8, str] = allocate[u8](alloc, total + 1);
     if (is_err[*u8, str](br)) { reply_empty_array(alloc, id_raw); ret; }
     val buf: *u8 = unwrap_ok[*u8, str](br);
@@ -745,72 +868,18 @@ fun emit_locations(alloc: *Allocator, id_raw: str, refs: *XRef, nref: usize, bin
     off = append(buf, off, id_raw);
     off = append(buf, off, mid);
 
-    var emitted: usize = 0;
-    if (nref > 0 && has_bind) { off = put_loc(buf, off, refs[0].file, refs[0].uri, bind, alloc, emitted); emitted = emitted + 1; }
+    k.buf   = buf;
+    k.off   = off;
+    k.count = 0;
     var sj: usize = 0;
-    for (sj < nref) { off = write_locations(?refs[sj], buf, off, alloc, ?emitted); sj = sj + 1; }
+    for (sj < nref) { walk_refs(?refs[sj], sj == 0 && has_bind, bind, ?k); sj = sj + 1; }
+    off = k.off;
 
     off = append(buf, off, suffix);
     buf[off] = 0;
     transport.send_message(buf::str, alloc);
     deallocate[u8](alloc, buf, total + 1);
     json.free_str(id_raw, alloc);
-}
-
-# size_locations: add the JSON length of every reference to `s.target` in source
-# `s` to `total`, advancing the running `count` (which sequences the separating
-# commas across the whole Location array).
-fun size_locations(s: *XRef, alloc: *Allocator, total: *usize, count: *usize) {
-    if (s.target == res.SYMBOL_NIL) { ret; }
-    var di: usize = 0;
-    for (di < s.a.decl_len) {
-        val dso: Option[token.Span] = features.decl_ref_span(s.a, s.rr, di::id.DeclId, s.target);
-        if (is_some[token.Span](dso)) { @total = @total + loc_len(s.file, s.uri, unwrap[token.Span](dso), alloc, @count); @count = @count + 1; }
-        val iso: Option[token.Span] = features.import_ref_span(s.a, s.rr, di::id.DeclId, s.target, s.file);
-        if (is_some[token.Span](iso)) { @total = @total + loc_len(s.file, s.uri, unwrap[token.Span](iso), alloc, @count); @count = @count + 1; }
-        di = di + 1;
-    }
-    var ei: usize = 0;
-    for (ei < s.a.expr_len) {
-        val so: Option[token.Span] = features.expr_ref_span(s.a, s.rr, ei::id.ExprId, s.target);
-        if (is_some[token.Span](so)) { @total = @total + loc_len(s.file, s.uri, unwrap[token.Span](so), alloc, @count); @count = @count + 1; }
-        ei = ei + 1;
-    }
-    var ti: usize = 0;
-    for (ti < s.a.type_len) {
-        val so: Option[token.Span] = features.type_ref_span(s.a, s.rr, ti::id.TypeId, s.target);
-        if (is_some[token.Span](so)) { @total = @total + loc_len(s.file, s.uri, unwrap[token.Span](so), alloc, @count); @count = @count + 1; }
-        ti = ti + 1;
-    }
-}
-
-# write_locations: append every reference to `s.target` in source `s` to `buf`,
-# advancing the running `emitted` count (sequencing the separating commas), and
-# return the new offset. mirrors size_locations.
-fun write_locations(s: *XRef, buf: *u8, off: usize, alloc: *Allocator, emitted: *usize) usize {
-    if (s.target == res.SYMBOL_NIL) { ret off; }
-    var o: usize = off;
-    var di: usize = 0;
-    for (di < s.a.decl_len) {
-        val dso: Option[token.Span] = features.decl_ref_span(s.a, s.rr, di::id.DeclId, s.target);
-        if (is_some[token.Span](dso)) { o = put_loc(buf, o, s.file, s.uri, unwrap[token.Span](dso), alloc, @emitted); @emitted = @emitted + 1; }
-        val iso: Option[token.Span] = features.import_ref_span(s.a, s.rr, di::id.DeclId, s.target, s.file);
-        if (is_some[token.Span](iso)) { o = put_loc(buf, o, s.file, s.uri, unwrap[token.Span](iso), alloc, @emitted); @emitted = @emitted + 1; }
-        di = di + 1;
-    }
-    var ei: usize = 0;
-    for (ei < s.a.expr_len) {
-        val so: Option[token.Span] = features.expr_ref_span(s.a, s.rr, ei::id.ExprId, s.target);
-        if (is_some[token.Span](so)) { o = put_loc(buf, o, s.file, s.uri, unwrap[token.Span](so), alloc, @emitted); @emitted = @emitted + 1; }
-        ei = ei + 1;
-    }
-    var ti: usize = 0;
-    for (ti < s.a.type_len) {
-        val so: Option[token.Span] = features.type_ref_span(s.a, s.rr, ti::id.TypeId, s.target);
-        if (is_some[token.Span](so)) { o = put_loc(buf, o, s.file, s.uri, unwrap[token.Span](so), alloc, @emitted); @emitted = @emitted + 1; }
-        ti = ti + 1;
-    }
-    ret o;
 }
 
 # emit_rename: send a WorkspaceEdit renaming the symbol to `new_name` across the
@@ -876,41 +945,21 @@ fun emit_rename(alloc: *Allocator, id_raw: str, refs: *XRef, nref: usize, new_na
 
 # rename_group_json: the `changes`-map entry `"<uri>":[<edits>]` for source `s`,
 # renaming the declaration, import-path leaves, and every body reference spelled
-# `name` to the already-quoted `qname`, or nil when `s` contributes no edit. the
-# active buffer's param / generic binding is included when `include_bind`.
+# `name` to the already-quoted `qname` (via the shared walk; see WalkSink), or
+# nil when `s` contributes no edit. the active buffer's param / generic binding
+# is included when `include_bind`.
 fun rename_group_json(s: *XRef, include_bind: bool, bind: token.Span, name: str, qname: str, alloc: *Allocator) str {
     if (s.target == res.SYMBOL_NIL) { ret nil; }
     val quri: str = json.quote(s.uri, alloc);
     if (quri == nil) { ret nil; }
 
-    var ebytes: usize = 0;
-    var count:  usize = 0;
-    if (include_bind) { ebytes = ebytes + edit_len(s.file, bind, qname, alloc, count); count = count + 1; }
-    var di: usize = 0;
-    for (di < s.a.decl_len) {
-        val dso: Option[token.Span] = features.decl_ref_span(s.a, s.rr, di::id.DeclId, s.target);
-        if (is_some[token.Span](dso)) { ebytes = ebytes + edit_len(s.file, unwrap[token.Span](dso), qname, alloc, count); count = count + 1; }
-        val iso: Option[token.Span] = features.import_ref_span(s.a, s.rr, di::id.DeclId, s.target, s.file);
-        if (is_some[token.Span](iso)) { ebytes = ebytes + edit_len(s.file, unwrap[token.Span](iso), qname, alloc, count); count = count + 1; }
-        di = di + 1;
-    }
-    var ei: usize = 0;
-    for (ei < s.a.expr_len) {
-        val so: Option[token.Span] = features.expr_ref_span(s.a, s.rr, ei::id.ExprId, s.target);
-        if (is_some[token.Span](so) && features.span_text_equals(s.file, unwrap[token.Span](so), name)) { ebytes = ebytes + edit_len(s.file, unwrap[token.Span](so), qname, alloc, count); count = count + 1; }
-        ei = ei + 1;
-    }
-    var ti: usize = 0;
-    for (ti < s.a.type_len) {
-        val so: Option[token.Span] = features.type_ref_span(s.a, s.rr, ti::id.TypeId, s.target);
-        if (is_some[token.Span](so) && features.span_text_equals(s.file, unwrap[token.Span](so), name)) { ebytes = ebytes + edit_len(s.file, unwrap[token.Span](so), qname, alloc, count); count = count + 1; }
-        ti = ti + 1;
-    }
-    if (count == 0) { json.free_str(quri, alloc); ret nil; }
+    var k: WalkSink = sink_init(alloc, qname, name);
+    walk_refs(s, include_bind, bind, ?k);
+    if (k.count == 0) { json.free_str(quri, alloc); ret nil; }
 
     val open:  str = ":[";
     val close: str = "]";
-    val total: usize = str_len(quri) + str_len(open) + ebytes + str_len(close);
+    val total: usize = str_len(quri) + str_len(open) + k.total + str_len(close);
     val r: Result[*u8, str] = allocate[u8](alloc, total + 1);
     if (is_err[*u8, str](r)) { json.free_str(quri, alloc); ret nil; }
     val buf: *u8 = unwrap_ok[*u8, str](r);
@@ -918,28 +967,11 @@ fun rename_group_json(s: *XRef, include_bind: bool, bind: token.Span, name: str,
     var off: usize = 0;
     off = append(buf, off, quri);
     off = append(buf, off, open);
-    var emitted: usize = 0;
-    if (include_bind) { off = put_edit(buf, off, s.file, bind, qname, alloc, emitted); emitted = emitted + 1; }
-    var d2: usize = 0;
-    for (d2 < s.a.decl_len) {
-        val dso: Option[token.Span] = features.decl_ref_span(s.a, s.rr, d2::id.DeclId, s.target);
-        if (is_some[token.Span](dso)) { off = put_edit(buf, off, s.file, unwrap[token.Span](dso), qname, alloc, emitted); emitted = emitted + 1; }
-        val iso: Option[token.Span] = features.import_ref_span(s.a, s.rr, d2::id.DeclId, s.target, s.file);
-        if (is_some[token.Span](iso)) { off = put_edit(buf, off, s.file, unwrap[token.Span](iso), qname, alloc, emitted); emitted = emitted + 1; }
-        d2 = d2 + 1;
-    }
-    var e2: usize = 0;
-    for (e2 < s.a.expr_len) {
-        val so: Option[token.Span] = features.expr_ref_span(s.a, s.rr, e2::id.ExprId, s.target);
-        if (is_some[token.Span](so) && features.span_text_equals(s.file, unwrap[token.Span](so), name)) { off = put_edit(buf, off, s.file, unwrap[token.Span](so), qname, alloc, emitted); emitted = emitted + 1; }
-        e2 = e2 + 1;
-    }
-    var t2: usize = 0;
-    for (t2 < s.a.type_len) {
-        val so: Option[token.Span] = features.type_ref_span(s.a, s.rr, t2::id.TypeId, s.target);
-        if (is_some[token.Span](so) && features.span_text_equals(s.file, unwrap[token.Span](so), name)) { off = put_edit(buf, off, s.file, unwrap[token.Span](so), qname, alloc, emitted); emitted = emitted + 1; }
-        t2 = t2 + 1;
-    }
+    k.buf   = buf;
+    k.off   = off;
+    k.count = 0;
+    walk_refs(s, include_bind, bind, ?k);
+    off = k.off;
     off = append(buf, off, close);
     buf[off] = 0;
     json.free_str(quri, alloc);

--- a/src/language.mach
+++ b/src/language.mach
@@ -9,12 +9,16 @@
 #
 # cross-module scope: the buffer is resolved with a populated dependency set, so
 # a symbol imported through a `use` binds to its declaration in a dependency Ast.
-# definition / references / hover resolve that declaration through `project`'s
-# symbol -> Ast / SourceFile / URI mapping, pointing at the defining module's
-# file on disk (`project.site_of`). rename / prepareRename stay confined to
-# symbols local to the buffer — a dependency's declaration is not the editor's to
-# rewrite. completion offers the file's module-level names, `use` aliases, and
-# the primitive types (see `features.completion_candidate`).
+# definition / hover resolve that declaration through `project`'s symbol -> Ast /
+# SourceFile / URI mapping, pointing at the defining module's file on disk
+# (`project.site_of`). references and rename walk the whole loaded project graph
+# through a shared use-site index (`build_refs` over `project.module_view`):
+# references reports every use-site across all modules; rename rewrites the
+# declaration plus every importer (body references and `use` path leaves), but
+# only for symbols declared in the user's own project — a dependency's
+# declaration is not the editor's to rewrite. completion offers the file's
+# module-level names, `use` aliases, and the primitive types (see
+# `features.completion_candidate`).
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -419,10 +423,9 @@ pub fun definition(ws: *project.Workspace, es: *editor.EditorSession, s: *sess.S
 }
 
 # references: answer textDocument/references with every Location resolving to
-# the symbol at the cursor — the use-sites in this buffer plus the declaration.
-# the declaration lands in the buffer for a local symbol and in the defining
-# dependency module's file for a cross-module one. empty when the position is
-# not on a resolved symbol.
+# the symbol at the cursor — its declaration plus every use-site across the
+# loaded project graph (the requesting buffer and every other module that
+# references the symbol). empty when the position is not on a resolved symbol.
 pub fun references(ws: *project.Workspace, es: *editor.EditorSession, s: *sess.Session, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
     val id_raw: str = json.extract_raw(body, "\"id\"", alloc);
     if (id_raw == nil) { ret; }
@@ -443,37 +446,24 @@ pub fun references(ws: *project.Workspace, es: *editor.EditorSession, s: *sess.S
     var bind: token.Span;
     val has_bind: bool = binding_span(an, sr.sym_id, ?bind);
 
-    # the in-buffer walk finds the local decl and every use-site; a cross-module
-    # symbol's declaration lives in a dependency file and is added separately.
-    var xfile: *src.SourceFile = an.file;
-    var xuri:  str = uri;
-    var xspan: token.Span = bind;
-    var has_x: bool = false;
-    var site:  project.Site;
-    var has_site: bool = false;
-    if (sym.origin != an.own) {
-        val site_o: Option[project.Site] = project.site_of(ws, an.own, an.a, an.file, uri, sym);
-        if (is_some[project.Site](site_o)) {
-            site = unwrap[project.Site](site_o);
-            has_site = true;
-            val spo: Option[token.Span] = features.definition_name_span(site.a, sym);
-            if (is_some[token.Span](spo)) {
-                xfile = site.file;
-                xuri  = site.uri;
-                xspan = unwrap[token.Span](spo);
-                has_x = true;
-            }
-        }
-    }
+    val cap: usize = (project.module_count(ws) + 1)::usize;
+    val ra: Result[*XRef, str] = allocate[XRef](alloc, cap);
+    if (is_err[*XRef, str](ra)) { reply_empty_array(alloc, id_raw); ret; }
+    val refs: *XRef = unwrap_ok[*XRef, str](ra);
 
-    emit_locations(an, alloc, id_raw, uri, sr.sym_id, bind, has_bind, xfile, xuri, xspan, has_x);
-    if (has_site) { project.free_site(ws, ?site); }
-    json.free_str(id_raw, alloc);
+    val n: usize = build_refs(ws, an, uri, sym, sr.sym_id, false, refs, cap);
+    emit_locations(alloc, id_raw, refs, n, bind, has_bind);
+    free_refs(ws, refs, n);
+    deallocate[XRef](alloc, refs, cap);
 }
 
 # rename: answer textDocument/rename with a WorkspaceEdit replacing every
-# reference to the symbol at the cursor with the requested new name, across
-# this file. empty edit for a non-local symbol.
+# reference to the symbol at the cursor with the requested new name, across the
+# whole project graph — the declaring file plus every module that imports or
+# uses it (including each importer's `use` path leaf). confined to symbols
+# declared in the user's own project: a dependency's declaration is not the
+# editor's to rewrite, so renaming a cross-module dependency symbol yields an
+# empty edit.
 pub fun rename(ws: *project.Workspace, es: *editor.EditorSession, s: *sess.Session, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
     val id_raw: str = json.extract_raw(body, "\"id\"", alloc);
     if (id_raw == nil) { ret; }
@@ -489,17 +479,36 @@ pub fun rename(ws: *project.Workspace, es: *editor.EditorSession, s: *sess.Sessi
     val ro: Option[features.SymbolRef] = features.ref_at(an.a, an.rr, an.own, offset);
     if (!is_some[features.SymbolRef](ro)) { reply_empty_edit(alloc, id_raw); json.free_str(new_name, alloc); ret; }
     val sr: features.SymbolRef = unwrap[features.SymbolRef](ro);
-    if (!sr.local) { reply_empty_edit(alloc, id_raw); json.free_str(new_name, alloc); ret; }
+
+    val so: Option[*res.Symbol] = features.symbol(an.rr, sr.sym_id);
+    if (!is_some[*res.Symbol](so)) { reply_empty_edit(alloc, id_raw); json.free_str(new_name, alloc); ret; }
+    val sym: *res.Symbol = unwrap[*res.Symbol](so);
+    if (!renameable(ws, sym, sr)) { reply_empty_edit(alloc, id_raw); json.free_str(new_name, alloc); ret; }
+
+    # the declared name guards the cross-file walk: only occurrences spelled with
+    # it are rewritten, so an aliased import's references are left untouched.
+    val no: Option[str] = intern.lookup(?s.interner, sym.name);
+    if (!is_some[str](no)) { reply_empty_edit(alloc, id_raw); json.free_str(new_name, alloc); ret; }
+    val name: str = unwrap[str](no);
 
     var bind: token.Span;
     val has_bind: bool = binding_span(an, sr.sym_id, ?bind);
-    emit_rename(an, alloc, id_raw, uri, sr.sym_id, new_name, bind, has_bind);
+
+    val cap: usize = (project.module_count(ws) + 1)::usize;
+    val ra: Result[*XRef, str] = allocate[XRef](alloc, cap);
+    if (is_err[*XRef, str](ra)) { reply_empty_edit(alloc, id_raw); json.free_str(new_name, alloc); ret; }
+    val refs: *XRef = unwrap_ok[*XRef, str](ra);
+
+    val n: usize = build_refs(ws, an, uri, sym, sr.sym_id, true, refs, cap);
+    emit_rename(alloc, id_raw, refs, n, new_name, name, bind, has_bind);
+    free_refs(ws, refs, n);
+    deallocate[XRef](alloc, refs, cap);
     json.free_str(new_name, alloc);
-    json.free_str(id_raw, alloc);
 }
 
 # prepare_rename: answer textDocument/prepareRename with the range of the name
-# token at the cursor when it is a renameable local symbol, or null.
+# token at the cursor when it is a renameable symbol (a buffer-local symbol, or a
+# project-owned cross-module one), or null when it is not the editor's to rename.
 pub fun prepare_rename(ws: *project.Workspace, es: *editor.EditorSession, s: *sess.Session, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
     val id_raw: str = json.extract_raw(body, "\"id\"", alloc);
     if (id_raw == nil) { ret; }
@@ -512,7 +521,10 @@ pub fun prepare_rename(ws: *project.Workspace, es: *editor.EditorSession, s: *se
     val ro: Option[features.SymbolRef] = features.ref_at(an.a, an.rr, an.own, offset);
     if (!is_some[features.SymbolRef](ro)) { reply_null(alloc, id_raw); ret; }
     val sr: features.SymbolRef = unwrap[features.SymbolRef](ro);
-    if (!sr.local) { reply_null(alloc, id_raw); ret; }
+
+    val so: Option[*res.Symbol] = features.symbol(an.rr, sr.sym_id);
+    if (!is_some[*res.Symbol](so)) { reply_null(alloc, id_raw); ret; }
+    if (!renameable(ws, unwrap[*res.Symbol](so), sr)) { reply_null(alloc, id_raw); ret; }
 
     val range: positions.LspRange = positions.range_of(an.file, sr.name_span);
     val rng: str = range_json(range, alloc);
@@ -568,6 +580,109 @@ fun binding_span(an: Analyzed, sid: res.SymbolId, out: *token.Span) bool {
     ret true;
 }
 
+# renameable: whether the symbol at the cursor may be renamed — a buffer-local
+# symbol always, a cross-module symbol only when declared in a project-owned
+# module (a dependency's declaration is not the editor's to rewrite). primitives
+# and unresolved positions are excluded upstream (sr.local is false for them).
+fun renameable(ws: *project.Workspace, sym: *res.Symbol, sr: features.SymbolRef) bool {
+    if (sr.local) { ret true; }
+    ret project.is_project_module(ws, sym.origin);
+}
+
+# XRef: one file contributing references to a target symbol — its Ast, resolve
+# tables, source file, document URI, and the local SymbolId every reference in
+# it resolves to. the active buffer is the first XRef (live resolve, borrowed
+# URI); each other loaded module that references the symbol is another (graph
+# snapshot, an owned `file://` URI freed by free_refs). see build_refs.
+rec XRef {
+    a:         *ast.Ast;
+    rr:        *res.ResolveResult;
+    file:      *src.SourceFile;
+    uri:       str;
+    owned_uri: bool;
+    target:    res.SymbolId;
+}
+
+# build_refs: populate `out` with the files that reference the symbol at the
+# cursor and return the count. `out[0]` is always the active buffer (resolved
+# live, matched by its own SymbolId). each subsequent entry is a loaded module
+# whose resolve result contains the symbol's canonical (origin, decl) identity,
+# skipping the buffer's on-disk twin so its live edits are not double-counted.
+# `project_only` restricts the walk to project-owned modules (rename); references
+# passes false to include dependency modules. the symbol's canonical identity is
+# read directly for a cross-module reference, or recovered from the buffer's
+# on-disk module for a buffer-local pub declaration; a buffer-local non-pub
+# symbol has no cross-file use-sites, so only the active buffer is returned.
+# ---
+# ws:          the workspace
+# an:          the active buffer's analysis
+# uri:         the active buffer's document URI
+# sym:         the resolved symbol at the cursor
+# self_target: the symbol's SymbolId in the active buffer's resolve result
+# project_only:restrict the graph walk to project-owned modules
+# out:         array of at least `cap` XRef slots
+# cap:         capacity of `out` (module_count + 1)
+# ret:         number of populated entries (>= 1)
+fun build_refs(ws: *project.Workspace, an: Analyzed, uri: str, sym: *res.Symbol, self_target: res.SymbolId, project_only: bool, out: *XRef, cap: usize) usize {
+    out[0].a         = an.a;
+    out[0].rr        = an.rr;
+    out[0].file      = an.file;
+    out[0].uri       = uri;
+    out[0].owned_uri = false;
+    out[0].target    = self_target;
+    var n: usize = 1;
+
+    val self_o: Option[sess.ModuleId] = project.module_for_uri(ws, uri);
+    val have_self: bool = is_some[sess.ModuleId](self_o);
+    var self_mid: sess.ModuleId = 0::sess.ModuleId;
+    if (have_self) { self_mid = unwrap[sess.ModuleId](self_o); }
+
+    var canon_origin: sess.ModuleId = sym.origin;
+    var canon_decl:   id.DeclId     = sym.decl;
+    if (sym.origin == an.own) {
+        if (!have_self) { ret n; }
+        val mv_o: Option[project.ModuleView] = project.module_view(ws, self_mid);
+        if (!is_some[project.ModuleView](mv_o)) { ret n; }
+        canon_decl   = features.export_decl_of(unwrap[project.ModuleView](mv_o).rr, sym.name, sym.kind);
+        canon_origin = self_mid;
+    }
+    if (canon_decl == id.DECL_NIL) { ret n; }
+
+    val mc: u32 = project.module_count(ws);
+    var mid: u32 = 0;
+    for (mid < mc && n < cap) {
+        val cur: sess.ModuleId = mid::sess.ModuleId;
+        if ((have_self && cur == self_mid)
+            || (project_only && !project.is_project_module(ws, cur))) { mid = mid + 1; cnt; }
+        val mv_o: Option[project.ModuleView] = project.module_view(ws, cur);
+        if (!is_some[project.ModuleView](mv_o)) { mid = mid + 1; cnt; }
+        val mv: project.ModuleView = unwrap[project.ModuleView](mv_o);
+        val tgt: res.SymbolId = features.symbol_by_decl(mv.rr, canon_origin, canon_decl);
+        if (tgt == res.SYMBOL_NIL) { mid = mid + 1; cnt; }
+        val muri: str = project.module_uri(ws, cur);
+        if (muri == nil) { mid = mid + 1; cnt; }
+        out[n].a         = mv.a;
+        out[n].rr        = mv.rr;
+        out[n].file      = mv.file;
+        out[n].uri       = muri;
+        out[n].owned_uri = true;
+        out[n].target    = tgt;
+        n = n + 1;
+        mid = mid + 1;
+    }
+    ret n;
+}
+
+# free_refs: release the owned `file://` URIs of the graph-module entries in a
+# built XRef array. the active buffer's borrowed URI is left untouched.
+fun free_refs(ws: *project.Workspace, refs: *XRef, n: usize) {
+    var i: usize = 0;
+    for (i < n) {
+        if (refs[i].owned_uri && refs[i].uri != nil) { json.free_str(refs[i].uri, ws.alloc); }
+        i = i + 1;
+    }
+}
+
 # analyze: resolve the document named by `uri` against the project dependency
 # graph and populate `out` with its session, file, Ast, ResolveResult, and
 # module id. false when the document is unknown or resolution fails. the module
@@ -605,41 +720,21 @@ fun locate(ws: *project.Workspace, es: *editor.EditorSession, s: *sess.Session, 
     ret positions.offset_at(out.file, line::usize, ch::usize);
 }
 
-# emit_locations: send a Location[] result of every reference to `target`. the
-# in-buffer use-sites and the local decl name span come from the resolve walk
-# over `an`; a param / generic binding site, which has no Decl node, is passed
-# in `bind` when `has_bind`; a cross-module declaration, which lives in another
-# file, is passed in (`xfile`, `xuri`, `xspan`) when `has_x`.
-fun emit_locations(an: Analyzed, alloc: *Allocator, id_raw: str, uri: str, target: res.SymbolId, bind: token.Span, has_bind: bool, xfile: *src.SourceFile, xuri: str, xspan: token.Span, has_x: bool) {
+# emit_locations: send a Location[] of every reference to the symbol across the
+# files in `refs`. each XRef contributes its declaration, import-path leaves, and
+# every body use-site of its local target; the active buffer's param / generic
+# binding (which has no Decl node) is `refs[0]`'s and is passed in `bind` when
+# `has_bind`. takes ownership of `id_raw` and frees it.
+fun emit_locations(alloc: *Allocator, id_raw: str, refs: *XRef, nref: usize, bind: token.Span, has_bind: bool) {
     val prefix: str = "{\"jsonrpc\":\"2.0\",\"id\":";
     val mid:    str = ",\"result\":[";
     val suffix: str = "]}";
 
     var total: usize = str_len(prefix) + str_len(id_raw) + str_len(mid) + str_len(suffix);
     var count: usize = 0;
-
-    if (has_x)    { total = total + loc_len(xfile, xuri, xspan, alloc, count); count = count + 1; }
-    if (has_bind) { total = total + loc_len(an.file, uri, bind, alloc, count); count = count + 1; }
-
-    # first pass: size
-    var ei: usize = 0;
-    for (ei < an.a.expr_len) {
-        val so: Option[token.Span] = features.expr_ref_span(an.a, an.rr, ei::id.ExprId, target);
-        if (is_some[token.Span](so)) { total = total + loc_len(an.file, uri, unwrap[token.Span](so), alloc, count); count = count + 1; }
-        ei = ei + 1;
-    }
-    var ti: usize = 0;
-    for (ti < an.a.type_len) {
-        val so: Option[token.Span] = features.type_ref_span(an.a, an.rr, ti::id.TypeId, target);
-        if (is_some[token.Span](so)) { total = total + loc_len(an.file, uri, unwrap[token.Span](so), alloc, count); count = count + 1; }
-        ti = ti + 1;
-    }
-    var di: usize = 0;
-    for (di < an.a.decl_len) {
-        val so: Option[token.Span] = features.decl_ref_span(an.a, an.rr, di::id.DeclId, target);
-        if (is_some[token.Span](so)) { total = total + loc_len(an.file, uri, unwrap[token.Span](so), alloc, count); count = count + 1; }
-        di = di + 1;
-    }
+    if (nref > 0 && has_bind) { total = total + loc_len(refs[0].file, refs[0].uri, bind, alloc, count); count = count + 1; }
+    var si: usize = 0;
+    for (si < nref) { size_locations(?refs[si], alloc, ?total, ?count); si = si + 1; }
 
     val br: Result[*u8, str] = allocate[u8](alloc, total + 1);
     if (is_err[*u8, str](br)) { reply_empty_array(alloc, id_raw); ret; }
@@ -651,76 +746,109 @@ fun emit_locations(an: Analyzed, alloc: *Allocator, id_raw: str, uri: str, targe
     off = append(buf, off, mid);
 
     var emitted: usize = 0;
-    if (has_x)    { off = put_loc(buf, off, xfile, xuri, xspan, alloc, emitted); emitted = emitted + 1; }
-    if (has_bind) { off = put_loc(buf, off, an.file, uri, bind, alloc, emitted); emitted = emitted + 1; }
-    var e2: usize = 0;
-    for (e2 < an.a.expr_len) {
-        val so: Option[token.Span] = features.expr_ref_span(an.a, an.rr, e2::id.ExprId, target);
-        if (is_some[token.Span](so)) { off = put_loc(buf, off, an.file, uri, unwrap[token.Span](so), alloc, emitted); emitted = emitted + 1; }
-        e2 = e2 + 1;
-    }
-    var t2: usize = 0;
-    for (t2 < an.a.type_len) {
-        val so: Option[token.Span] = features.type_ref_span(an.a, an.rr, t2::id.TypeId, target);
-        if (is_some[token.Span](so)) { off = put_loc(buf, off, an.file, uri, unwrap[token.Span](so), alloc, emitted); emitted = emitted + 1; }
-        t2 = t2 + 1;
-    }
-    var d2: usize = 0;
-    for (d2 < an.a.decl_len) {
-        val so: Option[token.Span] = features.decl_ref_span(an.a, an.rr, d2::id.DeclId, target);
-        if (is_some[token.Span](so)) { off = put_loc(buf, off, an.file, uri, unwrap[token.Span](so), alloc, emitted); emitted = emitted + 1; }
-        d2 = d2 + 1;
-    }
+    if (nref > 0 && has_bind) { off = put_loc(buf, off, refs[0].file, refs[0].uri, bind, alloc, emitted); emitted = emitted + 1; }
+    var sj: usize = 0;
+    for (sj < nref) { off = write_locations(?refs[sj], buf, off, alloc, ?emitted); sj = sj + 1; }
 
     off = append(buf, off, suffix);
     buf[off] = 0;
     transport.send_message(buf::str, alloc);
     deallocate[u8](alloc, buf, total + 1);
+    json.free_str(id_raw, alloc);
 }
 
-# emit_rename: send a WorkspaceEdit with one TextEdit per in-file reference to
-# `target`, each replacing the reference's range with `new_name`. a param /
-# generic binding site is passed in `bind` when `has_bind`.
-fun emit_rename(an: Analyzed, alloc: *Allocator, id_raw: str, uri: str, target: res.SymbolId, new_name: str, bind: token.Span, has_bind: bool) {
-    val quri: str = json.quote(uri, alloc);
-    val qname: str = json.quote(new_name, alloc);
-    if (quri == nil || qname == nil) {
-        json.free_str(quri, alloc); json.free_str(qname, alloc);
-        reply_empty_edit(alloc, id_raw); ret;
+# size_locations: add the JSON length of every reference to `s.target` in source
+# `s` to `total`, advancing the running `count` (which sequences the separating
+# commas across the whole Location array).
+fun size_locations(s: *XRef, alloc: *Allocator, total: *usize, count: *usize) {
+    if (s.target == res.SYMBOL_NIL) { ret; }
+    var di: usize = 0;
+    for (di < s.a.decl_len) {
+        val dso: Option[token.Span] = features.decl_ref_span(s.a, s.rr, di::id.DeclId, s.target);
+        if (is_some[token.Span](dso)) { @total = @total + loc_len(s.file, s.uri, unwrap[token.Span](dso), alloc, @count); @count = @count + 1; }
+        val iso: Option[token.Span] = features.import_ref_span(s.a, s.rr, di::id.DeclId, s.target, s.file);
+        if (is_some[token.Span](iso)) { @total = @total + loc_len(s.file, s.uri, unwrap[token.Span](iso), alloc, @count); @count = @count + 1; }
+        di = di + 1;
     }
+    var ei: usize = 0;
+    for (ei < s.a.expr_len) {
+        val so: Option[token.Span] = features.expr_ref_span(s.a, s.rr, ei::id.ExprId, s.target);
+        if (is_some[token.Span](so)) { @total = @total + loc_len(s.file, s.uri, unwrap[token.Span](so), alloc, @count); @count = @count + 1; }
+        ei = ei + 1;
+    }
+    var ti: usize = 0;
+    for (ti < s.a.type_len) {
+        val so: Option[token.Span] = features.type_ref_span(s.a, s.rr, ti::id.TypeId, s.target);
+        if (is_some[token.Span](so)) { @total = @total + loc_len(s.file, s.uri, unwrap[token.Span](so), alloc, @count); @count = @count + 1; }
+        ti = ti + 1;
+    }
+}
+
+# write_locations: append every reference to `s.target` in source `s` to `buf`,
+# advancing the running `emitted` count (sequencing the separating commas), and
+# return the new offset. mirrors size_locations.
+fun write_locations(s: *XRef, buf: *u8, off: usize, alloc: *Allocator, emitted: *usize) usize {
+    if (s.target == res.SYMBOL_NIL) { ret off; }
+    var o: usize = off;
+    var di: usize = 0;
+    for (di < s.a.decl_len) {
+        val dso: Option[token.Span] = features.decl_ref_span(s.a, s.rr, di::id.DeclId, s.target);
+        if (is_some[token.Span](dso)) { o = put_loc(buf, o, s.file, s.uri, unwrap[token.Span](dso), alloc, @emitted); @emitted = @emitted + 1; }
+        val iso: Option[token.Span] = features.import_ref_span(s.a, s.rr, di::id.DeclId, s.target, s.file);
+        if (is_some[token.Span](iso)) { o = put_loc(buf, o, s.file, s.uri, unwrap[token.Span](iso), alloc, @emitted); @emitted = @emitted + 1; }
+        di = di + 1;
+    }
+    var ei: usize = 0;
+    for (ei < s.a.expr_len) {
+        val so: Option[token.Span] = features.expr_ref_span(s.a, s.rr, ei::id.ExprId, s.target);
+        if (is_some[token.Span](so)) { o = put_loc(buf, o, s.file, s.uri, unwrap[token.Span](so), alloc, @emitted); @emitted = @emitted + 1; }
+        ei = ei + 1;
+    }
+    var ti: usize = 0;
+    for (ti < s.a.type_len) {
+        val so: Option[token.Span] = features.type_ref_span(s.a, s.rr, ti::id.TypeId, s.target);
+        if (is_some[token.Span](so)) { o = put_loc(buf, o, s.file, s.uri, unwrap[token.Span](so), alloc, @emitted); @emitted = @emitted + 1; }
+        ti = ti + 1;
+    }
+    ret o;
+}
+
+# emit_rename: send a WorkspaceEdit renaming the symbol to `new_name` across the
+# files in `refs`, one `changes` entry per file. each entry renames the
+# declaration, the import-path leaves, and every body reference spelled with the
+# declared name `name` (so an aliased import's references are not rewritten); the
+# active buffer's param / generic binding is included when `has_bind`. takes
+# ownership of `id_raw` and frees it.
+fun emit_rename(alloc: *Allocator, id_raw: str, refs: *XRef, nref: usize, new_name: str, name: str, bind: token.Span, has_bind: bool) {
+    val qname: str = json.quote(new_name, alloc);
+    if (qname == nil) { reply_empty_edit(alloc, id_raw); ret; }
+
+    val ga: Result[*str, str] = allocate[str](alloc, nref);
+    if (is_err[*str, str](ga)) { json.free_str(qname, alloc); reply_empty_edit(alloc, id_raw); ret; }
+    val groups: *str = unwrap_ok[*str, str](ga);
 
     val prefix: str = "{\"jsonrpc\":\"2.0\",\"id\":";
-    val mid1:   str = ",\"result\":{\"changes\":{";
-    val mid2:   str = ":[";
-    val suffix: str = "]}}}";
-
-    var total: usize = str_len(prefix) + str_len(id_raw) + str_len(mid1) + str_len(quri) + str_len(mid2) + str_len(suffix);
-    var count: usize = 0;
-
-    if (has_bind) { total = total + edit_len(an.file, bind, qname, alloc, count); count = count + 1; }
-
-    var e1: usize = 0;
-    for (e1 < an.a.expr_len) {
-        val so: Option[token.Span] = features.expr_ref_span(an.a, an.rr, e1::id.ExprId, target);
-        if (is_some[token.Span](so)) { total = total + edit_len(an.file, unwrap[token.Span](so), qname, alloc, count); count = count + 1; }
-        e1 = e1 + 1;
-    }
-    var ty1: usize = 0;
-    for (ty1 < an.a.type_len) {
-        val so: Option[token.Span] = features.type_ref_span(an.a, an.rr, ty1::id.TypeId, target);
-        if (is_some[token.Span](so)) { total = total + edit_len(an.file, unwrap[token.Span](so), qname, alloc, count); count = count + 1; }
-        ty1 = ty1 + 1;
-    }
-    var d1: usize = 0;
-    for (d1 < an.a.decl_len) {
-        val so: Option[token.Span] = features.decl_ref_span(an.a, an.rr, d1::id.DeclId, target);
-        if (is_some[token.Span](so)) { total = total + edit_len(an.file, unwrap[token.Span](so), qname, alloc, count); count = count + 1; }
-        d1 = d1 + 1;
+    val mid:    str = ",\"result\":{\"changes\":{";
+    val suffix: str = "}}}";
+    var total: usize = str_len(prefix) + str_len(id_raw) + str_len(mid) + str_len(suffix);
+    var ng: usize = 0;
+    var si: usize = 0;
+    for (si < nref) {
+        val g: str = rename_group_json(?refs[si], si == 0 && has_bind, bind, name, qname, alloc);
+        if (g != nil) {
+            if (ng > 0) { total = total + 1; }
+            total = total + str_len(g);
+            groups[ng] = g;
+            ng = ng + 1;
+        }
+        si = si + 1;
     }
 
     val br: Result[*u8, str] = allocate[u8](alloc, total + 1);
     if (is_err[*u8, str](br)) {
-        json.free_str(quri, alloc); json.free_str(qname, alloc);
+        free_groups(groups, ng, alloc);
+        deallocate[str](alloc, groups, nref);
+        json.free_str(qname, alloc);
         reply_empty_edit(alloc, id_raw); ret;
     }
     val buf: *u8 = unwrap_ok[*u8, str](br);
@@ -728,37 +856,100 @@ fun emit_rename(an: Analyzed, alloc: *Allocator, id_raw: str, uri: str, target: 
     var off: usize = 0;
     off = append(buf, off, prefix);
     off = append(buf, off, id_raw);
-    off = append(buf, off, mid1);
-    off = append(buf, off, quri);
-    off = append(buf, off, mid2);
-
-    var emitted: usize = 0;
-    if (has_bind) { off = put_edit(buf, off, an.file, bind, qname, alloc, emitted); emitted = emitted + 1; }
-    var e2: usize = 0;
-    for (e2 < an.a.expr_len) {
-        val so: Option[token.Span] = features.expr_ref_span(an.a, an.rr, e2::id.ExprId, target);
-        if (is_some[token.Span](so)) { off = put_edit(buf, off, an.file, unwrap[token.Span](so), qname, alloc, emitted); emitted = emitted + 1; }
-        e2 = e2 + 1;
+    off = append(buf, off, mid);
+    var gi: usize = 0;
+    for (gi < ng) {
+        if (gi > 0) { buf[off] = ','; off = off + 1; }
+        off = append(buf, off, groups[gi]);
+        gi = gi + 1;
     }
-    var t2: usize = 0;
-    for (t2 < an.a.type_len) {
-        val so: Option[token.Span] = features.type_ref_span(an.a, an.rr, t2::id.TypeId, target);
-        if (is_some[token.Span](so)) { off = put_edit(buf, off, an.file, unwrap[token.Span](so), qname, alloc, emitted); emitted = emitted + 1; }
-        t2 = t2 + 1;
-    }
-    var d2: usize = 0;
-    for (d2 < an.a.decl_len) {
-        val so: Option[token.Span] = features.decl_ref_span(an.a, an.rr, d2::id.DeclId, target);
-        if (is_some[token.Span](so)) { off = put_edit(buf, off, an.file, unwrap[token.Span](so), qname, alloc, emitted); emitted = emitted + 1; }
-        d2 = d2 + 1;
-    }
-
     off = append(buf, off, suffix);
     buf[off] = 0;
     transport.send_message(buf::str, alloc);
     deallocate[u8](alloc, buf, total + 1);
-    json.free_str(quri, alloc);
+
+    free_groups(groups, ng, alloc);
+    deallocate[str](alloc, groups, nref);
     json.free_str(qname, alloc);
+    json.free_str(id_raw, alloc);
+}
+
+# rename_group_json: the `changes`-map entry `"<uri>":[<edits>]` for source `s`,
+# renaming the declaration, import-path leaves, and every body reference spelled
+# `name` to the already-quoted `qname`, or nil when `s` contributes no edit. the
+# active buffer's param / generic binding is included when `include_bind`.
+fun rename_group_json(s: *XRef, include_bind: bool, bind: token.Span, name: str, qname: str, alloc: *Allocator) str {
+    if (s.target == res.SYMBOL_NIL) { ret nil; }
+    val quri: str = json.quote(s.uri, alloc);
+    if (quri == nil) { ret nil; }
+
+    var ebytes: usize = 0;
+    var count:  usize = 0;
+    if (include_bind) { ebytes = ebytes + edit_len(s.file, bind, qname, alloc, count); count = count + 1; }
+    var di: usize = 0;
+    for (di < s.a.decl_len) {
+        val dso: Option[token.Span] = features.decl_ref_span(s.a, s.rr, di::id.DeclId, s.target);
+        if (is_some[token.Span](dso)) { ebytes = ebytes + edit_len(s.file, unwrap[token.Span](dso), qname, alloc, count); count = count + 1; }
+        val iso: Option[token.Span] = features.import_ref_span(s.a, s.rr, di::id.DeclId, s.target, s.file);
+        if (is_some[token.Span](iso)) { ebytes = ebytes + edit_len(s.file, unwrap[token.Span](iso), qname, alloc, count); count = count + 1; }
+        di = di + 1;
+    }
+    var ei: usize = 0;
+    for (ei < s.a.expr_len) {
+        val so: Option[token.Span] = features.expr_ref_span(s.a, s.rr, ei::id.ExprId, s.target);
+        if (is_some[token.Span](so) && features.span_text_equals(s.file, unwrap[token.Span](so), name)) { ebytes = ebytes + edit_len(s.file, unwrap[token.Span](so), qname, alloc, count); count = count + 1; }
+        ei = ei + 1;
+    }
+    var ti: usize = 0;
+    for (ti < s.a.type_len) {
+        val so: Option[token.Span] = features.type_ref_span(s.a, s.rr, ti::id.TypeId, s.target);
+        if (is_some[token.Span](so) && features.span_text_equals(s.file, unwrap[token.Span](so), name)) { ebytes = ebytes + edit_len(s.file, unwrap[token.Span](so), qname, alloc, count); count = count + 1; }
+        ti = ti + 1;
+    }
+    if (count == 0) { json.free_str(quri, alloc); ret nil; }
+
+    val open:  str = ":[";
+    val close: str = "]";
+    val total: usize = str_len(quri) + str_len(open) + ebytes + str_len(close);
+    val r: Result[*u8, str] = allocate[u8](alloc, total + 1);
+    if (is_err[*u8, str](r)) { json.free_str(quri, alloc); ret nil; }
+    val buf: *u8 = unwrap_ok[*u8, str](r);
+
+    var off: usize = 0;
+    off = append(buf, off, quri);
+    off = append(buf, off, open);
+    var emitted: usize = 0;
+    if (include_bind) { off = put_edit(buf, off, s.file, bind, qname, alloc, emitted); emitted = emitted + 1; }
+    var d2: usize = 0;
+    for (d2 < s.a.decl_len) {
+        val dso: Option[token.Span] = features.decl_ref_span(s.a, s.rr, d2::id.DeclId, s.target);
+        if (is_some[token.Span](dso)) { off = put_edit(buf, off, s.file, unwrap[token.Span](dso), qname, alloc, emitted); emitted = emitted + 1; }
+        val iso: Option[token.Span] = features.import_ref_span(s.a, s.rr, d2::id.DeclId, s.target, s.file);
+        if (is_some[token.Span](iso)) { off = put_edit(buf, off, s.file, unwrap[token.Span](iso), qname, alloc, emitted); emitted = emitted + 1; }
+        d2 = d2 + 1;
+    }
+    var e2: usize = 0;
+    for (e2 < s.a.expr_len) {
+        val so: Option[token.Span] = features.expr_ref_span(s.a, s.rr, e2::id.ExprId, s.target);
+        if (is_some[token.Span](so) && features.span_text_equals(s.file, unwrap[token.Span](so), name)) { off = put_edit(buf, off, s.file, unwrap[token.Span](so), qname, alloc, emitted); emitted = emitted + 1; }
+        e2 = e2 + 1;
+    }
+    var t2: usize = 0;
+    for (t2 < s.a.type_len) {
+        val so: Option[token.Span] = features.type_ref_span(s.a, s.rr, t2::id.TypeId, s.target);
+        if (is_some[token.Span](so) && features.span_text_equals(s.file, unwrap[token.Span](so), name)) { off = put_edit(buf, off, s.file, unwrap[token.Span](so), qname, alloc, emitted); emitted = emitted + 1; }
+        t2 = t2 + 1;
+    }
+    off = append(buf, off, close);
+    buf[off] = 0;
+    json.free_str(quri, alloc);
+    ret buf::str;
+}
+
+# free_groups: free the first `n` owned changes-map entry strings in `groups`.
+fun free_groups(groups: *str, n: usize, alloc: *Allocator) {
+    var i: usize = 0;
+    for (i < n) { json.free_str(groups[i], alloc); i = i + 1; }
 }
 
 # emit_document_symbols: send a DocumentSymbol[] of the file's top-level decls.

--- a/src/project.mach
+++ b/src/project.mach
@@ -295,6 +295,122 @@ pub fun free_site(w: *Workspace, site: *Site) {
     site.owned = false;
 }
 
+# ModuleView: a borrowed view of one loaded module for the workspace-wide
+# use-site walk — its parsed Ast, resolve side tables, and backing source file.
+# ---
+# a:    the module's parsed Ast (decl / expr / type ids index into it)
+# rr:   the module's ResolveResult side tables
+# file: the SourceFile backing `a` (byte offset <-> position, span text)
+pub rec ModuleView {
+    a:    *ast.Ast;
+    rr:   *res.ResolveResult;
+    file: *src.SourceFile;
+}
+
+# module_count: the number of loaded project modules, or 0 when no project is
+# loaded. the workspace-wide references / rename walk iterates [0, count).
+# ---
+# w:   the workspace
+# ret: the loaded module count
+pub fun module_count(w: *Workspace) u32 {
+    if (!w.has_project) { ret 0; }
+    ret w.p.module_len;
+}
+
+# module_view: a borrowed view of loaded module `mid` for the use-site walk, or
+# none when the id is out of range, the module did not resolve, or its source is
+# missing. the returned pointers are owned by the loaded project / session.
+# ---
+# w:   the workspace
+# mid: a loaded module id in [0, module_count)
+# ret: some(ModuleView), or none
+pub fun module_view(w: *Workspace, mid: sess.ModuleId) Option[ModuleView] {
+    if (!w.has_project || mid::u32 >= w.p.module_len) { ret none[ModuleView](); }
+    val m: *driver.ModuleEntry = ?w.p.modules[mid::u32];
+    if (!m.resolved) { ret none[ModuleView](); }
+    val fo: Option[*src.SourceFile] = src.get(?w.s.sources, m.file_id);
+    if (!is_some[*src.SourceFile](fo)) { ret none[ModuleView](); }
+    var v: ModuleView;
+    v.a    = ?m.a;
+    v.rr   = ?m.resolve_result;
+    v.file = unwrap[*src.SourceFile](fo);
+    ret some[ModuleView](v);
+}
+
+# module_uri: a freshly built, normalized `file://` URI for loaded module `mid`'s
+# source file, owned by the caller, or nil when the id is out of range / on
+# allocation failure.
+# ---
+# w:   the workspace
+# mid: a loaded module id
+# ret: an owned URI, or nil
+pub fun module_uri(w: *Workspace, mid: sess.ModuleId) str {
+    if (!w.has_project || mid::u32 >= w.p.module_len) { ret nil; }
+    val m: *driver.ModuleEntry = ?w.p.modules[mid::u32];
+    val fo: Option[*src.SourceFile] = src.get(?w.s.sources, m.file_id);
+    if (!is_some[*src.SourceFile](fo)) { ret nil; }
+    ret file_uri(w.alloc, unwrap[*src.SourceFile](fo).path);
+}
+
+# module_for_uri: the loaded module whose source file is the document at `uri`
+# (matched on the normalized filesystem path), or none. lets the workspace walk
+# skip the active buffer's on-disk twin, whose live edits the buffer's own
+# resolve already covers, so its references are not counted twice.
+# ---
+# w:   the workspace
+# uri: a document URI
+# ret: some(ModuleId), or none
+pub fun module_for_uri(w: *Workspace, uri: str) Option[sess.ModuleId] {
+    if (!w.has_project || uri == nil) { ret none[sess.ModuleId](); }
+    val path: str = uri_to_path(w.alloc, uri);
+    if (path == nil) { ret none[sess.ModuleId](); }
+    val norm: str = normalize_path(w.alloc, path);
+    strutil.str_free(w.alloc, path);
+    if (norm == nil) { ret none[sess.ModuleId](); }
+
+    var found:  bool = false;
+    var result: sess.ModuleId = 0::sess.ModuleId;
+    var i: u32 = 0;
+    for (i < w.p.module_len && !found) {
+        val m: *driver.ModuleEntry = ?w.p.modules[i];
+        val fo: Option[*src.SourceFile] = src.get(?w.s.sources, m.file_id);
+        if (is_some[*src.SourceFile](fo)) {
+            val mnorm: str = normalize_path(w.alloc, unwrap[*src.SourceFile](fo).path);
+            if (mnorm != nil) {
+                if (str_equals(mnorm, norm)) { found = true; result = i::sess.ModuleId; }
+                strutil.str_free(w.alloc, mnorm);
+            }
+        }
+        i = i + 1;
+    }
+    strutil.str_free(w.alloc, norm);
+    if (!found) { ret none[sess.ModuleId](); }
+    ret some[sess.ModuleId](result);
+}
+
+# is_project_module: whether loaded module `mid` belongs to the user's own
+# project rather than a vendored dependency — true iff its fully-qualified path's
+# head segment is the project id. rename gates cross-file edits on it so a
+# dependency's declaration (e.g. a std symbol) is never rewritten.
+# ---
+# w:   the workspace
+# mid: a loaded module id
+# ret: true for a project-owned module
+pub fun is_project_module(w: *Workspace, mid: sess.ModuleId) bool {
+    if (!w.has_project || mid::u32 >= w.p.module_len) { ret false; }
+    val m: *driver.ModuleEntry = ?w.p.modules[mid::u32];
+    val id_opt:  Option[str] = intern.lookup(?w.s.interner, w.p.config.id);
+    val fqn_opt: Option[str] = intern.lookup(?w.s.interner, m.fqn);
+    if (!is_some[str](id_opt) || !is_some[str](fqn_opt)) { ret false; }
+    val pid: str = unwrap[str](id_opt);
+    val fqn: str = unwrap[str](fqn_opt);
+    val plen: usize = str_len(pid);
+    val flen: usize = str_len(fqn);
+    if (flen < plen || !str_starts_with(fqn, pid)) { ret false; }
+    if (flen == plen) { ret true; }
+    ret fqn[plen] == '.';
+}
+
 # document_root: the project root governing `uri` — the nearest ancestor of its
 # decoded filesystem path holding a `mach.toml` — as an owned string, or nil
 # for a non-file URI or a document outside any project.

--- a/src/project.mach
+++ b/src/project.mach
@@ -355,7 +355,13 @@ pub fun module_uri(w: *Workspace, mid: sess.ModuleId) str {
 # module_for_uri: the loaded module whose source file is the document at `uri`
 # (matched on the normalized filesystem path), or none. lets the workspace walk
 # skip the active buffer's on-disk twin, whose live edits the buffer's own
-# resolve already covers, so its references are not counted twice.
+# resolve already covers, so its references are not counted twice. matching is
+# lexical (`.` / `..` collapse only): the std fs surface exposes neither
+# realpath nor inode identity, so a buffer opened through a symlinked or
+# differently-cased path does not match its twin and that file is walked as a
+# separate module — yielding duplicate locations / a duplicate WorkspaceEdit
+# key for the same physical file. such documents normally fail the
+# project-root gate and resolve single-file, which keeps the window narrow.
 # ---
 # w:   the workspace
 # uri: a document URI

--- a/test/fixture-ws/mach.toml
+++ b/test/fixture-ws/mach.toml
@@ -1,0 +1,20 @@
+# cross-file fixture for the workspace-wide references / rename tests. two
+# project-owned modules, no external deps: `lib` declares a `pub` symbol and the
+# entry module `app` imports and uses it, so a rename of that symbol must reach
+# both files (the declaration, the import path leaf, and the use-sites).
+#
+# uses the mach v1.4.0 [target.X]/[bin.X] manifest format, so the server's
+# bumped build_project loads it the same way it loads a real project.
+[project]
+id      = "wsfix"
+version = "0.0.0"
+src     = "src"
+target  = "native"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.wsfix]
+entry = "app.mach"

--- a/test/fixture-ws/src/app.mach
+++ b/test/fixture-ws/src/app.mach
@@ -1,7 +1,8 @@
-# app: the entry module; imports lib.shared and uses it twice, so workspace
-# references / rename on `shared` reach both this file and lib.mach.
+# app: the entry module; imports lib.shared (used twice) and lib.LIMIT, so
+# workspace references / rename on either reach both this file and lib.mach.
 use wsfix.lib.shared;
+use wsfix.lib.LIMIT;
 
 fun main() i64 {
-    ret shared(1) + shared(2);
+    ret shared(1) + shared(2) + LIMIT;
 }

--- a/test/fixture-ws/src/app.mach
+++ b/test/fixture-ws/src/app.mach
@@ -1,0 +1,7 @@
+# app: the entry module; imports lib.shared and uses it twice, so workspace
+# references / rename on `shared` reach both this file and lib.mach.
+use wsfix.lib.shared;
+
+fun main() i64 {
+    ret shared(1) + shared(2);
+}

--- a/test/fixture-ws/src/lib.mach
+++ b/test/fixture-ws/src/lib.mach
@@ -5,3 +5,7 @@
 pub fun shared(x: i64) i64 {
     ret x;
 }
+
+# LIMIT: a pub constant the app module imports; a function-local binding that
+# shadows this name must rename buffer-local without bridging to it.
+pub val LIMIT: i64 = 10;

--- a/test/fixture-ws/src/lib.mach
+++ b/test/fixture-ws/src/lib.mach
@@ -1,0 +1,7 @@
+# lib: a project module whose pub symbol is imported across files, so renaming
+# it must rewrite this declaration and every importer.
+
+# shared: a value passed through; imported and used by the app module.
+pub fun shared(x: i64) i64 {
+    ret x;
+}

--- a/test/run.py
+++ b/test/run.py
@@ -10,11 +10,13 @@ import sys
 import test_diagnostics
 import test_features
 import test_crossmodule
+import test_workspace
 
 SUITES = [
     ("diagnostics", test_diagnostics.run),
     ("features", test_features.run),
     ("crossmodule", test_crossmodule.run),
+    ("workspace", test_workspace.run),
 ]
 
 

--- a/test/test_crossmodule.py
+++ b/test/test_crossmodule.py
@@ -50,6 +50,9 @@ def main_scenario():
             {"textDocument": {"uri": URI}, "position": STR_LEN,
              "context": {"includeDeclaration": True}}),
         req(23, "textDocument/definition", {"textDocument": {"uri": URI}, "position": LOCAL}),
+        req(24, "textDocument/prepareRename", {"textDocument": {"uri": URI}, "position": STR_LEN}),
+        req(25, "textDocument/rename",
+            {"textDocument": {"uri": URI}, "position": STR_LEN, "newName": "nope"}),
         req(2, "shutdown", None),
         notify("exit"),
     ]
@@ -92,6 +95,15 @@ def main_scenario():
             failures.append(f"definition(length) left the buffer: {lv['uri']}")
         if lv["range"]["start"]["line"] != 9:
             failures.append(f"definition(length) points to line {lv['range']['start']['line']}, expected 9")
+
+    # a dependency symbol is not the editor's to rewrite: prepareRename refuses
+    # (null) and rename yields an empty WorkspaceEdit.
+    prv = (by_id(msgs, 24) or {}).get("result", "missing")
+    if prv is not None:
+        failures.append(f"prepareRename(str_len dep) should be null, got {prv!r}")
+    rnv = (by_id(msgs, 25) or {}).get("result")
+    if not isinstance(rnv, dict) or rnv.get("changes") != {}:
+        failures.append(f"rename(str_len dep) should be an empty WorkspaceEdit, got {rnv!r}")
 
     if code != 0:
         failures.append("non-zero exit code after clean shutdown")

--- a/test/test_crossmodule.py
+++ b/test/test_crossmodule.py
@@ -165,6 +165,55 @@ def percent_encoding_scenario():
     return failures
 
 
+def dep_buffer_rename_scenario():
+    """a dependency source opened directly (as after go-to-definition) is not the
+    editor's to rewrite: even though its symbols resolve buffer-locally, its
+    on-disk twin is a non-project module, so prepareRename refuses and rename
+    yields an empty WorkspaceEdit (regression: the local-symbol path skipped the
+    project-ownership check)."""
+    dep_path = os.path.join(REPO, "dep", "mach-std", "src", "types", "string.mach")
+    dep_text = open(dep_path).read()
+    decl_line = None
+    decl_col = None
+    for i, line in enumerate(dep_text.splitlines()):
+        if "pub fun str_len" in line:
+            decl_line, decl_col = i, line.find("str_len")
+            break
+    if decl_line is None:
+        return [f"str_len declaration not found in {dep_path}"]
+
+    app_text = open(APP).read()
+    dep_pos = pos(decl_line, decl_col)
+    frames = [
+        req(1, "initialize", {"capabilities": {}}),
+        notify("initialized"),
+        did_open(URI, app_text),
+        # resolve the project document first so the fixture graph is loaded
+        req(10, "textDocument/definition", {"textDocument": {"uri": URI}, "position": STR_LEN}),
+        did_open(DEP_STRING_URI, dep_text),
+        req(20, "textDocument/prepareRename",
+            {"textDocument": {"uri": DEP_STRING_URI}, "position": dep_pos}),
+        req(21, "textDocument/rename",
+            {"textDocument": {"uri": DEP_STRING_URI}, "position": dep_pos, "newName": "nope"}),
+        req(2, "shutdown", None),
+        notify("exit"),
+    ]
+    code, msgs = drive(frames)
+
+    failures = []
+    check_dep_definition(failures, "definition(str_len) before the dep open",
+                         (by_id(msgs, 10) or {}).get("result"))
+    prv = (by_id(msgs, 20) or {}).get("result", "missing")
+    if prv is not None:
+        failures.append(f"prepareRename(dep buffer decl) should be null, got {prv!r}")
+    rnv = (by_id(msgs, 21) or {}).get("result")
+    if not isinstance(rnv, dict) or rnv.get("changes") != {}:
+        failures.append(f"rename(dep buffer decl) should be an empty WorkspaceEdit, got {rnv!r}")
+    if code != 0:
+        failures.append("non-zero exit code after clean shutdown")
+    return failures
+
+
 def run():
     """drive the cross-module scenarios; return a list of failure strings."""
     if not os.path.exists(APP):
@@ -173,6 +222,7 @@ def run():
     failures += main_scenario()
     failures += scratch_ordering_scenario()
     failures += percent_encoding_scenario()
+    failures += dep_buffer_rename_scenario()
     return failures
 
 

--- a/test/test_workspace.py
+++ b/test/test_workspace.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""workspace-wide references / rename scenarios over test/fixture-ws, a depless
+two-module project: lib.mach declares `pub fun shared` and the entry app.mach
+imports and uses it. references must reach use-sites in both files, and rename
+must rewrite the declaration, the importer's `use` path leaf, and every use-site
+across both files — from either the using buffer or the declaring buffer."""
+import os
+
+from harness import drive, req, notify, did_open, pos, by_id, file_uri, standalone, REPO
+
+FIX = os.path.join(REPO, "test", "fixture-ws")
+APP = os.path.join(FIX, "src", "app.mach")
+LIB = os.path.join(FIX, "src", "lib.mach")
+APP_URI = file_uri(APP)
+LIB_URI = file_uri(LIB)
+
+# byte positions (0-based):
+#   app.mach line 2:  `use wsfix.lib.shared;`        -> `shared` leaf at col 14
+#   app.mach line 5:  `    ret shared(1) + shared(2);` -> uses at col 8 and col 20
+#   lib.mach line 4:  `pub fun shared(x: i64) i64 {`  -> decl name `shared` at col 8
+APP_USE = pos(5, 8)
+LIB_DECL = pos(4, 8)
+
+
+def from_using_buffer():
+    """references / rename invoked on a use-site in the importing buffer reach
+    both files (cross-module symbol declared in a sibling project module)."""
+    text = open(APP).read()
+    frames = [
+        req(1, "initialize", {"capabilities": {}}),
+        notify("initialized"),
+        did_open(APP_URI, text),
+        req(20, "textDocument/references",
+            {"textDocument": {"uri": APP_URI}, "position": APP_USE,
+             "context": {"includeDeclaration": True}}),
+        req(21, "textDocument/rename",
+            {"textDocument": {"uri": APP_URI}, "position": APP_USE, "newName": "renamed"}),
+        req(2, "shutdown", None),
+        notify("exit"),
+    ]
+    code, msgs = drive(frames)
+    failures = []
+
+    rv = (by_id(msgs, 20) or {}).get("result")
+    if not isinstance(rv, list):
+        failures.append("references(shared) result is not an array")
+    else:
+        uris = [e.get("uri", "") for e in rv]
+        if APP_URI not in uris:
+            failures.append("references(shared) missing the importer's use-sites")
+        if LIB_URI not in uris:
+            failures.append(f"references(shared) missing the cross-file declaration in lib.mach (got {sorted(set(uris))})")
+        if len(rv) < 4:
+            failures.append(f"references(shared) found {len(rv)}, expected >= 4 (decl + use leaf + 2 uses)")
+
+    rn = (by_id(msgs, 21) or {}).get("result")
+    if not rn or "changes" not in rn:
+        failures.append("rename(shared) returned no WorkspaceEdit")
+    else:
+        changes = rn["changes"]
+        if APP_URI not in changes:
+            failures.append("rename(shared) did not edit the importing file")
+        if LIB_URI not in changes:
+            failures.append(f"rename(shared) did not edit the declaring file (changed {sorted(changes.keys())})")
+        all_edits = [e for edits in changes.values() for e in edits]
+        if any(e.get("newText") != "renamed" for e in all_edits):
+            failures.append("rename(shared) edit newText is not 'renamed'")
+        # the declaration in lib.mach is rewritten at its name span (line 4)
+        lib_lines = {e["range"]["start"]["line"] for e in changes.get(LIB_URI, [])}
+        if 4 not in lib_lines:
+            failures.append(f"rename(shared) did not rewrite the lib.mach declaration on line 4 (lines {sorted(lib_lines)})")
+        # the importer's `use` path leaf (line 2) is rewritten so it keeps compiling
+        app_lines = {e["range"]["start"]["line"] for e in changes.get(APP_URI, [])}
+        if 2 not in app_lines:
+            failures.append(f"rename(shared) did not rewrite the app.mach `use` path leaf on line 2 (lines {sorted(app_lines)})")
+
+    if code != 0:
+        failures.append("non-zero exit code after clean shutdown")
+    return failures
+
+
+def from_declaring_buffer():
+    """rename invoked on the declaration itself reaches the importer; prepareRename
+    offers the name range for the project-owned symbol."""
+    text = open(LIB).read()
+    frames = [
+        req(1, "initialize", {"capabilities": {}}),
+        notify("initialized"),
+        did_open(LIB_URI, text),
+        req(30, "textDocument/prepareRename", {"textDocument": {"uri": LIB_URI}, "position": LIB_DECL}),
+        req(31, "textDocument/rename",
+            {"textDocument": {"uri": LIB_URI}, "position": LIB_DECL, "newName": "passthru"}),
+        req(2, "shutdown", None),
+        notify("exit"),
+    ]
+    code, msgs = drive(frames)
+    failures = []
+
+    prv = (by_id(msgs, 30) or {}).get("result")
+    if not prv or "start" not in prv:
+        failures.append("prepareRename(shared decl) returned no range")
+
+    rn = (by_id(msgs, 31) or {}).get("result")
+    if not rn or "changes" not in rn:
+        failures.append("rename(shared decl) returned no WorkspaceEdit")
+    else:
+        changes = rn["changes"]
+        if LIB_URI not in changes or APP_URI not in changes:
+            failures.append(f"rename(shared decl) is not cross-file (changed {sorted(changes.keys())})")
+        all_edits = [e for edits in changes.values() for e in edits]
+        if any(e.get("newText") != "passthru" for e in all_edits):
+            failures.append("rename(shared decl) edit newText is not 'passthru'")
+
+    if code != 0:
+        failures.append("non-zero exit code after clean shutdown")
+    return failures
+
+
+def run():
+    """drive the workspace cross-file scenarios; return a list of failure strings."""
+    if not os.path.exists(APP):
+        return [f"fixture not found at {APP}"]
+    failures = []
+    failures += from_using_buffer()
+    failures += from_declaring_buffer()
+    return failures
+
+
+if __name__ == "__main__":
+    standalone("workspace", run)

--- a/test/test_workspace.py
+++ b/test/test_workspace.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
 """workspace-wide references / rename scenarios over test/fixture-ws, a depless
-two-module project: lib.mach declares `pub fun shared` and the entry app.mach
-imports and uses it. references must reach use-sites in both files, and rename
-must rewrite the declaration, the importer's `use` path leaf, and every use-site
-across both files — from either the using buffer or the declaring buffer."""
+two-module project: lib.mach declares `pub fun shared` (and `pub val LIMIT`) and
+the entry app.mach imports and uses them. references must reach use-sites in
+both files, and rename must rewrite the declaration, the importer's `use` path
+leaf, and every use-site across both files — from either the using buffer or
+the declaring buffer. a block-local shadow of a pub name must stay
+buffer-local, and a pub declaration already renamed by unsaved edits must
+refuse rather than emit a partial edit."""
 import os
 
 from harness import drive, req, notify, did_open, pos, by_id, file_uri, standalone, REPO
@@ -16,10 +19,34 @@ LIB_URI = file_uri(LIB)
 
 # byte positions (0-based):
 #   app.mach line 2:  `use wsfix.lib.shared;`        -> `shared` leaf at col 14
-#   app.mach line 5:  `    ret shared(1) + shared(2);` -> uses at col 8 and col 20
+#   app.mach line 6:  `    ret shared(1) + shared(2) + LIMIT;` -> uses at col 8 / 20
 #   lib.mach line 4:  `pub fun shared(x: i64) i64 {`  -> decl name `shared` at col 8
-APP_USE = pos(5, 8)
+APP_USE = pos(6, 8)
 LIB_DECL = pos(4, 8)
+
+# lib.mach with unsaved edits appended: `other` shadows the module-scope pub
+# LIMIT with a block-local binding. renaming the local must not bridge to the
+# pub symbol app.mach imports.
+SHADOW_SRC = (
+    "pub fun shared(x: i64) i64 {\n"   # line 0
+    "    ret x;\n"
+    "}\n"
+    "\n"
+    "pub val LIMIT: i64 = 10;\n"       # line 4 (the pub the shadow must not touch)
+    "\n"
+    "fun other() i64 {\n"
+    "    val LIMIT: i64 = 3;\n"        # line 7, name at col 8
+    "    ret LIMIT;\n"                 # line 8, use at col 8
+    "}\n"
+)
+
+# lib.mach with the pub declaration renamed by unsaved edits: the on-disk twin
+# still exports `shared`, so `shared2`'s cross-file identity is unrecoverable.
+STALE_SRC = (
+    "pub fun shared2(x: i64) i64 {\n"  # line 0, name at col 8
+    "    ret x;\n"
+    "}\n"
+)
 
 
 def from_using_buffer():
@@ -116,6 +143,89 @@ def from_declaring_buffer():
     return failures
 
 
+def local_shadow_stays_local():
+    """renaming a block-local binding that shadows a module-scope pub name must
+    stay buffer-local: it must not bridge to the pub symbol and rewrite the
+    importer's references (regression: the bridge keyed on (name, kind) alone)."""
+    frames = [
+        req(1, "initialize", {"capabilities": {}}),
+        notify("initialized"),
+        did_open(LIB_URI, SHADOW_SRC),
+        req(40, "textDocument/references",
+            {"textDocument": {"uri": LIB_URI}, "position": pos(7, 8),
+             "context": {"includeDeclaration": True}}),
+        req(41, "textDocument/rename",
+            {"textDocument": {"uri": LIB_URI}, "position": pos(7, 8), "newName": "CAP"}),
+        req(2, "shutdown", None),
+        notify("exit"),
+    ]
+    code, msgs = drive(frames)
+    failures = []
+
+    rv = (by_id(msgs, 40) or {}).get("result")
+    if not isinstance(rv, list):
+        failures.append("references(local LIMIT) result is not an array")
+    else:
+        uris = {e.get("uri", "") for e in rv}
+        if uris - {LIB_URI}:
+            failures.append(f"references(local LIMIT) leaked across files: {sorted(uris)}")
+        lines = {e["range"]["start"]["line"] for e in rv}
+        if 4 in lines:
+            failures.append("references(local LIMIT) included the shadowed pub declaration on line 4")
+
+    rn = (by_id(msgs, 41) or {}).get("result")
+    if not rn or "changes" not in rn:
+        failures.append("rename(local LIMIT) returned no WorkspaceEdit")
+    else:
+        changes = rn["changes"]
+        if set(changes.keys()) - {LIB_URI}:
+            failures.append(f"rename(local LIMIT) edited other files: {sorted(changes.keys())}")
+        lines = {e["range"]["start"]["line"] for e in changes.get(LIB_URI, [])}
+        if 4 in lines:
+            failures.append("rename(local LIMIT) rewrote the shadowed pub declaration on line 4")
+        if not {7, 8} <= lines:
+            failures.append(f"rename(local LIMIT) missed the local binding/use (lines {sorted(lines)})")
+
+    if code != 0:
+        failures.append("non-zero exit code after clean shutdown")
+    return failures
+
+
+def stale_twin_refuses_rename():
+    """renaming a module-scope pub declaration whose name unsaved edits already
+    changed must refuse (empty edit): the stale on-disk twin cannot supply the
+    cross-file identity, and a buffer-local edit would be a partial rename.
+    references still answers buffer-locally."""
+    frames = [
+        req(1, "initialize", {"capabilities": {}}),
+        notify("initialized"),
+        did_open(LIB_URI, STALE_SRC),
+        req(50, "textDocument/rename",
+            {"textDocument": {"uri": LIB_URI}, "position": pos(0, 8), "newName": "shared3"}),
+        req(51, "textDocument/references",
+            {"textDocument": {"uri": LIB_URI}, "position": pos(0, 8),
+             "context": {"includeDeclaration": True}}),
+        req(2, "shutdown", None),
+        notify("exit"),
+    ]
+    code, msgs = drive(frames)
+    failures = []
+
+    rn = (by_id(msgs, 50) or {}).get("result")
+    if not isinstance(rn, dict) or rn.get("changes") != {}:
+        failures.append(f"rename(stale shared2) should be an empty WorkspaceEdit, got {rn!r}")
+
+    rv = (by_id(msgs, 51) or {}).get("result")
+    if not isinstance(rv, list) or len(rv) < 1:
+        failures.append(f"references(stale shared2) should still answer buffer-locally, got {rv!r}")
+    elif any(e.get("uri") != LIB_URI for e in rv):
+        failures.append("references(stale shared2) left the buffer")
+
+    if code != 0:
+        failures.append("non-zero exit code after clean shutdown")
+    return failures
+
+
 def run():
     """drive the workspace cross-file scenarios; return a list of failure strings."""
     if not os.path.exists(APP):
@@ -123,6 +233,8 @@ def run():
     failures = []
     failures += from_using_buffer()
     failures += from_declaring_buffer()
+    failures += local_shadow_stays_local()
+    failures += stale_twin_refuses_rename()
     return failures
 
 


### PR DESCRIPTION
Closes #47

## Summary

References and rename were buffer-local: references found use-sites only in the
requesting buffer, and renaming a `pub` symbol that other files import produced a
compile-breaking partial rename. This adds a shared use-site index over the
loaded project graph (the per-module ASTs + resolve results already in the
session after `driver.build_project`) and rebuilds both features on it.

- **references** now reports the declaration plus every use-site **across all
  loaded modules**, not just the current buffer.
- **rename** is now **cross-file**: it rewrites the declaring file, every
  importer's body references, and each importer's `use` path leaf — so an
  imported symbol stays consistent after the rename. It is confined to symbols
  declared in the user's own project (a dependency's declaration is still not the
  editor's to rewrite); `prepareRename` returns the name range for renameable
  symbols and null for dependency-declared ones.

## Index design

A symbol's identity across modules is the pair `(origin ModuleId, decl DeclId)` —
an imported reference copies its referent's origin and decl, so the same logical
symbol shares that pair in every module's resolve result. `build_refs` resolves
the cursor symbol to its canonical pair (read directly for a cross-module
reference, or recovered from the buffer's on-disk module for a buffer-local pub
declaration), then for each loaded module finds the local SymbolId carrying that
pair (`features.symbol_by_decl`) and walks its expr/type/decl side tables. The
active buffer is always the first source (live resolve, matched by its own
SymbolId); its on-disk twin is skipped so live edits are not double-counted.

`use` / `fwd` import paths are not in the expr/type tables, but the resolver
records the imported symbol in `decl_symbol` and binds it under the path's leaf;
`features.import_ref_span` recovers that leaf so rename keeps importers compiling.
Body references are guarded by the declared name (`span_text_equals`) so a symbol
bound under an alias — whose references are spelled with the alias — is not
rewritten.

Cross-file rename shipped (no blocker); the prepareRename error-gate fallback was
not needed.

## Scope / known limitation

The project graph is a snapshot from the first analysis and is not rebuilt on
`didChange`, so cross-file results reflect on-disk state for files other than the
active buffer — the same as-of-load-time behavior the cross-module features (#39)
already have. Documented in the README.

## Tests

`make test` (build + full stdio suite) passes. Cross-file references and rename
coverage added — see the test commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)