### PR TITLE
docs(readme): drop stale #45 cross-module limitation note

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,13 +103,6 @@ lockfile touch).
 > need path-deduplicated multi-graph merging (to avoid duplicate edits for
 > modules shared between targets) and is deferred.
 
-> **Known limitation (#45):** the vendored `dep/mach` only parses the old
-> `[targets.<name>]` manifest format, so cross-module resolution is currently
-> **non-functional for v1.4.0-manifest projects — including this repo itself**
-> (its own `mach.toml` uses `[target.X]`/`[bin.X]`). Such projects resolve
-> single-file and the server reports the load failure via `window/showMessage`.
-> Fixed by bumping `dep/mach` to a version that parses the new format.
-
 ## Building
 
 The compiler and standard library are vendored under `dep/` as git dependencies.


### PR DESCRIPTION
Removes the stale `#45` known-limitation note that still claimed cross-module resolution is non-functional for v1.4.0-manifest projects.

`dep/mach` was bumped (#45 / #49) and the crossmodule / workspace / multiroot / invalidation test suites prove cross-module definition / references / hover / rename work, so the note directly contradicted the rest of the README. The scope note above it already describes the real limits (out-of-closure targets, dependency-declared symbols), so nothing is duplicated — the contradiction is simply removed.

Docs-only; `make test` passes (all 6 scenarios).

Closes #52