### PR TITLE
feat: per-root project handling and dep-graph invalidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ This server implements the **diagnostics** vertical slice plus the
 - LSP lifecycle: `initialize`, `initialized`, `shutdown`, `exit`.
 - Document synchronization (full-text): `textDocument/didOpen`,
   `didChange`, `didClose`.
+- Workspace file watching: `workspace/didChangeWatchedFiles` invalidates the
+  affected project root's graph, registered via `client/registerCapability`.
 - Diagnostics: on open/change the buffer text is fed to `mach.lang.editor`
   (`open` / `update` / `diagnostics`); every reported `diagnostic.Diagnostic`
   is mapped — its byte span through `source.position` to a 0-based LSP range,
@@ -38,38 +40,63 @@ This server implements the **diagnostics** vertical slice plus the
 
 ### Cross-module scope
 
-On first analysis the server loads the project's module graph from disk
+The server keeps a **per-root** map of project graphs: each open document is
+routed to the project root that governs its path (the nearest ancestor
+`mach.toml`), and that root's module graph is loaded from disk on first use
 (`mls.project` runs the compiler's own `driver.build_project` over the manifest
-and `dep/` tree) and snapshots every loaded module's exports into a dependency
-set, then re-resolves the open buffer against it. So a symbol imported through
-a `use` binds to its declaration in a dependency module, and:
+and `dep/` tree, snapshotting every loaded module's exports into a dependency
+set). The buffer is then re-resolved against its root's dep set, so several
+projects open in one session resolve independently. A document that is already a
+dependency module of a loaded root (e.g. a dep source opened via
+go-to-definition) is bound to that root read-only rather than spun up as its own
+project. A symbol imported through a `use` binds to its declaration in a
+dependency module, and:
 
 - hover / definition reach **cross-module and cross-file** symbols, pointing at
   the defining module's source file on disk (a `file://` location);
-- references and rename walk a shared use-site index over the loaded module
+- references and rename walk a shared use-site index over the document's root
   graph (`build_refs` over `mls.project`'s `module_view`): references reports
-  every use-site across all modules; rename rewrites the declaring file, every
-  importer's body references, and each importer's `use` path leaf (guarded by
-  the declared name, so an aliased import's references are left intact).
+  every use-site across that root's modules; rename rewrites the declaring file,
+  every importer's body references, and each importer's `use` path leaf (guarded
+  by the declared name, so an aliased import's references are left intact).
   Cross-file rename is confined to symbols declared in the user's own project —
   a dependency's declaration is not the editor's to rewrite, whether referenced
-  cross-module or opened directly as the buffer — and reflects the on-disk
-  state of files other than the active buffer, since the project graph is a
-  load-time snapshot not rebuilt on `didChange`. When a module-scope `pub`
-  symbol's cross-file identity cannot be recovered from its stale on-disk twin
-  (unsaved edits renamed the declaration), rename refuses with an empty edit
-  rather than emit a partial, compile-breaking one;
+  cross-module or opened directly as the buffer — and reflects the on-disk state
+  of files other than the active buffer (the project graph is a load-time
+  snapshot, not rebuilt on `didChange`). When a module-scope `pub` symbol's
+  cross-file identity cannot be recovered from its stale on-disk twin (unsaved
+  edits renamed the declaration), rename refuses with an empty edit rather than
+  emit a partial, compile-breaking one;
 - completion is a flat list of the file's named symbols and the primitives, not
   a lexically scoped view (the resolver's scope chain is not exposed by the
   side tables);
 - a document outside any project (no ancestor `mach.toml`) resolves single-file
   with an empty dependency set — references and rename then stay buffer-local.
 
-> **Scope note:** the loader builds the import-reachable module closure of the
+A root's graph is **invalidated and rebuilt** when its sources change on disk:
+the server registers `workspace/didChangeWatchedFiles` watchers (via
+`client/registerCapability` when the client supports dynamic registration) for
+the manifest, lockfile, and source trees, and a change to any file under a root
+drops that root so the next request reloads it. For clients that do not deliver
+watch notifications, a conservative manifest/lockfile mtime check on each access
+reloads the root. So editing a dependency source, or pulling updated deps,
+serves the new positions and text rather than the as-of-first-load snapshot.
+
+> **Module-id namespacing:** `driver.build_project` numbers modules from 0 and
+> writes them into the session's global module registries, so a second build
+> over the same session clobbers the first there. The server sidesteps this by
+> never reading those session registries — every cross-module lookup reads the
+> per-root `driver.Project.modules` array, whose ids are private to that project
+> — so several graphs coexist in one shared session (and one source map /
+> interner) without collision, and no per-root sessions are needed.
+
+> **Scope note:** each root's graph is the import-reachable module closure of the
 > manifest's default target (the compiler's own DFS load), so project files
 > outside that closure — secondary `bin` targets, modules nothing imports — are
-> not in the graph: references cannot see their use-sites and rename silently
-> leaves them untouched. Per-root multi-graph loading is tracked in #46.
+> still not in the graph: references cannot see their use-sites and rename
+> silently leaves them untouched. Loading every declared target per root would
+> need path-deduplicated multi-graph merging (to avoid duplicate edits for
+> modules shared between targets) and is deferred.
 
 > **Known limitation (#45):** the vendored `dep/mach` only parses the old
 > `[targets.<name>]` manifest format, so cross-module resolution is currently
@@ -109,7 +136,7 @@ and fetched by `mach dep pull`; `mach-std` tracks `branch/dev` and `mach` is pin
 | `diagnostics` | run `editor.diagnostics`, map spans, publish |
 | `positions` | byte offset ⇄ LSP `(line, character)` and span text |
 | `features` | offset → id → symbol query core over the resolve side tables |
-| `project` | load the project module graph; re-resolve a buffer against its dependency set; map a symbol to its declaring file's `file://` URI; expose the loaded modules for the workspace-wide use-site walk |
+| `project` | per-root project graphs: route a document to its governing root, load each root's module graph, re-resolve a buffer against its root's dependency set, map a symbol to its declaring file's `file://` URI, expose a root's loaded modules for the use-site walk, and invalidate a root on a watched-file change |
 | `language` | hover / definition / references / rename / documentSymbol / completion request bodies |
 | `trace` | append-only debug trace log (`/tmp/mach-lsp.log`) |
 
@@ -139,6 +166,13 @@ each scenario module asserts one surface:
   block-local binding shadowing a pub name renames buffer-local without touching
   importers, and a pub declaration renamed by unsaved edits refuses (empty edit)
   instead of emitting a partial rename.
+- `test_multiroot.py` — `test/fixture-ws` and `test/fixture` open in one
+  session: each cross-module definition lands in its own project's files, in
+  either open order, so the two roots resolve independently.
+- `test_invalidation.py` — a scratch copy of `test/fixture-ws`: editing a dep
+  source on disk and firing `workspace/didChangeWatchedFiles` (and, separately,
+  bumping the manifest mtime for the fallback path) makes the next definition
+  serve the shifted declaration line, proving the root's graph reloaded.
 
 ```sh
 make test          # builds, then runs test/run.py

--- a/README.md
+++ b/README.md
@@ -46,11 +46,13 @@ routed to the project root that governs its path (the nearest ancestor
 (`mls.project` runs the compiler's own `driver.build_project` over the manifest
 and `dep/` tree, snapshotting every loaded module's exports into a dependency
 set). The buffer is then re-resolved against its root's dep set, so several
-projects open in one session resolve independently. A document that is already a
-dependency module of a loaded root (e.g. a dep source opened via
-go-to-definition) is bound to that root read-only rather than spun up as its own
-project. A symbol imported through a `use` binds to its declaration in a
-dependency module, and:
+projects open in one session resolve independently. A document that is a
+dependency module of another root — one already loaded (e.g. a dep source opened
+via go-to-definition), or the project whose manifest declares the document's own
+nested root as a dep vendor dir, loaded on demand when the dep file is opened
+first — is bound to that root read-only rather than spun up as its own project,
+regardless of document open order. A symbol imported through a `use` binds to
+its declaration in a dependency module, and:
 
 - hover / definition reach **cross-module and cross-file** symbols, pointing at
   the defining module's source file on disk (a `file://` location);
@@ -77,10 +79,13 @@ A root's graph is **invalidated and rebuilt** when its sources change on disk:
 the server registers `workspace/didChangeWatchedFiles` watchers (via
 `client/registerCapability` when the client supports dynamic registration) for
 the manifest, lockfile, and source trees, and a change to any file under a root
-drops that root so the next request reloads it. For clients that do not deliver
-watch notifications, a conservative manifest/lockfile mtime check on each access
-reloads the root. So editing a dependency source, or pulling updated deps,
-serves the new positions and text rather than the as-of-first-load snapshot.
+drops that root so the next request reloads it. With watching active, editing a
+dependency source or pulling updated deps serves the new positions and text
+rather than the as-of-first-load snapshot. For clients that do not deliver watch
+notifications, a manifest/lockfile mtime check on each access reloads the root —
+and retries a previously failed load once the manifest is fixed — but bare
+source edits are only picked up through a watch notification (or a manifest /
+lockfile touch).
 
 > **Module-id namespacing:** `driver.build_project` numbers modules from 0 and
 > writes them into the session's global module registries, so a second build
@@ -157,8 +162,9 @@ each scenario module asserts one surface:
   `mach-std`): definition / references / hover on a `use`d std symbol reach a
   `file://` location inside `dep/mach-std`, a local symbol still resolves in the
   buffer, and renaming a dependency symbol is refused (prepareRename null, empty
-  edit) — whether referenced cross-module or with the dependency source itself
-  opened as the buffer.
+  edit) — whether referenced cross-module, with the dependency source opened as
+  the buffer, or with the dependency source opened cold before any project
+  document.
 - `test_workspace.py` — against `test/fixture-ws`, a depless two-module project:
   references on a `pub` symbol used across files returns use-sites in both
   modules, and rename rewrites the declaration, the importer's `use` path leaf,
@@ -172,7 +178,8 @@ each scenario module asserts one surface:
 - `test_invalidation.py` — a scratch copy of `test/fixture-ws`: editing a dep
   source on disk and firing `workspace/didChangeWatchedFiles` (and, separately,
   bumping the manifest mtime for the fallback path) makes the next definition
-  serve the shifted declaration line, proving the root's graph reloaded.
+  serve the shifted declaration line, proving the root's graph reloaded; a
+  broken manifest fixed on disk is retried rather than pinned failed.
 
 ```sh
 make test          # builds, then runs test/run.py

--- a/src/json.mach
+++ b/src/json.mach
@@ -16,6 +16,7 @@ use std.types.size.usize;
 use std.types.size.isize;
 use std.types.string.str;
 use std.types.string.str_len;
+use std.types.string.str_equals;
 use std.types.result.Result;
 use std.types.result.is_err;
 use std.types.result.unwrap_ok;
@@ -183,6 +184,55 @@ pub fun extract_number_after(data: str, anchor: str, key: str, alloc: *Allocator
     if (offset >= data_len) { ret 0; }
     val sub: str = (data::usize + offset)::str;
     ret extract_number_i64(sub, key, alloc);
+}
+
+# extract_string_seq: decode the string value of the `index`-th occurrence of
+# `key` in `data` (0-based), or nil when there are fewer than index+1
+# occurrences. lets a caller iterate a repeated key — e.g. every `"uri"` in a
+# `workspace/didChangeWatchedFiles` changes array — by bumping `index` until nil.
+# ---
+# data:  JSON text to scan
+# key:   quoted key to find, e.g. `"uri"`
+# index: zero-based occurrence to read
+# alloc: allocator backing the returned string
+# ret:   owned decoded value, or nil
+pub fun extract_string_seq(data: str, key: str, index: u32, alloc: *Allocator) str {
+    var sub: str = data;
+    val key_len: usize = str_len(key);
+    var i: u32 = 0;
+    for (i < index) {
+        val idx: isize = find_key(sub, key);
+        if (idx < 0) { ret nil; }
+        val off: usize = (idx::usize) + key_len;
+        if (off >= str_len(sub)) { ret nil; }
+        sub = (sub::usize + off)::str;
+        i = i + 1;
+    }
+    ret extract_string(sub, key, alloc);
+}
+
+# extract_bool_after: whether the boolean `key` appearing after the first
+# occurrence of `anchor` is the literal `true`. false when absent or non-true,
+# so a missing capability reads as unsupported.
+# ---
+# data:   JSON text to scan
+# anchor: quoted key marking where to start scanning
+# key:    quoted boolean key to read after the anchor
+# alloc:  scratch allocator (the raw token is freed before return)
+# ret:    true only when the value is the literal `true`
+pub fun extract_bool_after(data: str, anchor: str, key: str, alloc: *Allocator) bool {
+    val idx: isize = find_key(data, anchor);
+    if (idx < 0) { ret false; }
+    val data_len: usize = str_len(data);
+    val anchor_len: usize = str_len(anchor);
+    val offset: usize = (idx::usize) + anchor_len;
+    if (offset >= data_len) { ret false; }
+    val sub: str = (data::usize + offset)::str;
+    val raw: str = extract_raw(sub, key, alloc);
+    if (raw == nil) { ret false; }
+    val is_true: bool = str_equals(raw, "true");
+    free_str(raw, alloc);
+    ret is_true;
 }
 
 # quote: JSON-encode `s` as a quoted, escaped string literal (including the

--- a/src/json.mach
+++ b/src/json.mach
@@ -149,6 +149,18 @@ pub fun extract_number_i64(data: str, key: str, alloc: *Allocator) i64 {
     ret result;
 }
 
+# seek_after: the tail of `data` starting just past the first occurrence of
+# `anchor` as an object key, or nil when the anchor is absent or ends the text.
+# the shared prologue of the *_after accessors; the returned pointer borrows
+# `data`.
+fun seek_after(data: str, anchor: str) str {
+    val idx: isize = find_key(data, anchor);
+    if (idx < 0) { ret nil; }
+    val offset: usize = (idx::usize) + str_len(anchor);
+    if (offset >= str_len(data)) { ret nil; }
+    ret (data::usize + offset)::str;
+}
+
 # extract_after: read string `key` that appears after the first occurrence of
 # `anchor` (scopes a key lookup to a nested object whose opening key is known).
 # ---
@@ -158,13 +170,8 @@ pub fun extract_number_i64(data: str, key: str, alloc: *Allocator) i64 {
 # alloc:  allocator backing the returned string
 # ret:    owned decoded value, or nil
 pub fun extract_after(data: str, anchor: str, key: str, alloc: *Allocator) str {
-    val idx: isize = find_key(data, anchor);
-    if (idx < 0) { ret nil; }
-    val data_len: usize = str_len(data);
-    val anchor_len: usize = str_len(anchor);
-    val offset: usize = (idx::usize) + anchor_len;
-    if (offset >= data_len) { ret nil; }
-    val sub: str = (data::usize + offset)::str;
+    val sub: str = seek_after(data, anchor);
+    if (sub == nil) { ret nil; }
     ret extract_string(sub, key, alloc);
 }
 
@@ -176,13 +183,8 @@ pub fun extract_after(data: str, anchor: str, key: str, alloc: *Allocator) str {
 # alloc:  scratch allocator
 # ret:    the parsed integer, or 0
 pub fun extract_number_after(data: str, anchor: str, key: str, alloc: *Allocator) i64 {
-    val idx: isize = find_key(data, anchor);
-    if (idx < 0) { ret 0; }
-    val data_len: usize = str_len(data);
-    val anchor_len: usize = str_len(anchor);
-    val offset: usize = (idx::usize) + anchor_len;
-    if (offset >= data_len) { ret 0; }
-    val sub: str = (data::usize + offset)::str;
+    val sub: str = seek_after(data, anchor);
+    if (sub == nil) { ret 0; }
     ret extract_number_i64(sub, key, alloc);
 }
 
@@ -198,41 +200,78 @@ pub fun extract_number_after(data: str, anchor: str, key: str, alloc: *Allocator
 # ret:   owned decoded value, or nil
 pub fun extract_string_seq(data: str, key: str, index: u32, alloc: *Allocator) str {
     var sub: str = data;
-    val key_len: usize = str_len(key);
     var i: u32 = 0;
     for (i < index) {
-        val idx: isize = find_key(sub, key);
-        if (idx < 0) { ret nil; }
-        val off: usize = (idx::usize) + key_len;
-        if (off >= str_len(sub)) { ret nil; }
-        sub = (sub::usize + off)::str;
+        sub = seek_after(sub, key);
+        if (sub == nil) { ret nil; }
         i = i + 1;
     }
     ret extract_string(sub, key, alloc);
 }
 
-# extract_bool_after: whether the boolean `key` appearing after the first
-# occurrence of `anchor` is the literal `true`. false when absent or non-true,
-# so a missing capability reads as unsupported.
+# extract_bool_after: whether the boolean `key` inside the object value of
+# `anchor` is the literal `true`. the scan is scoped to the anchor's balanced
+# object, so an equally-named key in a later sibling object is never misread —
+# e.g. another capability's `dynamicRegistration` after an empty
+# `"didChangeWatchedFiles":{}`. false when the anchor is absent, its value is
+# not an object, or the key is absent / non-true, so a missing capability reads
+# as unsupported.
 # ---
 # data:   JSON text to scan
-# anchor: quoted key marking where to start scanning
-# key:    quoted boolean key to read after the anchor
-# alloc:  scratch allocator (the raw token is freed before return)
+# anchor: quoted key whose object value scopes the lookup
+# key:    quoted boolean key to read inside the anchor's object
+# alloc:  scratch allocator (the window and raw token are freed before return)
 # ret:    true only when the value is the literal `true`
 pub fun extract_bool_after(data: str, anchor: str, key: str, alloc: *Allocator) bool {
-    val idx: isize = find_key(data, anchor);
-    if (idx < 0) { ret false; }
-    val data_len: usize = str_len(data);
-    val anchor_len: usize = str_len(anchor);
-    val offset: usize = (idx::usize) + anchor_len;
-    if (offset >= data_len) { ret false; }
-    val sub: str = (data::usize + offset)::str;
-    val raw: str = extract_raw(sub, key, alloc);
-    if (raw == nil) { ret false; }
-    val is_true: bool = str_equals(raw, "true");
-    free_str(raw, alloc);
+    val sub: str = seek_after(data, anchor);
+    if (sub == nil) { ret false; }
+    val sub_len: usize = str_len(sub);
+    var pos: usize = skip_ws(sub, 0);
+    if (pos >= sub_len || sub[pos] != ':') { ret false; }
+    pos = skip_ws(sub, pos + 1);
+    if (pos >= sub_len || sub[pos] != '{') { ret false; }
+    val end: usize = object_end(sub, pos);
+    if (end == 0) { ret false; }
+
+    val window: str = copy_range(sub, pos, end, alloc);
+    if (window == nil) { ret false; }
+    val raw: str = extract_raw(window, key, alloc);
+    var is_true: bool = false;
+    if (raw != nil) {
+        is_true = str_equals(raw, "true");
+        free_str(raw, alloc);
+    }
+    free_str(window, alloc);
     ret is_true;
+}
+
+# object_end: the index one past the matching `}` of the `{` at `start`,
+# skipping string contents, or 0 when the object is unbalanced.
+fun object_end(data: str, start: usize) usize {
+    val n: usize = str_len(data);
+    var depth: usize = 0;
+    var in_str: bool = false;
+    var i: usize = start;
+    for (i < n) {
+        val c: u8 = data[i];
+        if (in_str) {
+            if (c == '\\') { i = i + 2; }
+            or {
+                if (c == '"') { in_str = false; }
+                i = i + 1;
+            }
+        }
+        or {
+            if (c == '"')  { in_str = true; }
+            or (c == '{')  { depth = depth + 1; }
+            or (c == '}')  {
+                depth = depth - 1;
+                if (depth == 0) { ret i + 1; }
+            }
+            i = i + 1;
+        }
+    }
+    ret 0;
 }
 
 # quote: JSON-encode `s` as a quoted, escaped string literal (including the

--- a/src/language.mach
+++ b/src/language.mach
@@ -66,12 +66,14 @@ use project:   mls.project;
 # a:    the buffer's parsed Ast
 # rr:   the buffer's ResolveResult side tables
 # own:  this buffer's module id (Symbol.origin equals it for local symbols)
+# root: the project root the buffer resolved against, or nil for single-file
 rec Analyzed {
     s:    *sess.Session;
     file: *src.SourceFile;
     a:    *ast.Ast;
     rr:   *res.ResolveResult;
     own:  sess.ModuleId;
+    root: *project.Root;
 }
 
 # hover: answer textDocument/hover with the type / declaration of the symbol at
@@ -123,7 +125,7 @@ pub fun hover(ws: *project.Workspace, es: *editor.EditorSession, s: *sess.Sessio
 fun hover_markdown(ws: *project.Workspace, an: Analyzed, sym: *res.Symbol, uri: str, alloc: *Allocator) str {
     var sig: str = nil;
     var doc: str = nil;
-    val site_o: Option[project.Site] = project.site_of(ws, an.own, an.a, an.file, uri, sym);
+    val site_o: Option[project.Site] = project.site_of(ws, an.root, an.own, an.a, an.file, uri, sym);
     if (is_some[project.Site](site_o)) {
         var site: project.Site = unwrap[project.Site](site_o);
         if (sym.decl != id.DECL_NIL) {
@@ -401,7 +403,7 @@ pub fun definition(ws: *project.Workspace, es: *editor.EditorSession, s: *sess.S
     if (!is_some[*res.Symbol](so)) { reply_null(alloc, id_raw); ret; }
     val sym: *res.Symbol = unwrap[*res.Symbol](so);
 
-    val site_o: Option[project.Site] = project.site_of(ws, an.own, an.a, an.file, uri, sym);
+    val site_o: Option[project.Site] = project.site_of(ws, an.root, an.own, an.a, an.file, uri, sym);
     if (!is_some[project.Site](site_o)) { reply_null(alloc, id_raw); ret; }
     var site: project.Site = unwrap[project.Site](site_o);
 
@@ -446,7 +448,7 @@ pub fun references(ws: *project.Workspace, es: *editor.EditorSession, s: *sess.S
     var bind: token.Span;
     val has_bind: bool = binding_span(an, sr.sym_id, ?bind);
 
-    val cap: usize = (project.module_count(ws) + 1)::usize;
+    val cap: usize = (project.module_count(an.root) + 1)::usize;
     val ra: Result[*XRef, str] = allocate[XRef](alloc, cap);
     if (is_err[*XRef, str](ra)) { reply_empty_array(alloc, id_raw); ret; }
     val refs: *XRef = unwrap_ok[*XRef, str](ra);
@@ -488,7 +490,7 @@ pub fun rename(ws: *project.Workspace, es: *editor.EditorSession, s: *sess.Sessi
     val so: Option[*res.Symbol] = features.symbol(an.rr, sr.sym_id);
     if (!is_some[*res.Symbol](so)) { reply_empty_edit(alloc, id_raw); json.free_str(new_name, alloc); ret; }
     val sym: *res.Symbol = unwrap[*res.Symbol](so);
-    if (!renameable(ws, uri, sym, sr)) { reply_empty_edit(alloc, id_raw); json.free_str(new_name, alloc); ret; }
+    if (!renameable(ws, an.root, uri, sym, sr)) { reply_empty_edit(alloc, id_raw); json.free_str(new_name, alloc); ret; }
 
     # the declared name guards the cross-file walk: only occurrences spelled with
     # it are rewritten, so an aliased import's references are left untouched.
@@ -499,7 +501,7 @@ pub fun rename(ws: *project.Workspace, es: *editor.EditorSession, s: *sess.Sessi
     var bind: token.Span;
     val has_bind: bool = binding_span(an, sr.sym_id, ?bind);
 
-    val cap: usize = (project.module_count(ws) + 1)::usize;
+    val cap: usize = (project.module_count(an.root) + 1)::usize;
     val ra: Result[*XRef, str] = allocate[XRef](alloc, cap);
     if (is_err[*XRef, str](ra)) { reply_empty_edit(alloc, id_raw); json.free_str(new_name, alloc); ret; }
     val refs: *XRef = unwrap_ok[*XRef, str](ra);
@@ -539,7 +541,7 @@ pub fun prepare_rename(ws: *project.Workspace, es: *editor.EditorSession, s: *se
 
     val so: Option[*res.Symbol] = features.symbol(an.rr, sr.sym_id);
     if (!is_some[*res.Symbol](so)) { reply_null(alloc, id_raw); ret; }
-    if (!renameable(ws, uri, unwrap[*res.Symbol](so), sr)) { reply_null(alloc, id_raw); ret; }
+    if (!renameable(ws, an.root, uri, unwrap[*res.Symbol](so), sr)) { reply_null(alloc, id_raw); ret; }
 
     val range: positions.LspRange = positions.range_of(an.file, sr.name_span);
     val rng: str = range_json(range, alloc);
@@ -602,11 +604,11 @@ fun binding_span(an: Analyzed, sid: res.SymbolId, out: *token.Span) bool {
 # source opened via go-to-definition, whose symbols all resolve buffer-locally)
 # must also be project-owned. a buffer with no twin (a scratch file, or one
 # outside the loaded graph) renames buffer-local.
-fun renameable(ws: *project.Workspace, uri: str, sym: *res.Symbol, sr: features.SymbolRef) bool {
-    if (!sr.local) { ret project.is_project_module(ws, sym.origin); }
-    val twin_o: Option[sess.ModuleId] = project.module_for_uri(ws, uri);
+fun renameable(ws: *project.Workspace, root: *project.Root, uri: str, sym: *res.Symbol, sr: features.SymbolRef) bool {
+    if (!sr.local) { ret project.is_project_module(ws, root, sym.origin); }
+    val twin_o: Option[sess.ModuleId] = project.module_for_uri(ws, root, uri);
     if (!is_some[sess.ModuleId](twin_o)) { ret true; }
-    ret project.is_project_module(ws, unwrap[sess.ModuleId](twin_o));
+    ret project.is_project_module(ws, root, unwrap[sess.ModuleId](twin_o));
 }
 
 # XRef: one file contributing references to a target symbol — its Ast, resolve
@@ -671,7 +673,7 @@ fun build_refs(ws: *project.Workspace, an: Analyzed, uri: str, sym: *res.Symbol,
     var n: usize = 1;
     @status = BRIDGE_LOCAL;
 
-    val self_o: Option[sess.ModuleId] = project.module_for_uri(ws, uri);
+    val self_o: Option[sess.ModuleId] = project.module_for_uri(ws, an.root, uri);
     val have_self: bool = is_some[sess.ModuleId](self_o);
     var self_mid: sess.ModuleId = 0::sess.ModuleId;
     if (have_self) { self_mid = unwrap[sess.ModuleId](self_o); }
@@ -681,7 +683,7 @@ fun build_refs(ws: *project.Workspace, an: Analyzed, uri: str, sym: *res.Symbol,
     if (sym.origin == an.own) {
         if ((sym.flags & res.SYM_FLAG_MODULE) == 0 || (sym.flags & res.SYM_FLAG_PUB) == 0) { ret n; }
         if (!have_self) { ret n; }
-        val mv_o: Option[project.ModuleView] = project.module_view(ws, self_mid);
+        val mv_o: Option[project.ModuleView] = project.module_view(ws, an.root, self_mid);
         if (!is_some[project.ModuleView](mv_o)) { @status = BRIDGE_FAILED; ret n; }
         canon_decl   = features.export_decl_of(unwrap[project.ModuleView](mv_o).rr, sym.name, sym.kind);
         canon_origin = self_mid;
@@ -690,18 +692,18 @@ fun build_refs(ws: *project.Workspace, an: Analyzed, uri: str, sym: *res.Symbol,
     if (canon_decl == id.DECL_NIL) { ret n; }
     @status = BRIDGE_OK;
 
-    val mc: u32 = project.module_count(ws);
+    val mc: u32 = project.module_count(an.root);
     var mid: u32 = 0;
     for (mid < mc && n < cap) {
         val cur: sess.ModuleId = mid::sess.ModuleId;
         if ((have_self && cur == self_mid)
-            || (project_only && !project.is_project_module(ws, cur))) { mid = mid + 1; cnt; }
-        val mv_o: Option[project.ModuleView] = project.module_view(ws, cur);
+            || (project_only && !project.is_project_module(ws, an.root, cur))) { mid = mid + 1; cnt; }
+        val mv_o: Option[project.ModuleView] = project.module_view(ws, an.root, cur);
         if (!is_some[project.ModuleView](mv_o)) { mid = mid + 1; cnt; }
         val mv: project.ModuleView = unwrap[project.ModuleView](mv_o);
         val tgt: res.SymbolId = features.symbol_by_decl(mv.rr, canon_origin, canon_decl);
         if (tgt == res.SYMBOL_NIL) { mid = mid + 1; cnt; }
-        val muri: str = project.module_uri(ws, cur);
+        val muri: str = project.module_uri(ws, an.root, cur);
         if (muri == nil) { mid = mid + 1; cnt; }
         out[n].a      = mv.a;
         out[n].rr     = mv.rr;
@@ -724,17 +726,19 @@ fun free_refs(ws: *project.Workspace, refs: *XRef, n: usize) {
     }
 }
 
-# analyze: resolve the document named by `uri` against the project dependency
-# graph and populate `out` with its session, file, Ast, ResolveResult, and
-# module id. false when the document is unknown or resolution fails. the module
-# id is the workspace's synthetic buffer id, matching the one resolution bound
-# local symbols under, so the local / cross-module distinction holds.
+# analyze: resolve the document named by `uri` against the dependency graph of
+# the project root that governs it and populate `out` with its session, file,
+# Ast, ResolveResult, governing root, and module id. false when the document is
+# unknown or resolution fails. the module id is the root's synthetic buffer id,
+# matching the one resolution bound local symbols under, so the local /
+# cross-module distinction holds.
 fun analyze(ws: *project.Workspace, es: *editor.EditorSession, s: *sess.Session, docs: *documents.Store, uri: str, out: *Analyzed) bool {
     if (uri == nil) { ret false; }
     val doc: *documents.Document = documents.find(docs, uri);
     if (doc == nil) { ret false; }
 
-    val rr_r: Result[*res.ResolveResult, str] = project.resolve_doc(ws, doc.file_id, uri);
+    val root: *project.Root = project.root_for(ws, uri);
+    val rr_r: Result[*res.ResolveResult, str] = project.resolve_doc(ws, root, doc.file_id);
     if (is_err[*res.ResolveResult, str](rr_r)) { ret false; }
     out.rr = unwrap_ok[*res.ResolveResult, str](rr_r);
     out.a  = editor.ast_of(es, doc.file_id);
@@ -744,7 +748,8 @@ fun analyze(ws: *project.Workspace, es: *editor.EditorSession, s: *sess.Session,
     if (!is_some[*src.SourceFile](fo)) { ret false; }
     out.s    = s;
     out.file = unwrap[*src.SourceFile](fo);
-    out.own  = project.own_module(ws, doc.file_id);
+    out.root = root;
+    out.own  = project.own_module(root, doc.file_id);
     ret true;
 }
 

--- a/src/project.mach
+++ b/src/project.mach
@@ -32,9 +32,10 @@
 #
 # invalidation: a root's graph is a load-time snapshot. `invalidate_uri` (driven
 # by `workspace/didChangeWatchedFiles`) drops every root whose tree contains the
-# changed file, so the next request rebuilds it from disk; a conservative
-# manifest/lockfile mtime check on each access reloads even when the client does
-# not deliver watch notifications.
+# changed file, so the next request rebuilds it from disk. when the client does
+# not deliver watch notifications, a conservative manifest/lockfile mtime check
+# on each access reloads a stale root and retries a previously failed one (a
+# since-fixed manifest); with watching active the check is skipped.
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -112,7 +113,8 @@ rec Cached {
 # path:        owned absolute project-root path (the dir holding `mach.toml`)
 # live:        whether this slot holds a tracked root; false slots are reusable
 # loaded:      whether the graph built; a live+!loaded slot is a remembered
-#              failed load, not retried per request until the root is invalidated
+#              failed load, retried only when the root is invalidated or its
+#              manifest / lockfile mtime changes
 # p:           the loaded project graph; valid only when loaded
 # deps:        snapshot of every loaded module's exports, fed to `res.resolve`
 # own_base:    base module id for this root's open buffers, past every loaded
@@ -133,23 +135,27 @@ pub rec Root {
 
 # Workspace: the session's project roots plus the per-buffer resolve cache.
 # ---
-# s:         borrowed compiler session (sources, interner, module registry)
-# es:        borrowed editor session (buffer parsing)
-# alloc:     allocator for owned storage
-# roots:     array of Root slots (live slots are tracked roots)
-# root_cap:  number of slots in `roots`
-# empty:     the empty dep set used for documents outside any project
-# cache:     per-FileId cache of each buffer's dep-aware ResolveResult
-# cache_len: number of slots in `cache`
+# s:            borrowed compiler session (sources, interner, module registry)
+# es:           borrowed editor session (buffer parsing)
+# alloc:        allocator for owned storage
+# roots:        array of Root slots (live slots are tracked roots)
+# root_cap:     number of slots in `roots`
+# watch_active: whether the client delivers workspace/didChangeWatchedFiles for
+#               the registered globs; when true the per-request manifest-mtime
+#               fallback check is skipped (the watcher covers it)
+# empty:        the empty dep set used for documents outside any project
+# cache:        per-FileId cache of each buffer's dep-aware ResolveResult
+# cache_len:    number of slots in `cache`
 pub rec Workspace {
-    s:         *sess.Session;
-    es:        *editor.EditorSession;
-    alloc:     *Allocator;
-    roots:     *Root;
-    root_cap:  u32;
-    empty:     res.ResolveDeps;
-    cache:     *Cached;
-    cache_len: u32;
+    s:            *sess.Session;
+    es:           *editor.EditorSession;
+    alloc:        *Allocator;
+    roots:        *Root;
+    root_cap:     u32;
+    watch_active: bool;
+    empty:        res.ResolveDeps;
+    cache:        *Cached;
+    cache_len:    u32;
 }
 
 # init: construct an empty workspace over the server's sessions.
@@ -165,11 +171,23 @@ pub fun init(s: *sess.Session, es: *editor.EditorSession, alloc: *Allocator) Wor
     w.alloc         = alloc;
     w.roots         = nil;
     w.root_cap      = 0;
+    w.watch_active  = false;
     w.empty.entries = nil;
     w.empty.count   = 0;
     w.cache         = nil;
     w.cache_len     = 0;
     ret w;
+}
+
+# set_watch_active: record that the client delivers
+# workspace/didChangeWatchedFiles for the registered manifest / lockfile /
+# source globs, so invalidation is event-driven and the per-request
+# manifest-mtime fallback check is skipped.
+# ---
+# w:  the workspace
+# on: whether file watching is active
+pub fun set_watch_active(w: *Workspace, on: bool) {
+    w.watch_active = on;
 }
 
 # dnit: release the resolve cache and every loaded root.
@@ -280,22 +298,25 @@ pub fun own_module(root: *Root, fid: src.FileId) sess.ModuleId {
 pub fun root_for(w: *Workspace, uri: str) *Root {
     if (uri == nil) { ret nil; }
     val doc_root: str = document_root(w, uri);
-    if (doc_root != nil) {
-        val existing: *Root = find_root(w, doc_root);
-        if (existing != nil) {
-            strutil.str_free(w.alloc, doc_root);
-            if (!existing.loaded) { ret nil; }
-            maybe_reload(w, existing);
-            if (!existing.loaded) { ret nil; }
-            ret existing;
-        }
-        # not its own project (yet): a dependency of a loaded root resolves there.
-        val twin: *Root = root_containing(w, uri);
-        if (twin != nil) { strutil.str_free(w.alloc, doc_root); ret twin; }
-        ret load_root(w, doc_root);
+
+    # a loaded root rooted elsewhere that holds the document as one of its
+    # modules governs it read-only: a vendored dependency resolves in the
+    # project that depends on it, never as its own project.
+    val twin: *Root = containing_root(w, uri, doc_root);
+    if (twin != nil) {
+        if (doc_root != nil) { strutil.str_free(w.alloc, doc_root); }
+        ret twin;
     }
-    # rootless document: bound to a loaded root only if it is a dependency twin.
-    ret root_containing(w, uri);
+    if (doc_root == nil) { ret nil; }
+
+    val existing: *Root = find_root(w, doc_root);
+    if (existing != nil) {
+        strutil.str_free(w.alloc, doc_root);
+        maybe_reload(w, existing);
+        if (!existing.loaded) { ret nil; }
+        ret existing;
+    }
+    ret load_root(w, doc_root);
 }
 
 # find_root: the live slot whose path equals `root_path`, or nil.
@@ -310,21 +331,28 @@ fun find_root(w: *Workspace, root_path: str) *Root {
     ret nil;
 }
 
-# root_containing: the loaded root whose graph holds the document at `uri` as a
-# module (matched on the normalized filesystem path), or nil. routes a
-# dependency source opened directly to the root that depends on it.
-fun root_containing(w: *Workspace, uri: str) *Root {
+# containing_root: the loaded root whose graph holds the document at `uri` as a
+# module (matched on the normalized filesystem path), skipping the document's
+# own root at `doc_root` (which find_root handles, with its outside-the-closure
+# files resolving against its dep set). a candidate is reload-checked and its
+# containment re-verified before it is handed out, so a twin-routed document
+# does not bypass the staleness check. nil when no other loaded root holds the
+# document.
+fun containing_root(w: *Workspace, uri: str, doc_root: str) *Root {
     if (w.roots == nil) { ret nil; }
+    var found: *Root = nil;
     var i: u32 = 0;
-    for (i < w.root_cap) {
+    for (i < w.root_cap && found == nil) {
         val r: *Root = ?w.roots[i];
-        if (r.live && r.loaded) {
-            val mo: Option[sess.ModuleId] = module_for_uri(w, r, uri);
-            if (is_some[sess.ModuleId](mo)) { ret r; }
+        if (r.live && r.loaded
+            && (doc_root == nil || !str_equals(r.path, doc_root))
+            && is_some[sess.ModuleId](module_for_uri(w, r, uri))) {
+            maybe_reload(w, r);
+            if (r.loaded && is_some[sess.ModuleId](module_for_uri(w, r, uri))) { found = r; }
         }
         i = i + 1;
     }
-    ret nil;
+    ret found;
 }
 
 # load_root: claim a slot for `root_path` (taking ownership of the string) and
@@ -379,11 +407,16 @@ fun alloc_slot(w: *Workspace) *Root {
     ret ?w.roots[old_cap];
 }
 
-# try_load: run build_project for `r.path` and snapshot the dep set into `r`. a
-# failure is surfaced (trace log + window/showMessage) and `r` left as a
-# remembered failed load. on success the whole resolve cache is cleared: results
-# resolved before the load used the empty dep set and the pre-load own_base.
+# try_load: run build_project for `r.path` and snapshot the dep set into `r`.
+# the manifest / lockfile mtimes are recorded at the start of the attempt
+# whether it succeeds or fails, so maybe_reload retries a failed root once those
+# files change instead of pinning the failure for the session. a failure is
+# surfaced (trace log + window/showMessage); on success the whole resolve cache
+# is cleared: results resolved before the load used the empty dep set and the
+# pre-load own_base.
 fun try_load(w: *Workspace, r: *Root) bool {
+    record_mtimes(w, r);
+
     val reg_r: Result[bool, str] = tgt.register_all(?w.s.interner);
     if (is_err[bool, str](reg_r)) {
         report_load_failure(w, r.path, unwrap_err[bool, str](reg_r));
@@ -401,17 +434,20 @@ fun try_load(w: *Workspace, r: *Root) bool {
     r.own_base      = r.p.module_len;
     r.deps.entries  = nil;
     r.deps.count    = 0;
-    record_mtimes(w, r);
     clear_cache(w);
     build_deps(w, r);
     ret true;
 }
 
-# maybe_reload: rebuild `r`'s graph when its manifest or lockfile changed on disk
-# since the load — the conservative fallback for clients that do not deliver
-# `workspace/didChangeWatchedFiles`. a no-op when nothing changed.
+# maybe_reload: rebuild `r`'s graph when its manifest or lockfile changed on
+# disk since the last load attempt — the conservative fallback for clients that
+# do not deliver `workspace/didChangeWatchedFiles`, and the retry path for a
+# root whose previous load failed (a since-fixed manifest). skipped entirely
+# when file watching is active: the watcher already invalidates on those
+# changes, so the per-request stats would be pure overhead. a no-op when
+# nothing changed.
 fun maybe_reload(w: *Workspace, r: *Root) {
-    if (!r.loaded) { ret; }
+    if (w.watch_active) { ret; }
     var man:  i64 = 0;
     var lock: i64 = 0;
     stat_mtimes(w, r.path, ?man, ?lock);

--- a/src/project.mach
+++ b/src/project.mach
@@ -13,11 +13,12 @@
 # multi-root by design: a `Workspace` holds one `Root` per distinct project
 # root open in the session, each with its own `driver.Project`, dep snapshot,
 # and synthetic buffer-id base. a document is routed to the root that governs
-# its path (the nearest ancestor `mach.toml`); a document that is already a
-# dependency module of a loaded root is routed to that root read-only, rather
-# than spun up as its own project; a document under no `mach.toml` resolves
-# single-file (empty dep set). the legacy "one project per session" behaviour
-# is just the one-Root case.
+# its path (the nearest ancestor `mach.toml`); a document that is a dependency
+# module of a root rooted elsewhere — already loaded, or an ancestor project
+# loaded on demand when the document's own root is nested under it — is routed
+# to that root read-only, rather than spun up as its own project; a document
+# under no `mach.toml` resolves single-file (empty dep set). the legacy "one
+# project per session" behaviour is just the one-Root case.
 #
 # module-id namespacing: `driver.build_project` allocates project-local module
 # ids from 0 and writes them into the session's global module registries, so a
@@ -65,6 +66,7 @@ use std.allocator.reallocate;
 use strutil: std.text.string;
 use fs:      std.filesystem;
 use pathlib: std.types.path;
+use toml:    std.data.toml;
 
 use mem: std.memory;
 
@@ -286,11 +288,12 @@ pub fun own_module(root: *Root, fid: src.FileId) sess.ModuleId {
     ret (base + fid::u32)::sess.ModuleId;
 }
 
-# root_for: the root governing the document at `uri`, loading it on first use, or
-# nil when the document resolves single-file (no ancestor `mach.toml`, or a
-# remembered failed load). a document whose own project root is not loaded but
-# which is already a dependency module of a loaded root is routed to that root
-# read-only, rather than spun up as its own project.
+# root_for: the root governing the document at `uri`, loading it on first use,
+# or nil when the document resolves single-file (no ancestor `mach.toml`, or a
+# remembered failed load). a document that is a dependency module of a root
+# rooted elsewhere — whether that root is already loaded, or is an ancestor
+# project loaded here on demand — is routed to that root read-only, rather than
+# spun up as its own project, regardless of document open order.
 # ---
 # w:   the workspace
 # uri: the document's URI
@@ -316,7 +319,107 @@ pub fun root_for(w: *Workspace, uri: str) *Root {
         if (!existing.loaded) { ret nil; }
         ret existing;
     }
+
+    # fresh root: when an ancestor project declares this root as one of its dep
+    # vendor dirs, load that project and prefer it when its graph holds the
+    # document — so a dependency source opened before any project document
+    # still routes read-only instead of becoming its own renameable project.
+    val outer: *Root = ancestor_root(w, uri, doc_root, doc_root);
+    if (outer != nil) { strutil.str_free(w.alloc, doc_root); ret outer; }
+
     ret load_root(w, doc_root);
+}
+
+# ancestor_root: load-and-prefer an outer project for the document at `uri`
+# whose own (fresh) root is `doc_root`. walks the chain of ancestor manifest
+# dirs strictly above `dir` (`doc_root` on the outer call), outermost first; an
+# ancestor is only considered when its manifest declares `doc_root` as one of
+# its dep vendor dirs (`vendors_dir`), so unrelated outer projects — a monorepo
+# root, this repo above its test fixtures — are never speculatively built. the
+# first considered ancestor whose loaded graph holds the document as a module
+# governs it; one that loads but does not hold it stays loaded (it is a real
+# project). ancestors already tracked are skipped: a loaded-and-containing one
+# was already returned by containing_root, and a failed one is not retried
+# here. only the document's direct vendoring project is found — a dep nested
+# inside another dep's tree routes to that dep's root, not the outermost
+# project. nil when no ancestor claims the document.
+fun ancestor_root(w: *Workspace, uri: str, doc_root: str, dir: str) *Root {
+    val par_r: Result[pathlib.Path, str] = pathlib.parent(w.alloc, dir);
+    if (is_err[pathlib.Path, str](par_r)) { ret nil; }
+    val par: str = unwrap_ok[pathlib.Path, str](par_r);
+    if (str_equals(par, dir)) { strutil.str_free(w.alloc, par); ret nil; }
+    val anc: str = project_root_for(w.alloc, par);
+    strutil.str_free(w.alloc, par);
+    if (anc == nil) { ret nil; }
+
+    val above: *Root = ancestor_root(w, uri, doc_root, anc);
+    if (above != nil) { strutil.str_free(w.alloc, anc); ret above; }
+
+    if (find_root(w, anc) != nil || !vendors_dir(w, anc, doc_root)) {
+        strutil.str_free(w.alloc, anc);
+        ret nil;
+    }
+
+    val r: *Root = load_root(w, anc);
+    if (r == nil) { ret nil; }
+    if (is_some[sess.ModuleId](module_for_uri(w, r, uri))) { ret r; }
+    ret nil;
+}
+
+# vendors_dir: whether the project at `root_path` declares a dependency whose
+# vendor dir is `dir` — i.e. `dir` equals `<root>/<[project].dep>/<alias>` for
+# some `[deps.<alias>]`, the same layout the driver's dep resolution reads. one
+# small manifest parse answers "could this project claim that nested root?"
+# without paying a full graph build; the loaded graph remains the authority on
+# actual containment. a manifest that fails to read or parse vendors nothing.
+# the parsed table is leaked into the server's page allocator — std.data.toml
+# exposes no teardown, the same convention the driver's own manifest reads use.
+fun vendors_dir(w: *Workspace, root_path: str, dir: str) bool {
+    val mp_r: Result[pathlib.Path, str] = pathlib.join(w.alloc, root_path, "mach.toml");
+    if (is_err[pathlib.Path, str](mp_r)) { ret false; }
+    val mp: str = unwrap_ok[pathlib.Path, str](mp_r);
+    val text_r: Result[str, str] = fs.read_all(w.alloc, mp);
+    strutil.str_free(w.alloc, mp);
+    if (is_err[str, str](text_r)) { ret false; }
+    val text: str = unwrap_ok[str, str](text_r);
+    val t_r: Result[toml.Table, str] = toml.parse(w.alloc, text);
+    strutil.str_free(w.alloc, text);
+    if (is_err[toml.Table, str](t_r)) { ret false; }
+    var t: toml.Table = unwrap_ok[toml.Table, str](t_r);
+
+    val deps: *toml.Table = toml.get_table(?t, "deps");
+    if (deps == nil) { ret false; }
+    var dir_dep: str = toml.get_str(?t, "project.dep");
+    if (dir_dep == nil) { dir_dep = "dep"; }
+
+    val want: str = normalize_path(w.alloc, dir);
+    if (want == nil) { ret false; }
+
+    var found: bool = false;
+    var i: usize = 0;
+    for (i < toml.table_len(deps) && !found) {
+        val alias: str = toml.table_key(deps, i);
+        if (alias != nil) {
+            val base_r: Result[pathlib.Path, str] = pathlib.join(w.alloc, root_path, dir_dep);
+            if (!is_err[pathlib.Path, str](base_r)) {
+                val base: str = unwrap_ok[pathlib.Path, str](base_r);
+                val cand_r: Result[pathlib.Path, str] = pathlib.join(w.alloc, base, alias);
+                strutil.str_free(w.alloc, base);
+                if (!is_err[pathlib.Path, str](cand_r)) {
+                    val cand: str = unwrap_ok[pathlib.Path, str](cand_r);
+                    val norm: str = normalize_path(w.alloc, cand);
+                    strutil.str_free(w.alloc, cand);
+                    if (norm != nil) {
+                        if (str_equals(norm, want)) { found = true; }
+                        strutil.str_free(w.alloc, norm);
+                    }
+                }
+            }
+        }
+        i = i + 1;
+    }
+    strutil.str_free(w.alloc, want);
+    ret found;
 }
 
 # find_root: the live slot whose path equals `root_path`, or nil.

--- a/src/project.mach
+++ b/src/project.mach
@@ -110,29 +110,35 @@ rec Cached {
 }
 
 # Root: one project root open in the session and the dependency graph built from
-# its manifest's default-target import closure.
+# its manifest's default-target import closure. a slot with a nil path is dead
+# and reusable.
 # ---
-# path:        owned absolute project-root path (the dir holding `mach.toml`)
-# live:        whether this slot holds a tracked root; false slots are reusable
-# loaded:      whether the graph built; a live+!loaded slot is a remembered
-#              failed load, retried only when the root is invalidated or its
-#              manifest / lockfile mtime changes
-# p:           the loaded project graph; valid only when loaded
-# deps:        snapshot of every loaded module's exports, fed to `res.resolve`
-# own_base:    base module id for this root's open buffers, past every loaded
-#              module id, so a buffer's synthetic module id never collides with a
-#              dependency's
-# man_mtime:   `mach.toml` mtime at load, for the conservative reload check
-# lock_mtime:  `mach.lock` mtime at load (0 when absent), same purpose
+# path:           owned absolute project-root path (the dir holding `mach.toml`)
+# loaded:         whether the graph built; a tracked !loaded slot is a remembered
+#                 failed load, retried only when the root is invalidated or its
+#                 manifest / lockfile mtime changes
+# p:              the loaded project graph; valid only when loaded
+# deps:           snapshot of every loaded module's exports, fed to `res.resolve`
+# mod_paths:      owned normalized source path per loaded module (nil entries for
+#                 unreadable / unnormalizable sources), so the per-request
+#                 uri -> module lookups are allocation-free string compares
+# mod_path_count: number of entries in `mod_paths`
+# own_base:       base module id for this root's open buffers, past every loaded
+#                 module id, so a buffer's synthetic module id never collides
+#                 with a dependency's
+# man_mtime:      `mach.toml` mtime at the last load attempt, for the
+#                 conservative reload / retry check
+# lock_mtime:     `mach.lock` mtime at the last load attempt (0 when absent)
 pub rec Root {
-    path:       str;
-    live:       bool;
-    loaded:     bool;
-    p:          driver.Project;
-    deps:       res.ResolveDeps;
-    own_base:   u32;
-    man_mtime:  i64;
-    lock_mtime: i64;
+    path:           str;
+    loaded:         bool;
+    p:              driver.Project;
+    deps:           res.ResolveDeps;
+    mod_paths:      *str;
+    mod_path_count: u32;
+    own_base:       u32;
+    man_mtime:      i64;
+    lock_mtime:     i64;
 }
 
 # Workspace: the session's project roots plus the per-buffer resolve cache.
@@ -140,7 +146,7 @@ pub rec Root {
 # s:            borrowed compiler session (sources, interner, module registry)
 # es:           borrowed editor session (buffer parsing)
 # alloc:        allocator for owned storage
-# roots:        array of Root slots (live slots are tracked roots)
+# roots:        array of Root slots (slots with a path are tracked roots)
 # root_cap:     number of slots in `roots`
 # watch_active: whether the client delivers workspace/didChangeWatchedFiles for
 #               the registered globs; when true the per-request manifest-mtime
@@ -205,7 +211,7 @@ pub fun dnit(w: *Workspace) {
     if (w.roots != nil) {
         var i: u32 = 0;
         for (i < w.root_cap) {
-            if (w.roots[i].live) { free_root(w, ?w.roots[i]); }
+            if (w.roots[i].path != nil) { free_root(w, ?w.roots[i]); }
             i = i + 1;
         }
         deallocate[Root](w.alloc, w.roots, w.root_cap::usize);
@@ -422,13 +428,13 @@ fun vendors_dir(w: *Workspace, root_path: str, dir: str) bool {
     ret found;
 }
 
-# find_root: the live slot whose path equals `root_path`, or nil.
+# find_root: the tracked slot whose path equals `root_path`, or nil.
 fun find_root(w: *Workspace, root_path: str) *Root {
     if (w.roots == nil) { ret nil; }
     var i: u32 = 0;
     for (i < w.root_cap) {
         val r: *Root = ?w.roots[i];
-        if (r.live && r.path != nil && str_equals(r.path, root_path)) { ret r; }
+        if (r.path != nil && str_equals(r.path, root_path)) { ret r; }
         i = i + 1;
     }
     ret nil;
@@ -443,18 +449,21 @@ fun find_root(w: *Workspace, root_path: str) *Root {
 # document.
 fun containing_root(w: *Workspace, uri: str, doc_root: str) *Root {
     if (w.roots == nil) { ret nil; }
+    val norm: str = uri_to_norm(w.alloc, uri);
+    if (norm == nil) { ret nil; }
     var found: *Root = nil;
     var i: u32 = 0;
     for (i < w.root_cap && found == nil) {
         val r: *Root = ?w.roots[i];
-        if (r.live && r.loaded
+        if (r.path != nil && r.loaded
             && (doc_root == nil || !str_equals(r.path, doc_root))
-            && is_some[sess.ModuleId](module_for_uri(w, r, uri))) {
+            && is_some[sess.ModuleId](module_for_norm(r, norm))) {
             maybe_reload(w, r);
-            if (r.loaded && is_some[sess.ModuleId](module_for_uri(w, r, uri))) { found = r; }
+            if (r.loaded && is_some[sess.ModuleId](module_for_norm(r, norm))) { found = r; }
         }
         i = i + 1;
     }
+    strutil.str_free(w.alloc, norm);
     ret found;
 }
 
@@ -464,24 +473,32 @@ fun containing_root(w: *Workspace, uri: str, doc_root: str) *Root {
 fun load_root(w: *Workspace, root_path: str) *Root {
     val slot: *Root = alloc_slot(w);
     if (slot == nil) { strutil.str_free(w.alloc, root_path); ret nil; }
-    slot.live       = true;
-    slot.loaded     = false;
-    slot.path       = root_path;
-    slot.deps.entries = nil;
-    slot.deps.count   = 0;
-    slot.own_base   = 0;
-    slot.man_mtime  = 0;
-    slot.lock_mtime = 0;
+    slot.path = root_path;
     if (try_load(w, slot)) { ret slot; }
     ret nil;
 }
 
-# alloc_slot: a reusable dead slot, growing the array if every slot is live.
-# nil on allocation failure.
+# reset_slot: zero a Root slot's fields, marking it dead and reusable. owned
+# storage must already be released (free_root) or never allocated (a fresh
+# slot).
+fun reset_slot(r: *Root) {
+    r.path           = nil;
+    r.loaded         = false;
+    r.deps.entries   = nil;
+    r.deps.count     = 0;
+    r.mod_paths      = nil;
+    r.mod_path_count = 0;
+    r.own_base       = 0;
+    r.man_mtime      = 0;
+    r.lock_mtime     = 0;
+}
+
+# alloc_slot: a reusable dead slot, growing the array when every slot is
+# tracked. nil on allocation failure.
 fun alloc_slot(w: *Workspace) *Root {
     var i: u32 = 0;
     for (i < w.root_cap) {
-        if (!w.roots[i].live) { ret ?w.roots[i]; }
+        if (w.roots[i].path == nil) { ret ?w.roots[i]; }
         i = i + 1;
     }
     val old_cap: u32 = w.root_cap;
@@ -500,10 +517,7 @@ fun alloc_slot(w: *Workspace) *Root {
     }
     var z: u32 = old_cap;
     for (z < new_cap) {
-        val s: *Root = ?w.roots[z];
-        s.live = false; s.loaded = false; s.path = nil;
-        s.deps.entries = nil; s.deps.count = 0;
-        s.own_base = 0; s.man_mtime = 0; s.lock_mtime = 0;
+        reset_slot(?w.roots[z]);
         z = z + 1;
     }
     w.root_cap = new_cap;
@@ -532,14 +546,50 @@ fun try_load(w: *Workspace, r: *Root) bool {
         ret false;
     }
 
-    r.p             = unwrap_ok[driver.Project, str](pr);
-    r.loaded        = true;
-    r.own_base      = r.p.module_len;
-    r.deps.entries  = nil;
-    r.deps.count    = 0;
+    r.p        = unwrap_ok[driver.Project, str](pr);
+    r.loaded   = true;
+    r.own_base = r.p.module_len;
     clear_cache(w);
+    build_mod_paths(w, r);
     build_deps(w, r);
     ret true;
+}
+
+# build_mod_paths: snapshot every loaded module's normalized source path into
+# `r.mod_paths`, indexed by module id, so the per-request uri -> module lookups
+# are allocation-free string compares. a source that cannot be read or
+# normalized leaves a nil entry, making that module unmatchable by uri (the
+# same outcome the per-request normalization had).
+fun build_mod_paths(w: *Workspace, r: *Root) {
+    val n: u32 = r.p.module_len;
+    if (n == 0) { ret; }
+    val arr_r: Result[*str, str] = allocate[str](w.alloc, n::usize);
+    if (is_err[*str, str](arr_r)) { ret; }
+    r.mod_paths      = unwrap_ok[*str, str](arr_r);
+    r.mod_path_count = n;
+
+    var i: u32 = 0;
+    for (i < n) {
+        r.mod_paths[i] = nil;
+        val fo: Option[*src.SourceFile] = src.get(?w.s.sources, (?r.p.modules[i]).file_id);
+        if (is_some[*src.SourceFile](fo)) {
+            r.mod_paths[i] = normalize_path(w.alloc, unwrap[*src.SourceFile](fo).path);
+        }
+        i = i + 1;
+    }
+}
+
+# free_mod_paths: release the per-module normalized path snapshot.
+fun free_mod_paths(w: *Workspace, r: *Root) {
+    if (r.mod_paths == nil) { ret; }
+    var i: u32 = 0;
+    for (i < r.mod_path_count) {
+        if (r.mod_paths[i] != nil) { strutil.str_free(w.alloc, r.mod_paths[i]); }
+        i = i + 1;
+    }
+    deallocate[str](w.alloc, r.mod_paths, r.mod_path_count::usize);
+    r.mod_paths      = nil;
+    r.mod_path_count = 0;
 }
 
 # maybe_reload: rebuild `r`'s graph when its manifest or lockfile changed on
@@ -570,17 +620,14 @@ fun maybe_reload(w: *Workspace, r: *Root) {
 # uri: the URI of the changed file
 pub fun invalidate_uri(w: *Workspace, uri: str) {
     if (uri == nil || w.roots == nil) { ret; }
-    val path: str = uri_to_path(w.alloc, uri);
-    if (path == nil) { ret; }
-    val norm: str = normalize_path(w.alloc, path);
-    strutil.str_free(w.alloc, path);
+    val norm: str = uri_to_norm(w.alloc, uri);
     if (norm == nil) { ret; }
 
     var changed: bool = false;
     var i: u32 = 0;
     for (i < w.root_cap) {
         val r: *Root = ?w.roots[i];
-        if (r.live && root_covers(w, norm, r.path)) {
+        if (r.path != nil && root_covers(w, norm, r.path)) {
             free_root(w, r);
             changed = true;
         }
@@ -610,19 +657,20 @@ fun is_under(file: str, dir: str) bool {
     ret file[dl] == '/';
 }
 
-# free_root: release a root's graph, dep snapshot, and owned path, marking the
-# slot reusable.
+# free_root: release a root's graph, dep snapshot, and owned path, resetting
+# the slot for reuse.
 fun free_root(w: *Workspace, r: *Root) {
     free_root_graph(w, r);
-    if (r.path != nil) { strutil.str_free(w.alloc, r.path); r.path = nil; }
-    r.live   = false;
-    r.loaded = false;
+    if (r.path != nil) { strutil.str_free(w.alloc, r.path); }
+    reset_slot(r);
 }
 
-# free_root_graph: release a root's dep snapshot and loaded project, leaving the
-# slot live with its path so it can reload in place.
+# free_root_graph: release a root's dep snapshot, module-path snapshot, and
+# loaded project, leaving the slot tracked with its path so it can reload in
+# place.
 fun free_root_graph(w: *Workspace, r: *Root) {
     free_deps(w, ?r.deps);
+    free_mod_paths(w, r);
     if (r.loaded) {
         driver.dnit_project(?r.p);
         r.loaded = false;
@@ -684,22 +732,27 @@ pub fun site_of(w: *Workspace, root: *Root, own: sess.ModuleId, own_a: *ast.Ast,
         ret some[Site](s);
     }
 
-    if (root == nil || !root.loaded || sym.origin::u32 >= root.p.module_len) { ret none[Site](); }
-    val m: *driver.ModuleEntry = ?root.p.modules[sym.origin::u32];
-    val dep_a: *ast.Ast = ?m.a;
+    val m: *driver.ModuleEntry = module_entry(root, sym.origin);
+    if (m == nil) { ret none[Site](); }
     val fo: Option[*src.SourceFile] = src.get(?w.s.sources, m.file_id);
     if (!is_some[*src.SourceFile](fo)) { ret none[Site](); }
-    val dep_file: *src.SourceFile = unwrap[*src.SourceFile](fo);
 
-    val furi: str = file_uri(w.alloc, dep_file.path);
+    val furi: str = module_uri(w, root, sym.origin);
     if (furi == nil) { ret none[Site](); }
 
     var s: Site;
-    s.a     = dep_a;
-    s.file  = dep_file;
+    s.a     = ?m.a;
+    s.file  = unwrap[*src.SourceFile](fo);
     s.uri   = furi;
     s.owned = true;
     ret some[Site](s);
+}
+
+# module_entry: loaded module `mid`'s entry in `root`, or nil when there is no
+# loaded project or the id is out of range.
+fun module_entry(root: *Root, mid: sess.ModuleId) *driver.ModuleEntry {
+    if (root == nil || !root.loaded || mid::u32 >= root.p.module_len) { ret nil; }
+    ret ?root.p.modules[mid::u32];
 }
 
 # free_site: release a Site's URI when it owns one.
@@ -744,9 +797,8 @@ pub fun module_count(root: *Root) u32 {
 # mid:  a loaded module id in [0, module_count)
 # ret:  some(ModuleView), or none
 pub fun module_view(w: *Workspace, root: *Root, mid: sess.ModuleId) Option[ModuleView] {
-    if (root == nil || !root.loaded || mid::u32 >= root.p.module_len) { ret none[ModuleView](); }
-    val m: *driver.ModuleEntry = ?root.p.modules[mid::u32];
-    if (!m.resolved) { ret none[ModuleView](); }
+    val m: *driver.ModuleEntry = module_entry(root, mid);
+    if (m == nil || !m.resolved) { ret none[ModuleView](); }
     val fo: Option[*src.SourceFile] = src.get(?w.s.sources, m.file_id);
     if (!is_some[*src.SourceFile](fo)) { ret none[ModuleView](); }
     var v: ModuleView;
@@ -757,19 +809,17 @@ pub fun module_view(w: *Workspace, root: *Root, mid: sess.ModuleId) Option[Modul
 }
 
 # module_uri: a freshly built, normalized `file://` URI for loaded module `mid`'s
-# source file in `root`, owned by the caller, or nil when there is no project,
-# the id is out of range, or allocation fails.
+# source file in `root` (from the root's path snapshot), owned by the caller, or
+# nil when there is no project, the id is out of range, or allocation fails.
 # ---
 # w:    the workspace
 # root: the root governing the request, or nil
 # mid:  a loaded module id
 # ret:  an owned URI, or nil
 pub fun module_uri(w: *Workspace, root: *Root, mid: sess.ModuleId) str {
-    if (root == nil || !root.loaded || mid::u32 >= root.p.module_len) { ret nil; }
-    val m: *driver.ModuleEntry = ?root.p.modules[mid::u32];
-    val fo: Option[*src.SourceFile] = src.get(?w.s.sources, m.file_id);
-    if (!is_some[*src.SourceFile](fo)) { ret nil; }
-    ret file_uri(w.alloc, unwrap[*src.SourceFile](fo).path);
+    if (root == nil || !root.loaded || mid::u32 >= root.mod_path_count) { ret nil; }
+    if (root.mod_paths[mid::u32] == nil) { ret nil; }
+    ret norm_uri(w.alloc, root.mod_paths[mid::u32]);
 }
 
 # module_for_uri: the loaded module in `root` whose source file is the document
@@ -788,30 +838,26 @@ pub fun module_uri(w: *Workspace, root: *Root, mid: sess.ModuleId) str {
 # ret:  some(ModuleId), or none
 pub fun module_for_uri(w: *Workspace, root: *Root, uri: str) Option[sess.ModuleId] {
     if (root == nil || !root.loaded || uri == nil) { ret none[sess.ModuleId](); }
-    val path: str = uri_to_path(w.alloc, uri);
-    if (path == nil) { ret none[sess.ModuleId](); }
-    val norm: str = normalize_path(w.alloc, path);
-    strutil.str_free(w.alloc, path);
+    val norm: str = uri_to_norm(w.alloc, uri);
     if (norm == nil) { ret none[sess.ModuleId](); }
+    val result: Option[sess.ModuleId] = module_for_norm(root, norm);
+    strutil.str_free(w.alloc, norm);
+    ret result;
+}
 
-    var found:  bool = false;
-    var result: sess.ModuleId = 0::sess.ModuleId;
+# module_for_norm: the loaded module in `root` whose normalized source path
+# equals `norm`, or none. the allocation-free core of module_for_uri, also used
+# where one normalized document path is matched against several roots.
+fun module_for_norm(root: *Root, norm: str) Option[sess.ModuleId] {
+    if (root == nil || !root.loaded || norm == nil) { ret none[sess.ModuleId](); }
     var i: u32 = 0;
-    for (i < root.p.module_len && !found) {
-        val m: *driver.ModuleEntry = ?root.p.modules[i];
-        val fo: Option[*src.SourceFile] = src.get(?w.s.sources, m.file_id);
-        if (is_some[*src.SourceFile](fo)) {
-            val mnorm: str = normalize_path(w.alloc, unwrap[*src.SourceFile](fo).path);
-            if (mnorm != nil) {
-                if (str_equals(mnorm, norm)) { found = true; result = i::sess.ModuleId; }
-                strutil.str_free(w.alloc, mnorm);
-            }
+    for (i < root.mod_path_count) {
+        if (root.mod_paths[i] != nil && str_equals(root.mod_paths[i], norm)) {
+            ret some[sess.ModuleId](i::sess.ModuleId);
         }
         i = i + 1;
     }
-    strutil.str_free(w.alloc, norm);
-    if (!found) { ret none[sess.ModuleId](); }
-    ret some[sess.ModuleId](result);
+    ret none[sess.ModuleId]();
 }
 
 # is_project_module: whether loaded module `mid` in `root` belongs to the user's
@@ -824,8 +870,8 @@ pub fun module_for_uri(w: *Workspace, root: *Root, uri: str) Option[sess.ModuleI
 # mid:  a loaded module id
 # ret:  true for a project-owned module
 pub fun is_project_module(w: *Workspace, root: *Root, mid: sess.ModuleId) bool {
-    if (root == nil || !root.loaded || mid::u32 >= root.p.module_len) { ret false; }
-    val m: *driver.ModuleEntry = ?root.p.modules[mid::u32];
+    val m: *driver.ModuleEntry = module_entry(root, mid);
+    if (m == nil) { ret false; }
     val id_opt:  Option[str] = intern.lookup(?w.s.interner, root.p.config.id);
     val fqn_opt: Option[str] = intern.lookup(?w.s.interner, m.fqn);
     if (!is_some[str](id_opt) || !is_some[str](fqn_opt)) { ret false; }
@@ -852,8 +898,8 @@ fun document_root(w: *Workspace, uri: str) str {
 # report_load_failure: log the loader error and warn the user through
 # window/showMessage so a manifest that fails to load (a malformed or
 # unparseable mach.toml) is distinguishable from "no project found". the slot
-# itself remembers the failure (live + !loaded), so the load is not retried per
-# request.
+# itself remembers the failure (tracked + !loaded), so the load is only retried
+# when the manifest / lockfile changes.
 fun report_load_failure(w: *Workspace, root: str, msg: str) {
     trace.log("project: failed to load project at ");
     trace.log(root);
@@ -1071,6 +1117,16 @@ fun uri_to_path(alloc: *Allocator, uri: str) str {
     ret buf::str;
 }
 
+# uri_to_norm: the normalized filesystem path of a `file://` URI, as an owned
+# string, or nil for a non-file URI / malformed escape / allocation failure.
+fun uri_to_norm(alloc: *Allocator, uri: str) str {
+    val path: str = uri_to_path(alloc, uri);
+    if (path == nil) { ret nil; }
+    val norm: str = normalize_path(alloc, path);
+    strutil.str_free(alloc, path);
+    ret norm;
+}
+
 # hex_val: the value of a hex digit, or -1.
 fun hex_val(c: u8) i64 {
     if (c >= '0' && c <= '9') { ret (c - '0')::i64; }
@@ -1147,24 +1203,20 @@ fun normalize_path(alloc: *Allocator, path: str) str {
     ret buf::str;
 }
 
-# file_uri: a `file://` URI for an absolute filesystem `path`, lexically
-# normalized, owned by the caller, or nil on allocation failure.
-fun file_uri(alloc: *Allocator, path: str) str {
-    val norm: str = normalize_path(alloc, path);
-    if (norm == nil) { ret nil; }
-
+# norm_uri: a `file://` URI for an already-normalized absolute path, owned by
+# the caller, or nil on allocation failure.
+fun norm_uri(alloc: *Allocator, norm: str) str {
     val scheme: str = "file://";
     val plen: usize = str_len(norm);
     val slen: usize = str_len(scheme);
     val total: usize = slen + plen;
     val r: Result[*u8, str] = allocate[u8](alloc, total + 1);
-    if (is_err[*u8, str](r)) { strutil.str_free(alloc, norm); ret nil; }
+    if (is_err[*u8, str](r)) { ret nil; }
     val buf: *u8 = unwrap_ok[*u8, str](r);
     var off: usize = 0;
     off = append(buf, off, scheme);
     off = append(buf, off, norm);
     buf[off] = 0;
-    strutil.str_free(alloc, norm);
     ret buf::str;
 }
 

--- a/src/project.mach
+++ b/src/project.mach
@@ -1,26 +1,40 @@
-# mls.project: the workspace dependency graph that powers cross-module analysis.
+# mls.project: the per-root workspace graphs that power cross-module analysis.
 #
 # the editor surface (`mach.lang.editor`) resolves one buffer in isolation with
 # an empty dependency set, so any symbol imported through a `use` binds to
 # SYMBOL_NIL and go-to-definition / references / hover cannot reach it. this
-# module closes that gap: it loads a project module graph from disk through the
-# compiler's own `driver.build_project` (manifest + lockfile + the `dep/` tree),
-# snapshots every loaded module's public surface into a single
-# `res.ResolveDeps`, and re-resolves an open buffer against that dep set with
-# `res.resolve` directly — the lower-level API the editor's `resolve` wraps.
+# module closes that gap: for each project root open in the session it loads a
+# module graph from disk through the compiler's own `driver.build_project`
+# (manifest + lockfile + the `dep/` tree), snapshots every loaded module's
+# public surface into a `res.ResolveDeps`, and re-resolves an open buffer
+# against that dep set with `res.resolve` directly — the lower-level API the
+# editor's `resolve` wraps.
 #
-# scope is one project per session: the first document whose path sits under a
-# `mach.toml` triggers the load, and that root is remembered. a document with
-# no project root, or under a DIFFERENT root, resolves single-file (empty dep
-# set) — it is never bound to another project's graph. a failed load is
-# surfaced (trace log + window/showMessage) and remembered per root so it is
-# not retried on every request, but a later document under a different root
-# still triggers a fresh load attempt. multi-root support is tracked in #46.
+# multi-root by design: a `Workspace` holds one `Root` per distinct project
+# root open in the session, each with its own `driver.Project`, dep snapshot,
+# and synthetic buffer-id base. a document is routed to the root that governs
+# its path (the nearest ancestor `mach.toml`); a document that is already a
+# dependency module of a loaded root is routed to that root read-only, rather
+# than spun up as its own project; a document under no `mach.toml` resolves
+# single-file (empty dep set). the legacy "one project per session" behaviour
+# is just the one-Root case.
 #
-# the loaded `driver.Project` owns every dependency `Ast`; its module ids are
-# registered on the shared session, so a cross-module symbol's `origin` maps
-# back to the defining module's `Ast` + `SourceFile` and hence to a `file://`
-# location on disk (see `site_of`).
+# module-id namespacing: `driver.build_project` allocates project-local module
+# ids from 0 and writes them into the session's global module registries, so a
+# second build over the same session clobbers the first there. the LSP never
+# reads those session registries — every cross-module lookup (site_of,
+# module_view, ...) reads the per-`Root` `driver.Project.modules` array, whose
+# ids are private to that project. each `Root` is therefore its own id space and
+# several projects coexist in one shared session without collision; per-root
+# sessions are unnecessary. a buffer resolves under a synthetic id past its
+# root's `module_len`, so a buffer-local symbol's `origin` never equals a
+# loaded dependency's.
+#
+# invalidation: a root's graph is a load-time snapshot. `invalidate_uri` (driven
+# by `workspace/didChangeWatchedFiles`) drops every root whose tree contains the
+# changed file, so the next request rebuilds it from disk; a conservative
+# manifest/lockfile mtime check on each access reloads even when the client does
+# not deliver watch notifications.
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -92,64 +106,73 @@ rec Cached {
     a:  *ast.Ast;
 }
 
-# Workspace: the lazily-loaded project graph plus the per-buffer resolve cache.
+# Root: one project root open in the session and the dependency graph built from
+# its manifest's default-target import closure.
 # ---
-# s:           borrowed compiler session (sources, interner, module registry)
-# es:          borrowed editor session (buffer parsing)
-# alloc:       allocator for owned storage
-# has_project: whether a project graph is loaded
-# root:        owned root path of the loaded project; nil when none
-# failed_root: owned root path of the last failed load attempt; nil when none.
-#              prevents re-running build_project per request for a known-bad
-#              root while still allowing a different root to attempt a load
-# p:           the loaded project graph; valid only when has_project
+# path:        owned absolute project-root path (the dir holding `mach.toml`)
+# live:        whether this slot holds a tracked root; false slots are reusable
+# loaded:      whether the graph built; a live+!loaded slot is a remembered
+#              failed load, not retried per request until the root is invalidated
+# p:           the loaded project graph; valid only when loaded
 # deps:        snapshot of every loaded module's exports, fed to `res.resolve`
-# empty:       the empty dep set used for documents outside the loaded project
-# own_base:    base module id for open buffers, past every loaded module id, so a
-#              buffer's synthetic module id never collides with a dependency's
-# cache:       per-FileId cache of each buffer's dep-aware ResolveResult
-# cache_len:   number of slots in `cache`
-pub rec Workspace {
-    s:           *sess.Session;
-    es:          *editor.EditorSession;
-    alloc:       *Allocator;
-    has_project: bool;
-    root:        str;
-    failed_root: str;
-    p:           driver.Project;
-    deps:        res.ResolveDeps;
-    empty:       res.ResolveDeps;
-    own_base:    u32;
-    cache:       *Cached;
-    cache_len:   u32;
+# own_base:    base module id for this root's open buffers, past every loaded
+#              module id, so a buffer's synthetic module id never collides with a
+#              dependency's
+# man_mtime:   `mach.toml` mtime at load, for the conservative reload check
+# lock_mtime:  `mach.lock` mtime at load (0 when absent), same purpose
+pub rec Root {
+    path:       str;
+    live:       bool;
+    loaded:     bool;
+    p:          driver.Project;
+    deps:       res.ResolveDeps;
+    own_base:   u32;
+    man_mtime:  i64;
+    lock_mtime: i64;
 }
 
-# init: construct an unloaded workspace over the server's sessions.
+# Workspace: the session's project roots plus the per-buffer resolve cache.
 # ---
-# s:     compiler session the graph loads into
-# es:    editor session whose buffers are re-resolved against the graph
+# s:         borrowed compiler session (sources, interner, module registry)
+# es:        borrowed editor session (buffer parsing)
+# alloc:     allocator for owned storage
+# roots:     array of Root slots (live slots are tracked roots)
+# root_cap:  number of slots in `roots`
+# empty:     the empty dep set used for documents outside any project
+# cache:     per-FileId cache of each buffer's dep-aware ResolveResult
+# cache_len: number of slots in `cache`
+pub rec Workspace {
+    s:         *sess.Session;
+    es:        *editor.EditorSession;
+    alloc:     *Allocator;
+    roots:     *Root;
+    root_cap:  u32;
+    empty:     res.ResolveDeps;
+    cache:     *Cached;
+    cache_len: u32;
+}
+
+# init: construct an empty workspace over the server's sessions.
+# ---
+# s:     compiler session the graphs load into
+# es:    editor session whose buffers are re-resolved against the graphs
 # alloc: allocator for all workspace-owned storage
-# ret:   an empty, unloaded Workspace
+# ret:   an empty, rootless Workspace
 pub fun init(s: *sess.Session, es: *editor.EditorSession, alloc: *Allocator) Workspace {
     var w: Workspace;
-    w.s           = s;
-    w.es          = es;
-    w.alloc       = alloc;
-    w.has_project = false;
-    w.root        = nil;
-    w.failed_root = nil;
-    w.deps.entries = nil;
-    w.deps.count   = 0;
+    w.s             = s;
+    w.es            = es;
+    w.alloc         = alloc;
+    w.roots         = nil;
+    w.root_cap      = 0;
     w.empty.entries = nil;
     w.empty.count   = 0;
-    w.own_base    = 0;
-    w.cache       = nil;
-    w.cache_len   = 0;
+    w.cache         = nil;
+    w.cache_len     = 0;
     ret w;
 }
 
-# dnit: release the resolve cache, the dep snapshot, the owned roots, and the
-# loaded project.
+# dnit: release the resolve cache and every loaded root.
 # ---
 # w: workspace to tear down; all owned fields are zeroed
 pub fun dnit(w: *Workspace) {
@@ -159,31 +182,28 @@ pub fun dnit(w: *Workspace) {
     }
     w.cache     = nil;
     w.cache_len = 0;
-    free_deps(w);
-    if (w.root != nil)        { strutil.str_free(w.alloc, w.root);        w.root = nil; }
-    if (w.failed_root != nil) { strutil.str_free(w.alloc, w.failed_root); w.failed_root = nil; }
-    if (w.has_project) {
-        driver.dnit_project(?w.p);
-        w.has_project = false;
+    if (w.roots != nil) {
+        var i: u32 = 0;
+        for (i < w.root_cap) {
+            if (w.roots[i].live) { free_root(w, ?w.roots[i]); }
+            i = i + 1;
+        }
+        deallocate[Root](w.alloc, w.roots, w.root_cap::usize);
     }
+    w.roots    = nil;
+    w.root_cap = 0;
 }
 
-# resolve_doc: the buffer's dep-aware ResolveResult. returns the cached result
-# when the buffer's Ast is unchanged since the last resolve; otherwise parses
-# if needed and re-resolves with `res.resolve`. the dep set is the loaded
-# project's when the document sits under its root (triggering the load on
-# first use), and empty otherwise — a document is never resolved against a
-# different project's graph.
+# resolve_doc: the buffer's dep-aware ResolveResult under `root` (nil for a
+# single-file document). returns the cached result when the buffer's Ast is
+# unchanged since the last resolve; otherwise parses if needed and re-resolves
+# with `res.resolve` against the root's dep set (empty when root is nil).
 # ---
-# w:   the workspace
-# fid: FileId of an open editor buffer
-# uri: the document's URI, used to locate its project root
-# ret: a borrowed pointer to the cached ResolveResult, or an error
-pub fun resolve_doc(w: *Workspace, fid: src.FileId, uri: str) Result[*res.ResolveResult, str] {
-    val doc_root: str = document_root(w, uri);
-    val use_proj: bool = use_project_deps(w, doc_root);
-    if (doc_root != nil) { strutil.str_free(w.alloc, doc_root); }
-
+# w:    the workspace
+# root: the root governing the document (from `root_for`), or nil
+# fid:  FileId of an open editor buffer
+# ret:  a borrowed pointer to the cached ResolveResult, or an error
+pub fun resolve_doc(w: *Workspace, root: *Root, fid: src.FileId) Result[*res.ResolveResult, str] {
     var a: *ast.Ast = editor.ast_of(w.es, fid);
     if (a != nil) {
         val hit: *res.ResolveResult = cache_hit(w, fid, a);
@@ -202,15 +222,15 @@ pub fun resolve_doc(w: *Workspace, fid: src.FileId, uri: str) Result[*res.Resolv
     # same way; neutral host defaults outside a project.
     var deps: *res.ResolveDeps = ?w.empty;
     var ctx: comptime.ComptimeCtx;
-    if (use_proj) {
-        deps = ?w.deps;
-        ctx = comptime.init(w.alloc, w.p.target.os_id, w.p.target.arch_id, w.p.target.arch.pointer_width, w.p.compiler_name, w.p.compiler_ver);
+    if (root != nil) {
+        deps = ?root.deps;
+        ctx = comptime.init(w.alloc, root.p.target.os_id, root.p.target.arch_id, root.p.target.arch.pointer_width, root.p.compiler_name, root.p.compiler_ver);
     }
     or {
         ctx = comptime.init(w.alloc, 0, 0, 8, intern.STR_NIL, intern.STR_NIL);
     }
 
-    val own: sess.ModuleId = own_module(w, fid);
+    val own: sess.ModuleId = own_module(root, fid);
     val rr_r: Result[res.ResolveResult, str] = res.resolve(w.s, a, deps, ?ctx, own);
     comptime.dnit(?ctx);
     if (is_err[res.ResolveResult, str](rr_r)) {
@@ -234,31 +254,288 @@ pub fun resolve_doc(w: *Workspace, fid: src.FileId, uri: str) Result[*res.Resolv
     ret ok[*res.ResolveResult, str](slot);
 }
 
-# own_module: the synthetic module id a buffer resolves under. offset past every
-# loaded module id so a buffer-local symbol's `origin` never equals a loaded
-# dependency's, keeping the local/cross-module distinction exact.
+# own_module: the synthetic module id a buffer resolves under for `root`. offset
+# past every loaded module id so a buffer-local symbol's `origin` never equals a
+# loaded dependency's, keeping the local/cross-module distinction exact. base 0
+# for a single-file document (root nil), whose empty dep set has no module ids.
+# ---
+# root: the root governing the buffer, or nil
+# fid:  FileId of the buffer
+# ret:  the buffer's module id for resolution
+pub fun own_module(root: *Root, fid: src.FileId) sess.ModuleId {
+    var base: u32 = 0;
+    if (root != nil) { base = root.own_base; }
+    ret (base + fid::u32)::sess.ModuleId;
+}
+
+# root_for: the root governing the document at `uri`, loading it on first use, or
+# nil when the document resolves single-file (no ancestor `mach.toml`, or a
+# remembered failed load). a document whose own project root is not loaded but
+# which is already a dependency module of a loaded root is routed to that root
+# read-only, rather than spun up as its own project.
 # ---
 # w:   the workspace
-# fid: FileId of the buffer
-# ret: the buffer's module id for resolution
-pub fun own_module(w: *Workspace, fid: src.FileId) sess.ModuleId {
-    ret (w.own_base + fid::u32)::sess.ModuleId;
+# uri: the document's URI
+# ret: a borrowed pointer to the governing Root, or nil
+pub fun root_for(w: *Workspace, uri: str) *Root {
+    if (uri == nil) { ret nil; }
+    val doc_root: str = document_root(w, uri);
+    if (doc_root != nil) {
+        val existing: *Root = find_root(w, doc_root);
+        if (existing != nil) {
+            strutil.str_free(w.alloc, doc_root);
+            if (!existing.loaded) { ret nil; }
+            maybe_reload(w, existing);
+            if (!existing.loaded) { ret nil; }
+            ret existing;
+        }
+        # not its own project (yet): a dependency of a loaded root resolves there.
+        val twin: *Root = root_containing(w, uri);
+        if (twin != nil) { strutil.str_free(w.alloc, doc_root); ret twin; }
+        ret load_root(w, doc_root);
+    }
+    # rootless document: bound to a loaded root only if it is a dependency twin.
+    ret root_containing(w, uri);
+}
+
+# find_root: the live slot whose path equals `root_path`, or nil.
+fun find_root(w: *Workspace, root_path: str) *Root {
+    if (w.roots == nil) { ret nil; }
+    var i: u32 = 0;
+    for (i < w.root_cap) {
+        val r: *Root = ?w.roots[i];
+        if (r.live && r.path != nil && str_equals(r.path, root_path)) { ret r; }
+        i = i + 1;
+    }
+    ret nil;
+}
+
+# root_containing: the loaded root whose graph holds the document at `uri` as a
+# module (matched on the normalized filesystem path), or nil. routes a
+# dependency source opened directly to the root that depends on it.
+fun root_containing(w: *Workspace, uri: str) *Root {
+    if (w.roots == nil) { ret nil; }
+    var i: u32 = 0;
+    for (i < w.root_cap) {
+        val r: *Root = ?w.roots[i];
+        if (r.live && r.loaded) {
+            val mo: Option[sess.ModuleId] = module_for_uri(w, r, uri);
+            if (is_some[sess.ModuleId](mo)) { ret r; }
+        }
+        i = i + 1;
+    }
+    ret nil;
+}
+
+# load_root: claim a slot for `root_path` (taking ownership of the string) and
+# build its graph. on failure the slot is kept as a remembered failed load and
+# nil is returned; on success the loaded Root pointer is returned.
+fun load_root(w: *Workspace, root_path: str) *Root {
+    val slot: *Root = alloc_slot(w);
+    if (slot == nil) { strutil.str_free(w.alloc, root_path); ret nil; }
+    slot.live       = true;
+    slot.loaded     = false;
+    slot.path       = root_path;
+    slot.deps.entries = nil;
+    slot.deps.count   = 0;
+    slot.own_base   = 0;
+    slot.man_mtime  = 0;
+    slot.lock_mtime = 0;
+    if (try_load(w, slot)) { ret slot; }
+    ret nil;
+}
+
+# alloc_slot: a reusable dead slot, growing the array if every slot is live.
+# nil on allocation failure.
+fun alloc_slot(w: *Workspace) *Root {
+    var i: u32 = 0;
+    for (i < w.root_cap) {
+        if (!w.roots[i].live) { ret ?w.roots[i]; }
+        i = i + 1;
+    }
+    val old_cap: u32 = w.root_cap;
+    var new_cap: u32 = old_cap;
+    if (new_cap == 0) { new_cap = 4; }
+    or                { new_cap = new_cap * 2; }
+    if (w.roots == nil) {
+        val r: Result[*Root, str] = allocate[Root](w.alloc, new_cap::usize);
+        if (is_err[*Root, str](r)) { ret nil; }
+        w.roots = unwrap_ok[*Root, str](r);
+    }
+    or {
+        val r: Result[*Root, str] = reallocate[Root](w.alloc, w.roots, old_cap::usize, new_cap::usize);
+        if (is_err[*Root, str](r)) { ret nil; }
+        w.roots = unwrap_ok[*Root, str](r);
+    }
+    var z: u32 = old_cap;
+    for (z < new_cap) {
+        val s: *Root = ?w.roots[z];
+        s.live = false; s.loaded = false; s.path = nil;
+        s.deps.entries = nil; s.deps.count = 0;
+        s.own_base = 0; s.man_mtime = 0; s.lock_mtime = 0;
+        z = z + 1;
+    }
+    w.root_cap = new_cap;
+    ret ?w.roots[old_cap];
+}
+
+# try_load: run build_project for `r.path` and snapshot the dep set into `r`. a
+# failure is surfaced (trace log + window/showMessage) and `r` left as a
+# remembered failed load. on success the whole resolve cache is cleared: results
+# resolved before the load used the empty dep set and the pre-load own_base.
+fun try_load(w: *Workspace, r: *Root) bool {
+    val reg_r: Result[bool, str] = tgt.register_all(?w.s.interner);
+    if (is_err[bool, str](reg_r)) {
+        report_load_failure(w, r.path, unwrap_err[bool, str](reg_r));
+        ret false;
+    }
+
+    val pr: Result[driver.Project, str] = driver.build_project(w.s, r.path, "");
+    if (is_err[driver.Project, str](pr)) {
+        report_load_failure(w, r.path, unwrap_err[driver.Project, str](pr));
+        ret false;
+    }
+
+    r.p             = unwrap_ok[driver.Project, str](pr);
+    r.loaded        = true;
+    r.own_base      = r.p.module_len;
+    r.deps.entries  = nil;
+    r.deps.count    = 0;
+    record_mtimes(w, r);
+    clear_cache(w);
+    build_deps(w, r);
+    ret true;
+}
+
+# maybe_reload: rebuild `r`'s graph when its manifest or lockfile changed on disk
+# since the load — the conservative fallback for clients that do not deliver
+# `workspace/didChangeWatchedFiles`. a no-op when nothing changed.
+fun maybe_reload(w: *Workspace, r: *Root) {
+    if (!r.loaded) { ret; }
+    var man:  i64 = 0;
+    var lock: i64 = 0;
+    stat_mtimes(w, r.path, ?man, ?lock);
+    if (man == r.man_mtime && lock == r.lock_mtime) { ret; }
+    free_root_graph(w, r);
+    clear_cache(w);
+    try_load(w, r);
+}
+
+# invalidate_uri: drop every loaded root whose tree contains the changed file, so
+# the next request rebuilds it from disk. the LSP trigger is
+# `workspace/didChangeWatchedFiles`; a changed `mach.toml` / `mach.lock` or any
+# source under a root (including a vendored dependency under `dep/`) invalidates
+# that root. the resolve cache is cleared when any root is dropped.
+# ---
+# w:   the workspace
+# uri: the URI of the changed file
+pub fun invalidate_uri(w: *Workspace, uri: str) {
+    if (uri == nil || w.roots == nil) { ret; }
+    val path: str = uri_to_path(w.alloc, uri);
+    if (path == nil) { ret; }
+    val norm: str = normalize_path(w.alloc, path);
+    strutil.str_free(w.alloc, path);
+    if (norm == nil) { ret; }
+
+    var changed: bool = false;
+    var i: u32 = 0;
+    for (i < w.root_cap) {
+        val r: *Root = ?w.roots[i];
+        if (r.live && root_covers(w, norm, r.path)) {
+            free_root(w, r);
+            changed = true;
+        }
+        i = i + 1;
+    }
+    strutil.str_free(w.alloc, norm);
+    if (changed) { clear_cache(w); }
+}
+
+# root_covers: whether `file_norm` (a normalized absolute path) lies within the
+# project rooted at `root_path` — equal to it or under it.
+fun root_covers(w: *Workspace, file_norm: str, root_path: str) bool {
+    if (root_path == nil) { ret false; }
+    val rn: str = normalize_path(w.alloc, root_path);
+    if (rn == nil) { ret false; }
+    val covered: bool = is_under(file_norm, rn);
+    strutil.str_free(w.alloc, rn);
+    ret covered;
+}
+
+# is_under: whether `file` equals `dir` or is a path beneath it.
+fun is_under(file: str, dir: str) bool {
+    val dl: usize = str_len(dir);
+    val fl: usize = str_len(file);
+    if (fl < dl || !str_starts_with(file, dir)) { ret false; }
+    if (fl == dl) { ret true; }
+    ret file[dl] == '/';
+}
+
+# free_root: release a root's graph, dep snapshot, and owned path, marking the
+# slot reusable.
+fun free_root(w: *Workspace, r: *Root) {
+    free_root_graph(w, r);
+    if (r.path != nil) { strutil.str_free(w.alloc, r.path); r.path = nil; }
+    r.live   = false;
+    r.loaded = false;
+}
+
+# free_root_graph: release a root's dep snapshot and loaded project, leaving the
+# slot live with its path so it can reload in place.
+fun free_root_graph(w: *Workspace, r: *Root) {
+    free_deps(w, ?r.deps);
+    if (r.loaded) {
+        driver.dnit_project(?r.p);
+        r.loaded = false;
+    }
+}
+
+# record_mtimes: snapshot the root's manifest / lockfile mtimes for the
+# conservative reload check.
+fun record_mtimes(w: *Workspace, r: *Root) {
+    stat_mtimes(w, r.path, ?r.man_mtime, ?r.lock_mtime);
+}
+
+# stat_mtimes: write the mtimes of `<root_path>/mach.toml` and
+# `<root_path>/mach.lock` (0 when absent) into `man` / `lock`.
+fun stat_mtimes(w: *Workspace, root_path: str, man: *i64, lock: *i64) {
+    @man  = join_mtime(w.alloc, root_path, "mach.toml");
+    @lock = join_mtime(w.alloc, root_path, "mach.lock");
+}
+
+# join_mtime: the mtime of `<dir>/<name>`, or 0 when the file is absent or
+# cannot be joined.
+fun join_mtime(alloc: *Allocator, dir: str, name: str) i64 {
+    val jr: Result[pathlib.Path, str] = pathlib.join(alloc, dir, name);
+    if (is_err[pathlib.Path, str](jr)) { ret 0; }
+    val p: str = unwrap_ok[pathlib.Path, str](jr);
+    var m: i64 = 0;
+    val fi_r: Result[fs.FileInfo, str] = fs.info_path(p);
+    if (!is_err[fs.FileInfo, str](fi_r)) {
+        var fi: fs.FileInfo = unwrap_ok[fs.FileInfo, str](fi_r);
+        m = fi.modified;
+    }
+    strutil.str_free(alloc, p);
+    ret m;
 }
 
 # site_of: where symbol `sym` is declared, as an Ast / SourceFile / URI triple.
 # a buffer-local symbol (origin equals the buffer's module) reports against the
 # request buffer; a cross-module symbol reports against the defining dependency
-# module's on-disk file, with a freshly built `file://` URI the caller must free
-# (see `free_site`). none when a cross-module symbol's module is unregistered.
+# module's on-disk file, read from `root`'s own project module array (whose ids
+# are private to that root), with a freshly built `file://` URI the caller must
+# free (see `free_site`). none when there is no project, or the defining module
+# cannot be located.
 # ---
 # w:       the workspace
+# root:    the root the buffer resolved against, or nil
 # own:     the buffer's own module id
 # own_a:   the buffer's Ast
 # own_file:the buffer's SourceFile
 # uri:     the request document's URI
 # sym:     the symbol whose declaration site is wanted
 # ret:     some(Site), or none when the defining module cannot be located
-pub fun site_of(w: *Workspace, own: sess.ModuleId, own_a: *ast.Ast, own_file: *src.SourceFile, uri: str, sym: *res.Symbol) Option[Site] {
+pub fun site_of(w: *Workspace, root: *Root, own: sess.ModuleId, own_a: *ast.Ast, own_file: *src.SourceFile, uri: str, sym: *res.Symbol) Option[Site] {
     if (sym.origin == own) {
         var s: Site;
         s.a     = own_a;
@@ -268,9 +545,10 @@ pub fun site_of(w: *Workspace, own: sess.ModuleId, own_a: *ast.Ast, own_file: *s
         ret some[Site](s);
     }
 
-    val dep_a: *ast.Ast = sess.module_ast(w.s, sym.origin);
-    if (dep_a == nil) { ret none[Site](); }
-    val fo: Option[*src.SourceFile] = src.get(?w.s.sources, dep_a.file_id);
+    if (root == nil || !root.loaded || sym.origin::u32 >= root.p.module_len) { ret none[Site](); }
+    val m: *driver.ModuleEntry = ?root.p.modules[sym.origin::u32];
+    val dep_a: *ast.Ast = ?m.a;
+    val fo: Option[*src.SourceFile] = src.get(?w.s.sources, m.file_id);
     if (!is_some[*src.SourceFile](fo)) { ret none[Site](); }
     val dep_file: *src.SourceFile = unwrap[*src.SourceFile](fo);
 
@@ -307,26 +585,28 @@ pub rec ModuleView {
     file: *src.SourceFile;
 }
 
-# module_count: the number of loaded project modules, or 0 when no project is
-# loaded. the workspace-wide references / rename walk iterates [0, count).
+# module_count: the number of loaded modules in `root`, or 0 when root is nil /
+# not loaded. the workspace-wide references / rename walk iterates [0, count).
 # ---
-# w:   the workspace
-# ret: the loaded module count
-pub fun module_count(w: *Workspace) u32 {
-    if (!w.has_project) { ret 0; }
-    ret w.p.module_len;
+# root: the root governing the request, or nil
+# ret:  the loaded module count
+pub fun module_count(root: *Root) u32 {
+    if (root == nil || !root.loaded) { ret 0; }
+    ret root.p.module_len;
 }
 
-# module_view: a borrowed view of loaded module `mid` for the use-site walk, or
-# none when the id is out of range, the module did not resolve, or its source is
-# missing. the returned pointers are owned by the loaded project / session.
+# module_view: a borrowed view of loaded module `mid` in `root` for the use-site
+# walk, or none when there is no project, the id is out of range, the module did
+# not resolve, or its source is missing. the returned pointers are owned by the
+# loaded project / session.
 # ---
-# w:   the workspace
-# mid: a loaded module id in [0, module_count)
-# ret: some(ModuleView), or none
-pub fun module_view(w: *Workspace, mid: sess.ModuleId) Option[ModuleView] {
-    if (!w.has_project || mid::u32 >= w.p.module_len) { ret none[ModuleView](); }
-    val m: *driver.ModuleEntry = ?w.p.modules[mid::u32];
+# w:    the workspace
+# root: the root governing the request, or nil
+# mid:  a loaded module id in [0, module_count)
+# ret:  some(ModuleView), or none
+pub fun module_view(w: *Workspace, root: *Root, mid: sess.ModuleId) Option[ModuleView] {
+    if (root == nil || !root.loaded || mid::u32 >= root.p.module_len) { ret none[ModuleView](); }
+    val m: *driver.ModuleEntry = ?root.p.modules[mid::u32];
     if (!m.resolved) { ret none[ModuleView](); }
     val fo: Option[*src.SourceFile] = src.get(?w.s.sources, m.file_id);
     if (!is_some[*src.SourceFile](fo)) { ret none[ModuleView](); }
@@ -338,36 +618,37 @@ pub fun module_view(w: *Workspace, mid: sess.ModuleId) Option[ModuleView] {
 }
 
 # module_uri: a freshly built, normalized `file://` URI for loaded module `mid`'s
-# source file, owned by the caller, or nil when the id is out of range / on
-# allocation failure.
+# source file in `root`, owned by the caller, or nil when there is no project,
+# the id is out of range, or allocation fails.
 # ---
-# w:   the workspace
-# mid: a loaded module id
-# ret: an owned URI, or nil
-pub fun module_uri(w: *Workspace, mid: sess.ModuleId) str {
-    if (!w.has_project || mid::u32 >= w.p.module_len) { ret nil; }
-    val m: *driver.ModuleEntry = ?w.p.modules[mid::u32];
+# w:    the workspace
+# root: the root governing the request, or nil
+# mid:  a loaded module id
+# ret:  an owned URI, or nil
+pub fun module_uri(w: *Workspace, root: *Root, mid: sess.ModuleId) str {
+    if (root == nil || !root.loaded || mid::u32 >= root.p.module_len) { ret nil; }
+    val m: *driver.ModuleEntry = ?root.p.modules[mid::u32];
     val fo: Option[*src.SourceFile] = src.get(?w.s.sources, m.file_id);
     if (!is_some[*src.SourceFile](fo)) { ret nil; }
     ret file_uri(w.alloc, unwrap[*src.SourceFile](fo).path);
 }
 
-# module_for_uri: the loaded module whose source file is the document at `uri`
-# (matched on the normalized filesystem path), or none. lets the workspace walk
-# skip the active buffer's on-disk twin, whose live edits the buffer's own
-# resolve already covers, so its references are not counted twice. matching is
-# lexical (`.` / `..` collapse only): the std fs surface exposes neither
-# realpath nor inode identity, so a buffer opened through a symlinked or
+# module_for_uri: the loaded module in `root` whose source file is the document
+# at `uri` (matched on the normalized filesystem path), or none. lets the
+# workspace walk skip the active buffer's on-disk twin, whose live edits the
+# buffer's own resolve already covers, so its references are not counted twice.
+# matching is lexical (`.` / `..` collapse only): the std fs surface exposes
+# neither realpath nor inode identity, so a buffer opened through a symlinked or
 # differently-cased path does not match its twin and that file is walked as a
-# separate module — yielding duplicate locations / a duplicate WorkspaceEdit
-# key for the same physical file. such documents normally fail the
-# project-root gate and resolve single-file, which keeps the window narrow.
+# separate module — yielding duplicate locations / a duplicate WorkspaceEdit key
+# for the same physical file.
 # ---
-# w:   the workspace
-# uri: a document URI
-# ret: some(ModuleId), or none
-pub fun module_for_uri(w: *Workspace, uri: str) Option[sess.ModuleId] {
-    if (!w.has_project || uri == nil) { ret none[sess.ModuleId](); }
+# w:    the workspace
+# root: the root governing the request, or nil
+# uri:  a document URI
+# ret:  some(ModuleId), or none
+pub fun module_for_uri(w: *Workspace, root: *Root, uri: str) Option[sess.ModuleId] {
+    if (root == nil || !root.loaded || uri == nil) { ret none[sess.ModuleId](); }
     val path: str = uri_to_path(w.alloc, uri);
     if (path == nil) { ret none[sess.ModuleId](); }
     val norm: str = normalize_path(w.alloc, path);
@@ -377,8 +658,8 @@ pub fun module_for_uri(w: *Workspace, uri: str) Option[sess.ModuleId] {
     var found:  bool = false;
     var result: sess.ModuleId = 0::sess.ModuleId;
     var i: u32 = 0;
-    for (i < w.p.module_len && !found) {
-        val m: *driver.ModuleEntry = ?w.p.modules[i];
+    for (i < root.p.module_len && !found) {
+        val m: *driver.ModuleEntry = ?root.p.modules[i];
         val fo: Option[*src.SourceFile] = src.get(?w.s.sources, m.file_id);
         if (is_some[*src.SourceFile](fo)) {
             val mnorm: str = normalize_path(w.alloc, unwrap[*src.SourceFile](fo).path);
@@ -394,18 +675,19 @@ pub fun module_for_uri(w: *Workspace, uri: str) Option[sess.ModuleId] {
     ret some[sess.ModuleId](result);
 }
 
-# is_project_module: whether loaded module `mid` belongs to the user's own
-# project rather than a vendored dependency — true iff its fully-qualified path's
-# head segment is the project id. rename gates cross-file edits on it so a
+# is_project_module: whether loaded module `mid` in `root` belongs to the user's
+# own project rather than a vendored dependency — true iff its fully-qualified
+# path's head segment is the project id. rename gates cross-file edits on it so a
 # dependency's declaration (e.g. a std symbol) is never rewritten.
 # ---
-# w:   the workspace
-# mid: a loaded module id
-# ret: true for a project-owned module
-pub fun is_project_module(w: *Workspace, mid: sess.ModuleId) bool {
-    if (!w.has_project || mid::u32 >= w.p.module_len) { ret false; }
-    val m: *driver.ModuleEntry = ?w.p.modules[mid::u32];
-    val id_opt:  Option[str] = intern.lookup(?w.s.interner, w.p.config.id);
+# w:    the workspace
+# root: the root governing the request, or nil
+# mid:  a loaded module id
+# ret:  true for a project-owned module
+pub fun is_project_module(w: *Workspace, root: *Root, mid: sess.ModuleId) bool {
+    if (root == nil || !root.loaded || mid::u32 >= root.p.module_len) { ret false; }
+    val m: *driver.ModuleEntry = ?root.p.modules[mid::u32];
+    val id_opt:  Option[str] = intern.lookup(?w.s.interner, root.p.config.id);
     val fqn_opt: Option[str] = intern.lookup(?w.s.interner, m.fqn);
     if (!is_some[str](id_opt) || !is_some[str](fqn_opt)) { ret false; }
     val pid: str = unwrap[str](id_opt);
@@ -428,62 +710,12 @@ fun document_root(w: *Workspace, uri: str) str {
     ret root;
 }
 
-# use_project_deps: whether the document under `doc_root` resolves against the
-# loaded project graph. triggers the load when no project is loaded yet and the
-# root has not already failed. a document with no root, or under a different
-# root than the loaded project's, resolves single-file (multi-root is #46).
-fun use_project_deps(w: *Workspace, doc_root: str) bool {
-    if (doc_root == nil) { ret false; }
-    if (w.has_project) {
-        if (str_equals(doc_root, w.root)) { ret true; }
-        trace.log("project: document outside the loaded project root, resolving single-file\n");
-        ret false;
-    }
-    if (w.failed_root != nil && str_equals(doc_root, w.failed_root)) { ret false; }
-    ret try_load(w, doc_root);
-}
-
-# try_load: run build_project for `root` and snapshot the dep set. a failure is
-# surfaced (trace log + window/showMessage) and the root remembered so it is
-# not retried per request. on success the resolve cache is cleared: results
-# resolved before the load used the empty dep set and the pre-load own_base.
-fun try_load(w: *Workspace, root: str) bool {
-    val reg_r: Result[bool, str] = tgt.register_all(?w.s.interner);
-    if (is_err[bool, str](reg_r)) {
-        report_load_failure(w, root, unwrap_err[bool, str](reg_r));
-        ret false;
-    }
-
-    val pr: Result[driver.Project, str] = driver.build_project(w.s, root, "");
-    if (is_err[driver.Project, str](pr)) {
-        report_load_failure(w, root, unwrap_err[driver.Project, str](pr));
-        ret false;
-    }
-
-    val dup_r: Result[str, str] = strutil.str_dup(w.alloc, root);
-    if (is_err[str, str](dup_r)) {
-        var p: driver.Project = unwrap_ok[driver.Project, str](pr);
-        driver.dnit_project(?p);
-        ret false;
-    }
-
-    w.p           = unwrap_ok[driver.Project, str](pr);
-    w.has_project = true;
-    w.root        = unwrap_ok[str, str](dup_r);
-    w.own_base    = w.p.module_len;
-    clear_cache(w);
-    build_deps(w);
-    ret true;
-}
-
-# report_load_failure: record `root` as failed, log the loader error, and warn
-# the user through window/showMessage so a manifest that fails to load (a
-# malformed or unparseable mach.toml) is distinguishable from "no project found".
+# report_load_failure: log the loader error and warn the user through
+# window/showMessage so a manifest that fails to load (a malformed or
+# unparseable mach.toml) is distinguishable from "no project found". the slot
+# itself remembers the failure (live + !loaded), so the load is not retried per
+# request.
 fun report_load_failure(w: *Workspace, root: str, msg: str) {
-    if (w.failed_root != nil) { strutil.str_free(w.alloc, w.failed_root); w.failed_root = nil; }
-    val dup_r: Result[str, str] = strutil.str_dup(w.alloc, root);
-    if (!is_err[str, str](dup_r)) { w.failed_root = unwrap_ok[str, str](dup_r); }
-
     trace.log("project: failed to load project at ");
     trace.log(root);
     trace.log(": ");
@@ -528,32 +760,32 @@ fun show_warning(w: *Workspace, text: str) {
     json.free_str(qmsg, w.alloc);
 }
 
-# build_deps: snapshot every loaded module's public surface into `w.deps`, one
+# build_deps: snapshot every loaded module's public surface into `r.deps`, one
 # ModuleExports per module keyed by FQN. mirrors the driver's per-module
 # dependency assembly but spans the whole graph, so a buffer's `use` of any
 # loaded module binds. modules with no exports contribute an empty entry.
-fun build_deps(w: *Workspace) {
-    val n: u32 = w.p.module_len;
+fun build_deps(w: *Workspace, r: *Root) {
+    val n: u32 = r.p.module_len;
     if (n == 0) { ret; }
-    val r: Result[*res.ModuleExports, str] = allocate[res.ModuleExports](w.alloc, n::usize);
-    if (is_err[*res.ModuleExports, str](r)) { ret; }
-    w.deps.entries = unwrap_ok[*res.ModuleExports, str](r);
-    w.deps.count   = n;
+    val res_r: Result[*res.ModuleExports, str] = allocate[res.ModuleExports](w.alloc, n::usize);
+    if (is_err[*res.ModuleExports, str](res_r)) { ret; }
+    r.deps.entries = unwrap_ok[*res.ModuleExports, str](res_r);
+    r.deps.count   = n;
 
     var i: u32 = 0;
     for (i < n) {
-        w.deps.entries[i] = module_exports(w, i::sess.ModuleId);
+        r.deps.entries[i] = module_exports(w, r, i::sess.ModuleId);
         i = i + 1;
     }
 }
 
-# module_exports: the public surface of loaded module `mid` as a ModuleExports,
-# copying each pub symbol's (kind, name, decl, slot, origin) so resolve can bind
-# a cross-module reference to the declaring module's Ast. this must track the
-# driver's private build_module_exports field-for-field; the driver helper
-# remained private through the #45 dep bump, so the copy stays.
-fun module_exports(w: *Workspace, mid: sess.ModuleId) res.ModuleExports {
-    val m: *driver.ModuleEntry = ?w.p.modules[mid::u32];
+# module_exports: the public surface of loaded module `mid` in `root` as a
+# ModuleExports, copying each pub symbol's (kind, name, decl, slot, origin) so
+# resolve can bind a cross-module reference to the declaring module's Ast. this
+# must track the driver's private build_module_exports field-for-field; the
+# driver helper remained private through the #45 dep bump, so the copy stays.
+fun module_exports(w: *Workspace, root: *Root, mid: sess.ModuleId) res.ModuleExports {
+    val m: *driver.ModuleEntry = ?root.p.modules[mid::u32];
     var mx: res.ModuleExports;
     mx.path    = m.fqn;
     mx.module  = mid;
@@ -583,21 +815,21 @@ fun module_exports(w: *Workspace, mid: sess.ModuleId) res.ModuleExports {
     ret mx;
 }
 
-# free_deps: release the dep snapshot's per-module symbol arrays and the entry
-# array.
-fun free_deps(w: *Workspace) {
-    if (w.deps.entries == nil) { ret; }
+# free_deps: release a dep snapshot's per-module symbol arrays and the entry
+# array, zeroing it.
+fun free_deps(w: *Workspace, deps: *res.ResolveDeps) {
+    if (deps.entries == nil) { ret; }
     var i: u32 = 0;
-    for (i < w.deps.count) {
-        val mx: *res.ModuleExports = ?w.deps.entries[i];
+    for (i < deps.count) {
+        val mx: *res.ModuleExports = ?deps.entries[i];
         if (mx.symbols != nil && mx.count > 0) {
             deallocate[res.PublicSymbol](w.alloc, mx.symbols, mx.count::usize);
         }
         i = i + 1;
     }
-    deallocate[res.ModuleExports](w.alloc, w.deps.entries, w.deps.count::usize);
-    w.deps.entries = nil;
-    w.deps.count   = 0;
+    deallocate[res.ModuleExports](w.alloc, deps.entries, deps.count::usize);
+    deps.entries = nil;
+    deps.count   = 0;
 }
 
 # cache_hit: the cached ResolveResult for `fid` when it was resolved from the

--- a/src/server.mach
+++ b/src/server.mach
@@ -46,21 +46,24 @@ pub val STATUS_EXITED:        u8 = 3;
 
 # Server: the long-lived server state.
 # ---
-# status:    current lifecycle phase
-# exit_code: process exit code to return from `run`
-# alloc:     allocator backing all server-owned memory
-# s:         compiler session (SourceMap + DiagList)
-# es:        editor session over `s` (per-buffer analysis)
-# docs:      URI -> editor buffer registry
-# ws:        project dependency graph backing cross-module analysis
+# status:        current lifecycle phase
+# exit_code:     process exit code to return from `run`
+# alloc:         allocator backing all server-owned memory
+# s:             compiler session (SourceMap + DiagList)
+# es:            editor session over `s` (per-buffer analysis)
+# docs:          URI -> editor buffer registry
+# ws:            per-root project graphs backing cross-module analysis
+# watch_dynamic: whether the client supports dynamic file-watch registration
+#                (`workspace/didChangeWatchedFiles`), advertised at initialize
 pub rec Server {
-    status:    u8;
-    exit_code: i64;
-    alloc:     *Allocator;
-    s:         sess.Session;
-    es:        editor.EditorSession;
-    docs:      documents.Store;
-    ws:        project.Workspace;
+    status:        u8;
+    exit_code:     i64;
+    alloc:         *Allocator;
+    s:             sess.Session;
+    es:            editor.EditorSession;
+    docs:          documents.Store;
+    ws:            project.Workspace;
+    watch_dynamic: bool;
 }
 
 # init: build a server over the given allocator.
@@ -72,6 +75,7 @@ pub fun init(srv: *Server, alloc: *Allocator) bool {
     srv.status = STATUS_UNINITIALIZED;
     srv.exit_code = 0;
     srv.alloc = alloc;
+    srv.watch_dynamic = false;
 
     val sr: Result[sess.Session, str] = sess.init(alloc);
     if (is_err[sess.Session, str](sr)) { ret false; }
@@ -140,6 +144,7 @@ fun dispatch(srv: *Server, msg: *transport.Message) {
     }
     if (str_equals(method, "initialized")) {
         json.free_str(method, srv.alloc);
+        handle_initialized(srv);
         ret;
     }
     if (str_equals(method, "shutdown")) {
@@ -176,6 +181,11 @@ fun dispatch(srv: *Server, msg: *transport.Message) {
     }
     if (str_equals(method, "textDocument/didSave")) {
         json.free_str(method, srv.alloc);
+        ret;
+    }
+    if (str_equals(method, "workspace/didChangeWatchedFiles")) {
+        json.free_str(method, srv.alloc);
+        handle_did_change_watched_files(srv, body);
         ret;
     }
 
@@ -228,6 +238,10 @@ fun handle_initialize(srv: *Server, body: str) {
     val id: str = json.extract_raw(body, "\"id\"", srv.alloc);
     if (id == nil) { ret; }
 
+    # remember whether the client can accept a dynamic watch registration, so
+    # `initialized` only sends one when it will be honoured.
+    srv.watch_dynamic = json.extract_bool_after(body, "\"didChangeWatchedFiles\"", "\"dynamicRegistration\"", srv.alloc);
+
     val prefix: str = "{\"jsonrpc\":\"2.0\",\"id\":";
     val result: str = ",\"result\":{\"capabilities\":{\"textDocumentSync\":1,\"hoverProvider\":true,\"definitionProvider\":true,\"referencesProvider\":true,\"renameProvider\":{\"prepareProvider\":true},\"documentSymbolProvider\":true,\"completionProvider\":{\"triggerCharacters\":[\".\"]}},\"serverInfo\":{\"name\":\"mach-lsp\"}}}";
     send_concat2(srv, prefix, id, result);
@@ -235,6 +249,31 @@ fun handle_initialize(srv: *Server, body: str) {
 
     srv.status = STATUS_RUNNING;
     trace.log("initialized\n");
+}
+
+# handle_initialized: once the client signals it is ready, register file
+# watchers for the manifest, lockfile, and source trees so a dep-graph change
+# (pulling deps, editing a dep source) triggers `workspace/didChangeWatchedFiles`
+# and the affected project root is rebuilt. only sent when the client advertised
+# dynamic registration; clients without it fall back to the server's mtime check.
+fun handle_initialized(srv: *Server) {
+    if (!srv.watch_dynamic) { ret; }
+    val reg: str = "{\"jsonrpc\":\"2.0\",\"id\":\"mls/registerWatchers\",\"method\":\"client/registerCapability\",\"params\":{\"registrations\":[{\"id\":\"mls-watched-files\",\"method\":\"workspace/didChangeWatchedFiles\",\"registerOptions\":{\"watchers\":[{\"globPattern\":\"**/mach.toml\"},{\"globPattern\":\"**/mach.lock\"},{\"globPattern\":\"**/*.mach\"}]}}]}}";
+    transport.send_message(reg, srv.alloc);
+}
+
+# handle_did_change_watched_files: invalidate every project root whose tree
+# contains a changed file, so the next request rebuilds it from disk. each
+# `uri` in the notification's `changes` array is invalidated in turn.
+fun handle_did_change_watched_files(srv: *Server, body: str) {
+    var i: u32 = 0;
+    for (true) {
+        val uri: str = json.extract_string_seq(body, "\"uri\"", i, srv.alloc);
+        if (uri == nil) { brk; }
+        project.invalidate_uri(?srv.ws, uri);
+        json.free_str(uri, srv.alloc);
+        i = i + 1;
+    }
 }
 
 # handle_shutdown: acknowledge a shutdown request and enter the shutting-down phase.

--- a/src/server.mach
+++ b/src/server.mach
@@ -260,6 +260,9 @@ fun handle_initialized(srv: *Server) {
     if (!srv.watch_dynamic) { ret; }
     val reg: str = "{\"jsonrpc\":\"2.0\",\"id\":\"mls/registerWatchers\",\"method\":\"client/registerCapability\",\"params\":{\"registrations\":[{\"id\":\"mls-watched-files\",\"method\":\"workspace/didChangeWatchedFiles\",\"registerOptions\":{\"watchers\":[{\"globPattern\":\"**/mach.toml\"},{\"globPattern\":\"**/mach.lock\"},{\"globPattern\":\"**/*.mach\"}]}}]}}";
     transport.send_message(reg, srv.alloc);
+    # the watcher now covers manifest / lockfile changes; skip the per-request
+    # mtime fallback check.
+    project.set_watch_active(?srv.ws, true);
 }
 
 # handle_did_change_watched_files: invalidate every project root whose tree

--- a/test/harness.py
+++ b/test/harness.py
@@ -8,8 +8,10 @@ no scenario duplicates them.
 """
 import json
 import os
+import select
 import subprocess
 import sys
+import time
 
 REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -100,3 +102,74 @@ def standalone(name, run):
         print("  -", f)
     print(f"{name}:", "FAILED" if fails else "PASSED")
     sys.exit(1 if fails else 0)
+
+
+class LiveServer:
+    """an interactive server session: send frames and read responses as they
+    arrive, so a scenario can act between requests (e.g. edit a file on disk and
+    fire a watched-files change before the next request). reads are bounded by a
+    timeout via select, so a misbehaving server cannot hang the suite."""
+
+    def __init__(self):
+        if not os.path.exists(BIN):
+            raise FileNotFoundError(f"server binary not found at {BIN} — run `mach build` first")
+        self.proc = subprocess.Popen([BIN], stdin=subprocess.PIPE,
+                                     stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        self.buf = b""
+
+    def send(self, frame):
+        """write one framed message to the server's stdin."""
+        self.proc.stdin.write(frame)
+        self.proc.stdin.flush()
+
+    def _pop(self):
+        """parse and remove one complete framed message from the buffer, or None."""
+        hdr_end = self.buf.find(b"\r\n\r\n")
+        if hdr_end < 0:
+            return None
+        header = self.buf[:hdr_end].decode(errors="replace")
+        clen = None
+        for line in header.split("\r\n"):
+            if line.lower().startswith("content-length:"):
+                clen = int(line.split(":", 1)[1].strip())
+        if clen is None:
+            return None
+        bstart = hdr_end + 4
+        if len(self.buf) < bstart + clen:
+            return None
+        msg = json.loads(self.buf[bstart:bstart + clen].decode())
+        self.buf = self.buf[bstart + clen:]
+        return msg
+
+    def recv_id(self, want_id, timeout=60):
+        """read messages until the response with id `want_id` arrives (draining
+        any notifications), or None on timeout."""
+        deadline = time.time() + timeout
+        while True:
+            msg = self._pop()
+            if msg is not None:
+                if msg.get("id") == want_id:
+                    return msg
+                continue
+            remaining = deadline - time.time()
+            if remaining <= 0:
+                return None
+            r, _, _ = select.select([self.proc.stdout], [], [], remaining)
+            if not r:
+                return None
+            chunk = os.read(self.proc.stdout.fileno(), 65536)
+            if not chunk:
+                return None
+            self.buf += chunk
+
+    def close(self, timeout=10):
+        """close stdin and wait for the server to exit; returns the exit code."""
+        try:
+            self.proc.stdin.close()
+        except OSError:
+            pass
+        try:
+            return self.proc.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            self.proc.kill()
+            return self.proc.wait()

--- a/test/run.py
+++ b/test/run.py
@@ -11,12 +11,16 @@ import test_diagnostics
 import test_features
 import test_crossmodule
 import test_workspace
+import test_multiroot
+import test_invalidation
 
 SUITES = [
     ("diagnostics", test_diagnostics.run),
     ("features", test_features.run),
     ("crossmodule", test_crossmodule.run),
     ("workspace", test_workspace.run),
+    ("multiroot", test_multiroot.run),
+    ("invalidation", test_invalidation.run),
 ]
 
 

--- a/test/test_crossmodule.py
+++ b/test/test_crossmodule.py
@@ -3,7 +3,8 @@
 on the vendored mach-std. definition / references / hover on a `use`d std symbol
 must reach the canonical file:// URI of the decl inside dep/mach-std, while a
 local symbol still resolves in the buffer. also covers project-load ordering (a
-scratch file opened first must not disable the later project load) and
+scratch file opened first must not disable the later project load; a dep source
+opened first must still refuse rename via its vendoring project) and
 percent-encoded document URIs."""
 import os
 
@@ -165,25 +166,28 @@ def percent_encoding_scenario():
     return failures
 
 
+def _strlen_decl():
+    """(dep text, position of the str_len declaration name) from the vendored
+    string.mach, or (None, None) when it cannot be located."""
+    dep_path = os.path.join(REPO, "dep", "mach-std", "src", "types", "string.mach")
+    dep_text = open(dep_path).read()
+    for i, line in enumerate(dep_text.splitlines()):
+        if "pub fun str_len" in line:
+            return dep_text, pos(i, line.find("str_len"))
+    return None, None
+
+
 def dep_buffer_rename_scenario():
     """a dependency source opened directly (as after go-to-definition) is not the
     editor's to rewrite: even though its symbols resolve buffer-locally, its
     on-disk twin is a non-project module, so prepareRename refuses and rename
     yields an empty WorkspaceEdit (regression: the local-symbol path skipped the
     project-ownership check)."""
-    dep_path = os.path.join(REPO, "dep", "mach-std", "src", "types", "string.mach")
-    dep_text = open(dep_path).read()
-    decl_line = None
-    decl_col = None
-    for i, line in enumerate(dep_text.splitlines()):
-        if "pub fun str_len" in line:
-            decl_line, decl_col = i, line.find("str_len")
-            break
-    if decl_line is None:
-        return [f"str_len declaration not found in {dep_path}"]
+    dep_text, dep_pos = _strlen_decl()
+    if dep_text is None:
+        return ["str_len declaration not found in dep/mach-std"]
 
     app_text = open(APP).read()
-    dep_pos = pos(decl_line, decl_col)
     frames = [
         req(1, "initialize", {"capabilities": {}}),
         notify("initialized"),
@@ -214,6 +218,41 @@ def dep_buffer_rename_scenario():
     return failures
 
 
+def dep_buffer_first_scenario():
+    """a dependency source opened cold — before any project document — must
+    still refuse rename: the vendoring project above it (this repo, which
+    declares mach-std as a dep) is loaded and the document routed as its
+    read-only twin, instead of the dep's own manifest dir becoming a renameable
+    project root (regression: open-order dependence of the refusal)."""
+    dep_text, dep_pos = _strlen_decl()
+    if dep_text is None:
+        return ["str_len declaration not found in dep/mach-std"]
+
+    frames = [
+        req(1, "initialize", {"capabilities": {}}),
+        notify("initialized"),
+        did_open(DEP_STRING_URI, dep_text),
+        req(20, "textDocument/prepareRename",
+            {"textDocument": {"uri": DEP_STRING_URI}, "position": dep_pos}),
+        req(21, "textDocument/rename",
+            {"textDocument": {"uri": DEP_STRING_URI}, "position": dep_pos, "newName": "nope"}),
+        req(2, "shutdown", None),
+        notify("exit"),
+    ]
+    code, msgs = drive(frames)
+
+    failures = []
+    prv = (by_id(msgs, 20) or {}).get("result", "missing")
+    if prv is not None:
+        failures.append(f"prepareRename(cold dep buffer decl) should be null, got {prv!r}")
+    rnv = (by_id(msgs, 21) or {}).get("result")
+    if not isinstance(rnv, dict) or rnv.get("changes") != {}:
+        failures.append(f"rename(cold dep buffer decl) should be an empty WorkspaceEdit, got {rnv!r}")
+    if code != 0:
+        failures.append("non-zero exit code after clean shutdown")
+    return failures
+
+
 def run():
     """drive the cross-module scenarios; return a list of failure strings."""
     if not os.path.exists(APP):
@@ -223,6 +262,7 @@ def run():
     failures += scratch_ordering_scenario()
     failures += percent_encoding_scenario()
     failures += dep_buffer_rename_scenario()
+    failures += dep_buffer_first_scenario()
     return failures
 
 

--- a/test/test_invalidation.py
+++ b/test/test_invalidation.py
@@ -6,7 +6,8 @@ scenario copies test/fixture-ws to a scratch dir, resolves a cross-file symbol
 that declaration down on disk and confirms the next resolve serves the new line —
 once via a `workspace/didChangeWatchedFiles` notification (the primary trigger),
 once via the manifest-mtime fallback for clients that do not deliver watch
-notifications."""
+notifications. a third scenario covers failed-load recovery: a broken manifest
+must not pin the failure for the session — fixing it on disk retries the load."""
 import os
 import shutil
 import tempfile
@@ -118,6 +119,48 @@ def mtime_fallback_trigger():
     return failures
 
 
+def broken_manifest_recovers():
+    """a root whose manifest fails to parse must not stay bricked for the whole
+    session on a non-watch client: once the manifest is fixed on disk (mtime
+    bumped past the failure snapshot), the next request retries the load and
+    cross-module resolution comes back."""
+    proj, app, lib = _scratch_project()
+    app_uri = file_uri(app)
+    lib_uri = file_uri(lib)
+    manifest = os.path.join(proj, "mach.toml")
+    good = open(manifest).read()
+    with open(manifest, "w") as f:
+        f.write("this is [ not a manifest\n")
+    failures = []
+    srv = LiveServer()
+    try:
+        srv.send(req(1, "initialize", {"capabilities": {}}))
+        srv.recv_id(1)
+        srv.send(notify("initialized"))
+        srv.send(did_open(app_uri, open(app).read()))
+
+        # broken manifest: the load fails, `shared` stays unresolved single-file
+        uri1, _ = _definition_line(srv, app_uri, 20)
+        if uri1 == lib_uri:
+            failures.append("definition(shared) resolved cross-module despite a broken manifest")
+
+        with open(manifest, "w") as f:
+            f.write(good)
+        future = os.path.getmtime(manifest) + 1000
+        os.utime(manifest, (future, future))
+
+        uri2, line2 = _definition_line(srv, app_uri, 21)
+        if uri2 != lib_uri or line2 != DECL_LINE:
+            failures.append(f"definition(shared) after manifest fix: uri {uri2} line {line2}, expected {lib_uri} line {DECL_LINE}")
+
+        srv.send(req(2, "shutdown", None))
+        srv.send(notify("exit"))
+    finally:
+        srv.close()
+        shutil.rmtree(proj, ignore_errors=True)
+    return failures
+
+
 def run():
     """drive the invalidation scenarios; return a list of failure strings."""
     if not os.path.exists(os.path.join(WS, "src", "app.mach")):
@@ -125,6 +168,7 @@ def run():
     failures = []
     failures += watched_files_trigger()
     failures += mtime_fallback_trigger()
+    failures += broken_manifest_recovers()
     return failures
 
 

--- a/test/test_invalidation.py
+++ b/test/test_invalidation.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""dep-graph invalidation scenarios: a project root's loaded graph is a snapshot,
+so editing one of its sources on disk must not keep serving stale positions. each
+scenario copies test/fixture-ws to a scratch dir, resolves a cross-file symbol
+(its declaration lives in lib.mach, reached from app.mach's `use`), then shifts
+that declaration down on disk and confirms the next resolve serves the new line —
+once via a `workspace/didChangeWatchedFiles` notification (the primary trigger),
+once via the manifest-mtime fallback for clients that do not deliver watch
+notifications."""
+import os
+import shutil
+import tempfile
+
+from harness import LiveServer, req, notify, did_open, pos, file_uri, standalone, REPO
+
+WS = os.path.join(REPO, "test", "fixture-ws")
+
+# fixture-ws/src/app.mach line 6: `ret shared(1) + shared(2) + LIMIT;` use at col 8.
+# fixture-ws/src/lib.mach  line 4: `pub fun shared(x: i64) i64 {` decl at col 8.
+APP_USE = pos(6, 8)
+DECL_LINE = 4
+SHIFT = 3
+
+
+def _scratch_project():
+    """copy fixture-ws into a fresh temp dir; return (dir, app path, lib path)."""
+    tmp = tempfile.mkdtemp(prefix="mls-inval-")
+    dst = os.path.join(tmp, "ws")
+    shutil.copytree(WS, dst)
+    return dst, os.path.join(dst, "src", "app.mach"), os.path.join(dst, "src", "lib.mach")
+
+
+def _definition_line(srv, app_uri, rid):
+    """request definition on the `shared` use-site and return (uri, line)."""
+    srv.send(req(rid, "textDocument/definition",
+                 {"textDocument": {"uri": app_uri}, "position": APP_USE}))
+    res = (srv.recv_id(rid) or {}).get("result")
+    if not res or "uri" not in res:
+        return None, None
+    return res["uri"], res.get("range", {}).get("start", {}).get("line")
+
+
+def _shift_decl(lib_path):
+    """prepend blank lines to lib.mach, moving the `shared` decl down by SHIFT."""
+    text = open(lib_path).read()
+    with open(lib_path, "w") as f:
+        f.write("\n" * SHIFT + text)
+
+
+def watched_files_trigger():
+    """edit a dep source on disk and fire didChangeWatchedFiles: the next
+    definition must serve the shifted declaration line, proving the root reloaded."""
+    proj, app, lib = _scratch_project()
+    app_uri = file_uri(app)
+    lib_uri = file_uri(lib)
+    failures = []
+    srv = LiveServer()
+    try:
+        srv.send(req(1, "initialize", {"capabilities": {}}))
+        srv.recv_id(1)
+        srv.send(notify("initialized"))
+        srv.send(did_open(app_uri, open(app).read()))
+
+        uri1, line1 = _definition_line(srv, app_uri, 20)
+        if uri1 != lib_uri or line1 != DECL_LINE:
+            failures.append(f"definition(shared) before edit: uri {uri1} line {line1}, expected {lib_uri} line {DECL_LINE}")
+
+        _shift_decl(lib)
+        srv.send(notify("workspace/didChangeWatchedFiles",
+                        {"changes": [{"uri": lib_uri, "type": 2}]}))
+
+        uri2, line2 = _definition_line(srv, app_uri, 21)
+        if uri2 != lib_uri or line2 != DECL_LINE + SHIFT:
+            failures.append(f"definition(shared) after didChangeWatchedFiles: uri {uri2} line {line2}, expected {lib_uri} line {DECL_LINE + SHIFT}")
+
+        srv.send(req(2, "shutdown", None))
+        srv.send(notify("exit"))
+    finally:
+        srv.close()
+        shutil.rmtree(proj, ignore_errors=True)
+    return failures
+
+
+def mtime_fallback_trigger():
+    """without any watch notification, a manifest mtime bump must reload the
+    graph (the conservative fallback), picking up a concurrent dep-source edit."""
+    proj, app, lib = _scratch_project()
+    app_uri = file_uri(app)
+    lib_uri = file_uri(lib)
+    manifest = os.path.join(proj, "mach.toml")
+    failures = []
+    srv = LiveServer()
+    try:
+        srv.send(req(1, "initialize", {"capabilities": {}}))
+        srv.recv_id(1)
+        srv.send(notify("initialized"))
+        srv.send(did_open(app_uri, open(app).read()))
+
+        uri1, line1 = _definition_line(srv, app_uri, 20)
+        if uri1 != lib_uri or line1 != DECL_LINE:
+            failures.append(f"definition(shared) before edit: uri {uri1} line {line1}, expected {lib_uri} line {DECL_LINE}")
+
+        _shift_decl(lib)
+        # bump the manifest mtime well past the load-time snapshot (mtime is
+        # second-granular, so a same-second rewrite would not register).
+        future = os.path.getmtime(manifest) + 1000
+        os.utime(manifest, (future, future))
+
+        uri2, line2 = _definition_line(srv, app_uri, 21)
+        if uri2 != lib_uri or line2 != DECL_LINE + SHIFT:
+            failures.append(f"definition(shared) after mtime bump: uri {uri2} line {line2}, expected {lib_uri} line {DECL_LINE + SHIFT}")
+
+        srv.send(req(2, "shutdown", None))
+        srv.send(notify("exit"))
+    finally:
+        srv.close()
+        shutil.rmtree(proj, ignore_errors=True)
+    return failures
+
+
+def run():
+    """drive the invalidation scenarios; return a list of failure strings."""
+    if not os.path.exists(os.path.join(WS, "src", "app.mach")):
+        return [f"fixture-ws not found at {WS}"]
+    failures = []
+    failures += watched_files_trigger()
+    failures += mtime_fallback_trigger()
+    return failures
+
+
+if __name__ == "__main__":
+    standalone("invalidation", run)

--- a/test/test_multiroot.py
+++ b/test/test_multiroot.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""multi-root scenarios: two independent project roots open in one session must
+load and resolve independently. test/fixture-ws is a depless two-module project
+whose `shared` resolves cross-file within itself; test/fixture depends on the
+vendored mach-std and its `str_len` resolves into dep/mach-std. opening both in
+one session, each cross-module definition must land in its own project's files
+— neither root's graph leaking into the other — and the order of opening must
+not matter."""
+import os
+
+from harness import drive, req, notify, did_open, pos, by_id, file_uri, standalone, REPO, FIXTURE
+
+WS = os.path.join(REPO, "test", "fixture-ws")
+WS_APP = os.path.join(WS, "src", "app.mach")
+WS_LIB = os.path.join(WS, "src", "lib.mach")
+WS_APP_URI = file_uri(WS_APP)
+WS_LIB_URI = file_uri(WS_LIB)
+
+FX_APP = os.path.join(FIXTURE, "src", "app.mach")
+FX_APP_URI = file_uri(FX_APP)
+DEP_STRING_URI = file_uri(os.path.join(REPO, "dep", "mach-std", "src", "types", "string.mach"))
+
+# fixture-ws/src/app.mach line 6: `ret shared(1) + shared(2) + LIMIT;` use at col 8.
+# fixture-ws/src/lib.mach  line 4: `pub fun shared(x: i64) i64 {` decl at col 8.
+WS_USE = pos(6, 8)
+# fixture/src/app.mach line 10: `    ret str_len(s);` use at col 8 (name at col 10).
+FX_USE = pos(10, 10)
+
+
+def both_resolve_independently(open_ws_first):
+    """open both projects in one session; each cross-module definition lands in
+    its own project's files regardless of which root was opened first."""
+    ws_text = open(WS_APP).read()
+    fx_text = open(FX_APP).read()
+    opens = [did_open(WS_APP_URI, ws_text), did_open(FX_APP_URI, fx_text)]
+    if not open_ws_first:
+        opens.reverse()
+    frames = [
+        req(1, "initialize", {"capabilities": {}}),
+        notify("initialized"),
+        *opens,
+        req(20, "textDocument/definition", {"textDocument": {"uri": WS_APP_URI}, "position": WS_USE}),
+        req(21, "textDocument/definition", {"textDocument": {"uri": FX_APP_URI}, "position": FX_USE}),
+        req(2, "shutdown", None),
+        notify("exit"),
+    ]
+    code, msgs = drive(frames)
+    order = "ws-first" if open_ws_first else "fixture-first"
+    failures = []
+
+    dws = (by_id(msgs, 20) or {}).get("result")
+    if not dws or "uri" not in dws:
+        failures.append(f"[{order}] definition(shared) returned no Location")
+    else:
+        if dws["uri"] != WS_LIB_URI:
+            failures.append(f"[{order}] definition(shared) landed in {dws['uri']}, expected {WS_LIB_URI}")
+        if dws.get("range", {}).get("start", {}).get("line") != 4:
+            failures.append(f"[{order}] definition(shared) line {dws.get('range', {}).get('start', {}).get('line')}, expected 4")
+
+    dfx = (by_id(msgs, 21) or {}).get("result")
+    if not dfx or "uri" not in dfx:
+        failures.append(f"[{order}] definition(str_len) returned no Location")
+    elif dfx["uri"] != DEP_STRING_URI:
+        failures.append(f"[{order}] definition(str_len) landed in {dfx['uri']}, expected {DEP_STRING_URI}")
+
+    if code != 0:
+        failures.append(f"[{order}] non-zero exit code after clean shutdown")
+    return failures
+
+
+def run():
+    """drive the multi-root scenarios; return a list of failure strings."""
+    if not os.path.exists(WS_APP) or not os.path.exists(FX_APP):
+        return ["multi-root fixtures not found"]
+    failures = []
+    failures += both_resolve_independently(True)
+    failures += both_resolve_independently(False)
+    return failures
+
+
+if __name__ == "__main__":
+    standalone("multiroot", run)


### PR DESCRIPTION
Closes #46.

Restructures the workspace loader from one project bound to the whole server session into per-root project graphs, and adds invalidation/reload of a root's graph when its sources change.

## Design

### Module-id namespacing across builds (shared session)
`driver.build_project` allocates project-local module ids from 0 and writes them into the session's global module registries, so a second build over the same session clobbers the first there — true session-wide namespacing is impossible without changing the vendored driver. The fix: the LSP no longer reads those session registries. `site_of` (the only consumer) now reads the per-`Root` `driver.Project.modules` array, whose ids are private to that project. Each `Root` is therefore its own id space and several projects coexist in one shared session without collision — no per-root sessions needed (buffers keep a single session/source-map/interner, so FileIds stay globally unique and no cross-session routing is required).

### Root → project map
A `Workspace` holds one `Root` per distinct project root open in the session, each with its own `driver.Project`, dep snapshot, and synthetic buffer-id base. A document is routed to the root that governs its path (nearest ancestor `mach.toml`); a document that is already a dependency module of a loaded root is routed there read-only rather than spun up as its own project (preserves the "a dependency's declaration is not the editor's to rewrite" guarantee); a document under no `mach.toml` resolves single-file. The legacy one-project-per-session behaviour is the one-`Root` case.

### Invalidation
`workspace/didChangeWatchedFiles` is the trigger: a changed `mach.toml`/`mach.lock` or any source under a root's tree (including a vendored dep under `dep/`) drops that root, so the next request rebuilds it from disk. The server registers watchers via `client/registerCapability` when the client advertises dynamic registration. Conservative fallback for clients without watched-files support: a manifest/lockfile mtime check on each access reloads the root.

### Entry-closure scope (PR #51 review addition)
Settled: each root loads its manifest default-target import closure (the driver's native single-graph unit). Covering secondary `bin`/`lib` targets or truly-unreferenced modules cleanly is deferred — see PR discussion.

## Tests
- multi-root: two independent projects open in one session resolve cross-module definitions into their own files.
- invalidation: edit a dep source on disk, fire `didChangeWatchedFiles`, verify definition/hover serve the shifted positions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)