### PR TITLE
fix: route transitively-nested deps to the outermost vendoring project

### DIFF
--- a/src/project.mach
+++ b/src/project.mach
@@ -336,19 +336,20 @@ pub fun root_for(w: *Workspace, uri: str) *Root {
     ret load_root(w, doc_root);
 }
 
-# ancestor_root: load-and-prefer an outer project for the document at `uri`
-# whose own (fresh) root is `doc_root`. walks the chain of ancestor manifest
-# dirs strictly above `dir` (`doc_root` on the outer call), outermost first; an
-# ancestor is only considered when its manifest declares `doc_root` as one of
-# its dep vendor dirs (`vendors_dir`), so unrelated outer projects — a monorepo
-# root, this repo above its test fixtures — are never speculatively built. the
-# first considered ancestor whose loaded graph holds the document as a module
-# governs it; one that loads but does not hold it stays loaded (it is a real
-# project). ancestors already tracked are skipped: a loaded-and-containing one
-# was already returned by containing_root, and a failed one is not retried
-# here. only the document's direct vendoring project is found — a dep nested
-# inside another dep's tree routes to that dep's root, not the outermost
-# project. nil when no ancestor claims the document.
+# ancestor_root: load-and-prefer the outermost project that vendors the document
+# at `uri` (whose own fresh root is `doc_root`) and whose loaded graph holds it.
+# walks the chain of ancestor manifest dirs strictly above `dir` (`doc_root` on
+# the outer call), outermost first; an ancestor is only considered when its
+# manifest declares a dependency whose vendor dir encloses `doc_root`
+# (`vendors_enclosing`), so unrelated outer projects — a monorepo root, this repo
+# above its test fixtures — are never speculatively built. the outermost
+# considered ancestor whose loaded graph holds the document governs it; one that
+# loads but does not hold it stays loaded (it is a real project) and the walk
+# falls inward to the next vendoring ancestor — so a dependency nested inside
+# another dependency's tree reaches the outermost project that actually closes
+# over it, not merely its immediate parent. ancestors already tracked are
+# skipped: a loaded one was already offered by containing_root, and a failed one
+# is not retried here. nil when no ancestor claims the document.
 fun ancestor_root(w: *Workspace, uri: str, doc_root: str, dir: str) *Root {
     val par_r: Result[pathlib.Path, str] = pathlib.parent(w.alloc, dir);
     if (is_err[pathlib.Path, str](par_r)) { ret nil; }
@@ -361,7 +362,7 @@ fun ancestor_root(w: *Workspace, uri: str, doc_root: str, dir: str) *Root {
     val above: *Root = ancestor_root(w, uri, doc_root, anc);
     if (above != nil) { strutil.str_free(w.alloc, anc); ret above; }
 
-    if (find_root(w, anc) != nil || !vendors_dir(w, anc, doc_root)) {
+    if (find_root(w, anc) != nil || !vendors_enclosing(w, anc, doc_root)) {
         strutil.str_free(w.alloc, anc);
         ret nil;
     }
@@ -372,15 +373,21 @@ fun ancestor_root(w: *Workspace, uri: str, doc_root: str, dir: str) *Root {
     ret nil;
 }
 
-# vendors_dir: whether the project at `root_path` declares a dependency whose
-# vendor dir is `dir` — i.e. `dir` equals `<root>/<[project].dep>/<alias>` for
-# some `[deps.<alias>]`, the same layout the driver's dep resolution reads. one
-# small manifest parse answers "could this project claim that nested root?"
-# without paying a full graph build; the loaded graph remains the authority on
-# actual containment. a manifest that fails to read or parse vendors nothing.
-# the parsed table is leaked into the server's page allocator — std.data.toml
-# exposes no teardown, the same convention the driver's own manifest reads use.
-fun vendors_dir(w: *Workspace, root_path: str, dir: str) bool {
+# vendors_enclosing: whether the project at `root_path` declares a dependency
+# whose vendor dir encloses `dir` — i.e. `dir` equals or lies under
+# `<root>/<[project].dep>/<alias>` for some `[deps.<alias>]`, the same layout the
+# driver's dep resolution reads. one small manifest parse answers "could this
+# project's dependency tree contain that nested root?" without paying a full
+# graph build; the loaded graph remains the authority on actual containment.
+# enclosure rather than equality is the speculative-build gate that lets a dep
+# nested inside another dep's tree reach the outermost vendoring project, not
+# merely its immediate parent, while still never building unrelated outer
+# projects — a monorepo root, this repo above its test fixtures — whose declared
+# vendor dirs enclose nothing the document sits in. a manifest that fails to read
+# or parse vendors nothing. the parsed table is leaked into the server's page
+# allocator — std.data.toml exposes no teardown, the same convention the driver's
+# own manifest reads use.
+fun vendors_enclosing(w: *Workspace, root_path: str, dir: str) bool {
     val mp_r: Result[pathlib.Path, str] = pathlib.join(w.alloc, root_path, "mach.toml");
     if (is_err[pathlib.Path, str](mp_r)) { ret false; }
     val mp: str = unwrap_ok[pathlib.Path, str](mp_r);
@@ -416,7 +423,7 @@ fun vendors_dir(w: *Workspace, root_path: str, dir: str) bool {
                     val norm: str = normalize_path(w.alloc, cand);
                     strutil.str_free(w.alloc, cand);
                     if (norm != nil) {
-                        if (str_equals(norm, want)) { found = true; }
+                        if (is_under(want, norm)) { found = true; }
                         strutil.str_free(w.alloc, norm);
                     }
                 }
@@ -440,26 +447,33 @@ fun find_root(w: *Workspace, root_path: str) *Root {
     ret nil;
 }
 
-# containing_root: the loaded root whose graph holds the document at `uri` as a
-# module (matched on the normalized filesystem path), skipping the document's
-# own root at `doc_root` (which find_root handles, with its outside-the-closure
-# files resolving against its dep set). a candidate is reload-checked and its
-# containment re-verified before it is handed out, so a twin-routed document
-# does not bypass the staleness check. nil when no other loaded root holds the
-# document.
+# containing_root: the outermost loaded root whose graph holds the document at
+# `uri` as a module (matched on the normalized filesystem path), skipping the
+# document's own root at `doc_root` (which find_root handles, with its
+# outside-the-closure files resolving against its dep set). when several loaded
+# roots hold the document — an outer project and a dependency nested within it —
+# the outermost wins (the shortest root path, since every holder is an ancestor
+# of the document on one root-to-file chain and so they nest), so a dependency
+# module routes to the project that vendors it regardless of which root loaded
+# first. each candidate is reload-checked and its containment re-verified before
+# it is accepted, so a twin-routed document does not bypass the staleness check.
+# nil when no other loaded root holds the document.
 fun containing_root(w: *Workspace, uri: str, doc_root: str) *Root {
     if (w.roots == nil) { ret nil; }
     val norm: str = uri_to_norm(w.alloc, uri);
     if (norm == nil) { ret nil; }
     var found: *Root = nil;
     var i: u32 = 0;
-    for (i < w.root_cap && found == nil) {
+    for (i < w.root_cap) {
         val r: *Root = ?w.roots[i];
         if (r.path != nil && r.loaded
             && (doc_root == nil || !str_equals(r.path, doc_root))
             && is_some[sess.ModuleId](module_for_norm(r, norm))) {
             maybe_reload(w, r);
-            if (r.loaded && is_some[sess.ModuleId](module_for_norm(r, norm))) { found = r; }
+            if (r.loaded && is_some[sess.ModuleId](module_for_norm(r, norm))
+                && (found == nil || str_len(r.path) < str_len(found.path))) {
+                found = r;
+            }
         }
         i = i + 1;
     }

--- a/test/fixture-nested/dep/mid/dep/leaf/mach.toml
+++ b/test/fixture-nested/dep/mid/dep/leaf/mach.toml
@@ -1,0 +1,15 @@
+# `leaf`: the innermost dependency, vendored inside `mid`'s tree two levels below
+# the `outer` project root.
+[project]
+id      = "leaf"
+version = "0.0.0"
+src     = "src"
+target  = "native"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.leaf]
+entry = "lib.mach"

--- a/test/fixture-nested/dep/mid/dep/leaf/src/lib.mach
+++ b/test/fixture-nested/dep/mid/dep/leaf/src/lib.mach
@@ -1,0 +1,6 @@
+# lib: the innermost dependency's module. opened cold — before any project
+# document — it must route read-only to the project that vendors it, never
+# become its own renameable project.
+pub fun b_thing() i64 {
+    ret 9;
+}

--- a/test/fixture-nested/dep/mid/mach.toml
+++ b/test/fixture-nested/dep/mid/mach.toml
@@ -1,0 +1,20 @@
+# `mid`: the middle dependency. it vendors `leaf` under its own dep/ tree, so a
+# leaf source is nested two levels below the `outer` project root. mid's entry
+# (lib.mach) imports leaf, so mid's own project graph closes over it.
+[project]
+id      = "mid"
+version = "0.0.0"
+src     = "src"
+dep     = "dep"
+target  = "native"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.mid]
+entry = "lib.mach"
+
+[deps.leaf]
+path = "dep/leaf"

--- a/test/fixture-nested/dep/mid/src/api.mach
+++ b/test/fixture-nested/dep/mid/src/api.mach
@@ -1,0 +1,6 @@
+# api: mid's outer-facing module, imported by the `outer` project. it does not
+# import `leaf`, so `outer`'s closure can include it without pulling the nested
+# leaf dependency that `outer` never declares.
+pub fun a_thing() i64 {
+    ret 7;
+}

--- a/test/fixture-nested/dep/mid/src/lib.mach
+++ b/test/fixture-nested/dep/mid/src/lib.mach
@@ -1,0 +1,7 @@
+# lib: mid's entry module; imports the vendored `leaf` dependency so mid's own
+# project graph closes over it. the `outer` project never loads this module.
+use leaf.lib.b_thing;
+
+pub fun mid_main() i64 {
+    ret b_thing();
+}

--- a/test/fixture-nested/mach.toml
+++ b/test/fixture-nested/mach.toml
@@ -1,0 +1,28 @@
+# two-level dependency-nesting fixture for the transitive cold-open routing
+# tests (#57). `outer` vendors `mid` (dep/mid), and `mid` vendors `leaf`
+# (dep/mid/dep/leaf), so a leaf source sits two dep levels below this root.
+# `outer`'s entry imports only mid.api — not mid's leaf-importing entry — so
+# `outer`'s graph closes over mid.api but never over leaf, while mid's own graph
+# closes over leaf. opening a leaf source cold must route read-only to the
+# project that vendors it regardless of open order, and mid.api must route to
+# `outer` rather than entrench `mid` as its own renameable project.
+#
+# self-contained path deps (no fetch); resolution follows the vendor layout
+# <root>/<dep>/<alias>, the same the server's build_project reads.
+[project]
+id      = "outer"
+version = "0.0.0"
+src     = "src"
+dep     = "dep"
+target  = "native"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.outer]
+entry = "app.mach"
+
+[deps.mid]
+path = "dep/mid"

--- a/test/fixture-nested/src/app.mach
+++ b/test/fixture-nested/src/app.mach
@@ -1,0 +1,8 @@
+# entry module of the `outer` project: imports mid.api so the project's graph
+# closes over the nested dependency's outer-facing module, but not over mid's
+# leaf-importing modules (which `outer` does not declare a path to).
+use mid.api.a_thing;
+
+fun use_a() i64 {
+    ret a_thing();
+}

--- a/test/test_crossmodule.py
+++ b/test/test_crossmodule.py
@@ -4,8 +4,8 @@ on the vendored mach-std. definition / references / hover on a `use`d std symbol
 must reach the canonical file:// URI of the decl inside dep/mach-std, while a
 local symbol still resolves in the buffer. also covers project-load ordering (a
 scratch file opened first must not disable the later project load; a dep source
-opened first must still refuse rename via its vendoring project) and
-percent-encoded document URIs."""
+opened first must still refuse rename via its vendoring project, at one and at
+two nesting levels) and percent-encoded document URIs."""
 import os
 
 from harness import drive, req, notify, did_open, pos, by_id, file_uri, standalone, FIXTURE, REPO
@@ -27,6 +27,12 @@ LOCAL = pos(9, 6)
 
 SCRATCH_URI = "file:///scratch.mach"
 SCRATCH_SRC = "fun lone() i64 { ret 1; }\n"
+
+# the two-level nesting fixture: project `outer` vendors `mid`, `mid` vendors
+# `leaf` (dep/mid/dep/leaf). `outer` closes over mid.api but not leaf.
+NESTED = os.path.join(REPO, "test", "fixture-nested")
+NESTED_LEAF = os.path.join(NESTED, "dep", "mid", "dep", "leaf", "src", "lib.mach")
+NESTED_MID_API = os.path.join(NESTED, "dep", "mid", "src", "api.mach")
 
 
 def check_dep_definition(failures, msg, dv):
@@ -253,6 +259,70 @@ def dep_buffer_first_scenario():
     return failures
 
 
+def _decl_pos(path, needle):
+    """(file text, position of `needle` on the first line that contains it), or
+    (None, None) when the file has no such line."""
+    text = open(path).read()
+    for i, line in enumerate(text.splitlines()):
+        if needle in line:
+            return text, pos(i, line.find(needle))
+    return None, None
+
+
+def nested_dep_first_scenario():
+    """a dependency nested two levels deep — `outer` vendors `mid`, `mid` vendors
+    `leaf` — opened cold before any project document must still refuse rename: the
+    leaf source routes read-only to the project that vendors it, and `mid`'s
+    outer-imported module then routes to `outer` rather than entrenching `mid` as
+    its own renameable project. depth- and open-order-independent refusal (#57)."""
+    if not os.path.exists(NESTED):
+        return [f"nested fixture not found at {NESTED}"]
+    leaf_text, leaf_pos = _decl_pos(NESTED_LEAF, "b_thing")
+    api_text, api_pos = _decl_pos(NESTED_MID_API, "a_thing")
+    if leaf_text is None or api_text is None:
+        return ["nested fixture declarations not found"]
+
+    leaf_uri = file_uri(NESTED_LEAF)
+    api_uri = file_uri(NESTED_MID_API)
+    frames = [
+        req(1, "initialize", {"capabilities": {}}),
+        notify("initialized"),
+        # the innermost dependency, opened cold before any project document
+        did_open(leaf_uri, leaf_text),
+        req(20, "textDocument/prepareRename",
+            {"textDocument": {"uri": leaf_uri}, "position": leaf_pos}),
+        req(21, "textDocument/rename",
+            {"textDocument": {"uri": leaf_uri}, "position": leaf_pos, "newName": "nope"}),
+        # mid's outer-imported module: must route to `outer`, not to an entrenched
+        # `mid`, so its declaration is read-only too
+        did_open(api_uri, api_text),
+        req(22, "textDocument/prepareRename",
+            {"textDocument": {"uri": api_uri}, "position": api_pos}),
+        req(23, "textDocument/rename",
+            {"textDocument": {"uri": api_uri}, "position": api_pos, "newName": "nope"}),
+        req(2, "shutdown", None),
+        notify("exit"),
+    ]
+    code, msgs = drive(frames)
+
+    failures = []
+    prv = (by_id(msgs, 20) or {}).get("result", "missing")
+    if prv is not None:
+        failures.append(f"prepareRename(cold leaf decl, depth 2) should be null, got {prv!r}")
+    rnv = (by_id(msgs, 21) or {}).get("result")
+    if not isinstance(rnv, dict) or rnv.get("changes") != {}:
+        failures.append(f"rename(cold leaf decl, depth 2) should be an empty WorkspaceEdit, got {rnv!r}")
+    prv2 = (by_id(msgs, 22) or {}).get("result", "missing")
+    if prv2 is not None:
+        failures.append(f"prepareRename(mid.api decl) should be null (routed to outer), got {prv2!r}")
+    rnv2 = (by_id(msgs, 23) or {}).get("result")
+    if not isinstance(rnv2, dict) or rnv2.get("changes") != {}:
+        failures.append(f"rename(mid.api decl) should be an empty WorkspaceEdit (routed to outer), got {rnv2!r}")
+    if code != 0:
+        failures.append("non-zero exit code after clean shutdown")
+    return failures
+
+
 def run():
     """drive the cross-module scenarios; return a list of failure strings."""
     if not os.path.exists(APP):
@@ -263,6 +333,7 @@ def run():
     failures += percent_encoding_scenario()
     failures += dep_buffer_rename_scenario()
     failures += dep_buffer_first_scenario()
+    failures += nested_dep_first_scenario()
     return failures
 
 


### PR DESCRIPTION
Closes #57.

## Problem

PR #54's cold-open routing prefers the outer project that vendors a dependency, but the speculative-build gate (`vendors_dir`) matched a project's declared vendor dir against the document's own root by **exact equality**. A dependency nested inside another dependency's tree (`P/dep/A/dep/B`) is only equal to the *immediate* parent's vendor dir, so the outer-chain walk stopped at the middle dep A: B routed to A's root, and A could be entrenched as its own renameable project once its files were opened.

## Design

The walk in `ancestor_root` already climbs outermost-first; the bug was the gate cutting it short. Rather than special-case a re-walk on the `find_root` path, the gate itself is corrected:

- `vendors_dir` → `vendors_enclosing`: an ancestor is considered when its declared dep tree **encloses** the document's own root (`is_under(doc_root, vendor_dir)`), not only when it equals it. The outermost ancestor whose loaded graph actually holds the document wins; one that loads but does not hold it stays loaded and the walk falls inward to the next vendoring ancestor. This reaches the outermost project that closes over the nested dep at any depth.
- `containing_root` now prefers the **outermost** holder (shortest root path) when several loaded roots hold the document, so routing is open-order independent once both an outer project and a nested dep are loaded.

Because any file under a vendored dep's root triggers the outer-chain walk on first open — and `vendors_enclosing` is true for every ancestor that vendors a dir enclosing that root — the outer project is loaded the first time any such file is seen. `containing_root` then routes every dep-module-of-the-outer to it on subsequent opens, so the `find_root` entrenchment cannot recur within the invariant's scope (a document that is a dependency module of a loadable outer project), without a per-request manifest re-walk.

The perf gate is preserved: an unrelated outer project (a monorepo root, this repo above its test fixtures) declares no vendor dir enclosing the document, so it is never speculatively built.

## Tests

New `test/fixture-nested`: project `outer` vendors dep `mid`, dep `mid` vendors dep `leaf` (`dep/mid/dep/leaf`). A `crossmodule` scenario opens a `leaf` file cold (before any project document) and asserts prepareRename is null / rename is an empty edit, then opens `mid`'s outer-imported module and asserts its symbol is read-only too (routed to `outer`, not entrenched at `mid`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)