### PR TITLE
fix(language): unify id_raw ownership across reply emitters

### DIFF
--- a/src/language.mach
+++ b/src/language.mach
@@ -567,7 +567,6 @@ pub fun document_symbol(ws: *project.Workspace, es: *editor.EditorSession, s: *s
     if (!okd) { reply_empty_array(alloc, id_raw); ret; }
 
     emit_document_symbols(an, s, alloc, id_raw);
-    json.free_str(id_raw, alloc);
 }
 
 # completion: answer textDocument/completion with the in-scope top-level names
@@ -581,7 +580,6 @@ pub fun completion(ws: *project.Workspace, es: *editor.EditorSession, s: *sess.S
     if (!okc) { reply_empty_array(alloc, id_raw); ret; }
 
     emit_completions(an, s, alloc, id_raw);
-    json.free_str(id_raw, alloc);
 }
 
 # binding_span: write the binding name span of a param / generic symbol into
@@ -990,6 +988,7 @@ fun free_groups(groups: *str, n: usize, alloc: *Allocator) {
 }
 
 # emit_document_symbols: send a DocumentSymbol[] of the file's top-level decls.
+# takes ownership of `id_raw` and frees it.
 fun emit_document_symbols(an: Analyzed, s: *sess.Session, alloc: *Allocator, id_raw: str) {
     val prefix: str = "{\"jsonrpc\":\"2.0\",\"id\":";
     val mid:    str = ",\"result\":[";
@@ -1038,6 +1037,7 @@ fun emit_document_symbols(an: Analyzed, s: *sess.Session, alloc: *Allocator, id_
     buf[off] = 0;
     transport.send_message(buf::str, alloc);
     deallocate[u8](alloc, buf, total + 1);
+    json.free_str(id_raw, alloc);
 }
 
 # doc_symbol_json: render decl `did` as a DocumentSymbol object, or nil when the
@@ -1107,7 +1107,8 @@ fun decl_lsp_kind(kind: decl.DeclKind) i64 {
 }
 
 # emit_completions: send a CompletionItem[] of the file's top-level names, each
-# deduped by spelling so a name declared once appears once.
+# deduped by spelling so a name declared once appears once. takes ownership of
+# `id_raw` and frees it.
 fun emit_completions(an: Analyzed, s: *sess.Session, alloc: *Allocator, id_raw: str) {
     val prefix: str = "{\"jsonrpc\":\"2.0\",\"id\":";
     val mid:    str = ",\"result\":{\"isIncomplete\":false,\"items\":[";
@@ -1158,6 +1159,7 @@ fun emit_completions(an: Analyzed, s: *sess.Session, alloc: *Allocator, id_raw: 
     buf[off] = 0;
     transport.send_message(buf::str, alloc);
     deallocate[u8](alloc, buf, total + 1);
+    json.free_str(id_raw, alloc);
 }
 
 # completion_first: whether symbol `sid` is a completion candidate AND the first


### PR DESCRIPTION
## Summary

`emit_document_symbols` and `emit_completions` freed `id_raw` on their allocation-failure path (via `reply_empty_array`), while their callers (`document_symbol` / `completion`) freed it again after the call returned — a double-free reachable on OOM.

This applies the sole-ownership convention PR #51 established for `emit_locations` / `emit_rename`: the emit function owns `id_raw` and frees it on every path, and the caller no longer frees after handing it off.

## Changes

- `emit_document_symbols` and `emit_completions` now `json.free_str(id_raw, ...)` on the success path (they already freed it via `reply_empty_array` on OOM), and document "takes ownership of `id_raw` and frees it" to match the existing emitters.
- `document_symbol` and `completion` no longer free `id_raw` after the emit call.

## Audit

Every handler extracting a request id in `src/language.mach` was checked; `server.mach`'s id handlers use the inline build-and-free-once pattern and were verified clean. Only the two emitters above carried the double-free. Full per-handler before/after in the PR discussion.

OOM paths are untestable through the harness; verified by audit. `make clean && make test` is green.

Closes #53