### PR TITLE
Workspace hardening: structural session boundary + root-stamped resolve cache

### DIFF
--- a/src/diagnostics.mach
+++ b/src/diagnostics.mach
@@ -24,7 +24,6 @@ use std.allocator.deallocate;
 
 use mem: std.memory;
 
-use sess:   mach.lang.session;
 use src:    mach.lang.source;
 use diag:   mach.lang.diagnostic;
 use editor: mach.lang.editor;
@@ -43,12 +42,12 @@ val MAX_DIAGNOSTICS: usize = 200;
 
 # publish: analyze `uri`'s buffer and send its current diagnostics.
 # ---
-# es:    editor session holding the buffer
-# s:     compiler session whose SourceMap resolves spans to positions
-# alloc: allocator for the message buffers
-# uri:   document URI to report on
-# fid:   editor FileId of the document's buffer
-pub fun publish(es: *editor.EditorSession, s: *sess.Session, alloc: *Allocator, uri: str, fid: src.FileId) {
+# es:      editor session holding the buffer
+# sources: source map whose SourceFiles resolve spans to positions
+# alloc:   allocator for the message buffers
+# uri:     document URI to report on
+# fid:     editor FileId of the document's buffer
+pub fun publish(es: *editor.EditorSession, sources: *src.SourceMap, alloc: *Allocator, uri: str, fid: src.FileId) {
     val dr: Result[*diag.DiagList, str] = editor.diagnostics(es, fid);
     if (is_err[*diag.DiagList, str](dr)) {
         clear(alloc, uri);
@@ -79,7 +78,7 @@ pub fun publish(es: *editor.EditorSession, s: *sess.Session, alloc: *Allocator, 
         var i: usize = 0;
         for (i < count) {
             val d: *diag.Diagnostic = ?list.items[i];
-            entries[entry_count] = build_entry(s, d, alloc);
+            entries[entry_count] = build_entry(sources, d, alloc);
             entry_count = entry_count + 1;
             i = i + 1;
         }
@@ -152,14 +151,14 @@ pub fun clear(alloc: *Allocator, uri: str) {
 }
 
 # build_entry: render one diagnostic as an LSP Diagnostic JSON object, resolving
-# its span to a 0-based range against the session source map.
-fun build_entry(s: *sess.Session, d: *diag.Diagnostic, alloc: *Allocator) str {
+# its span to a 0-based range against the source map.
+fun build_entry(sources: *src.SourceMap, d: *diag.Diagnostic, alloc: *Allocator) str {
     var start_line: usize = 0;
     var start_char: usize = 0;
     var end_line: usize = 0;
     var end_char: usize = 0;
 
-    val so: Option[*src.SourceFile] = src.get(?s.sources, d.file_id);
+    val so: Option[*src.SourceFile] = src.get(sources, d.file_id);
     if (is_some[*src.SourceFile](so)) {
         val sf: *src.SourceFile = unwrap[*src.SourceFile](so);
         val sp: src.Position = src.position(sf, d.span.offset);

--- a/src/language.mach
+++ b/src/language.mach
@@ -61,29 +61,29 @@ use project:   mls.project;
 
 # Analyzed: the resolved analysis of one request's target document.
 # ---
-# s:    the compiler session (interner for symbol names, sources)
-# file: the document's SourceFile (text + line index for offset/position)
-# a:    the buffer's parsed Ast
-# rr:   the buffer's ResolveResult side tables
-# own:  this buffer's module id (Symbol.origin equals it for local symbols)
-# root: the project root the buffer resolved against, or nil for single-file
+# interner: the session's string interner, for resolving symbol-name StrIds
+# file:     the document's SourceFile (text + line index for offset/position)
+# a:        the buffer's parsed Ast
+# rr:       the buffer's ResolveResult side tables
+# own:      this buffer's module id (Symbol.origin equals it for local symbols)
+# root:     the project root the buffer resolved against, or nil for single-file
 rec Analyzed {
-    s:    *sess.Session;
-    file: *src.SourceFile;
-    a:    *ast.Ast;
-    rr:   *res.ResolveResult;
-    own:  sess.ModuleId;
-    root: *project.Root;
+    interner: *intern.Interner;
+    file:     *src.SourceFile;
+    a:        *ast.Ast;
+    rr:       *res.ResolveResult;
+    own:      sess.ModuleId;
+    root:     *project.Root;
 }
 
 # hover: answer textDocument/hover with the type / declaration of the symbol at
 # the cursor, or null when the position is not on a resolved symbol.
-pub fun hover(ws: *project.Workspace, es: *editor.EditorSession, s: *sess.Session, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
+pub fun hover(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
     val id_raw: str = json.extract_raw(body, "\"id\"", alloc);
     if (id_raw == nil) { ret; }
 
     var an: Analyzed;
-    val off_o: Option[usize] = locate(ws, es, s, alloc, docs, body, uri, ?an);
+    val off_o: Option[usize] = locate(ws, es, alloc, docs, body, uri, ?an);
     if (!is_some[usize](off_o)) { reply_null(alloc, id_raw); ret; }
     val offset: usize = unwrap[usize](off_o);
 
@@ -139,7 +139,7 @@ fun hover_markdown(ws: *project.Workspace, an: Analyzed, sym: *res.Symbol, uri: 
         project.free_site(ws, ?site);
     }
     if (sig == nil) {
-        sig = compose_kind_name(sym, ?an.s.interner, alloc);
+        sig = compose_kind_name(sym, an.interner, alloc);
     }
     if (sig == nil) { json.free_str(doc, alloc); ret nil; }
 
@@ -386,12 +386,12 @@ fun compose_kind_name(sym: *res.Symbol, interner: *intern.Interner, alloc: *Allo
 # symbol's declaration. lands in the buffer for a local symbol and in the
 # defining dependency module's on-disk file for a cross-module one; null when
 # the position is not on a resolved symbol or its declaration cannot be located.
-pub fun definition(ws: *project.Workspace, es: *editor.EditorSession, s: *sess.Session, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
+pub fun definition(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
     val id_raw: str = json.extract_raw(body, "\"id\"", alloc);
     if (id_raw == nil) { ret; }
 
     var an: Analyzed;
-    val off_o: Option[usize] = locate(ws, es, s, alloc, docs, body, uri, ?an);
+    val off_o: Option[usize] = locate(ws, es, alloc, docs, body, uri, ?an);
     if (!is_some[usize](off_o)) { reply_null(alloc, id_raw); ret; }
     val offset: usize = unwrap[usize](off_o);
 
@@ -428,12 +428,12 @@ pub fun definition(ws: *project.Workspace, es: *editor.EditorSession, s: *sess.S
 # the symbol at the cursor — its declaration plus every use-site across the
 # loaded project graph (the requesting buffer and every other module that
 # references the symbol). empty when the position is not on a resolved symbol.
-pub fun references(ws: *project.Workspace, es: *editor.EditorSession, s: *sess.Session, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
+pub fun references(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
     val id_raw: str = json.extract_raw(body, "\"id\"", alloc);
     if (id_raw == nil) { ret; }
 
     var an: Analyzed;
-    val off_o: Option[usize] = locate(ws, es, s, alloc, docs, body, uri, ?an);
+    val off_o: Option[usize] = locate(ws, es, alloc, docs, body, uri, ?an);
     if (!is_some[usize](off_o)) { reply_empty_array(alloc, id_raw); ret; }
     val offset: usize = unwrap[usize](off_o);
 
@@ -471,7 +471,7 @@ pub fun references(ws: *project.Workspace, es: *editor.EditorSession, s: *sess.S
 # itself), so those yield an empty edit. an empty edit is also returned when a
 # module-scope pub symbol's cross-file identity cannot be recovered from its
 # stale on-disk twin — a buffer-local edit there would be a partial rename.
-pub fun rename(ws: *project.Workspace, es: *editor.EditorSession, s: *sess.Session, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
+pub fun rename(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
     val id_raw: str = json.extract_raw(body, "\"id\"", alloc);
     if (id_raw == nil) { ret; }
 
@@ -479,7 +479,7 @@ pub fun rename(ws: *project.Workspace, es: *editor.EditorSession, s: *sess.Sessi
     if (new_name == nil) { reply_null(alloc, id_raw); ret; }
 
     var an: Analyzed;
-    val off_o: Option[usize] = locate(ws, es, s, alloc, docs, body, uri, ?an);
+    val off_o: Option[usize] = locate(ws, es, alloc, docs, body, uri, ?an);
     if (!is_some[usize](off_o)) { reply_empty_edit(alloc, id_raw); json.free_str(new_name, alloc); ret; }
     val offset: usize = unwrap[usize](off_o);
 
@@ -494,7 +494,7 @@ pub fun rename(ws: *project.Workspace, es: *editor.EditorSession, s: *sess.Sessi
 
     # the declared name guards the cross-file walk: only occurrences spelled with
     # it are rewritten, so an aliased import's references are left untouched.
-    val no: Option[str] = intern.lookup(?s.interner, sym.name);
+    val no: Option[str] = intern.lookup(an.interner, sym.name);
     if (!is_some[str](no)) { reply_empty_edit(alloc, id_raw); json.free_str(new_name, alloc); ret; }
     val name: str = unwrap[str](no);
 
@@ -526,12 +526,12 @@ pub fun rename(ws: *project.Workspace, es: *editor.EditorSession, s: *sess.Sessi
 # prepare_rename: answer textDocument/prepareRename with the range of the name
 # token at the cursor when it is a renameable symbol (a buffer-local symbol, or a
 # project-owned cross-module one), or null when it is not the editor's to rename.
-pub fun prepare_rename(ws: *project.Workspace, es: *editor.EditorSession, s: *sess.Session, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
+pub fun prepare_rename(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
     val id_raw: str = json.extract_raw(body, "\"id\"", alloc);
     if (id_raw == nil) { ret; }
 
     var an: Analyzed;
-    val off_o: Option[usize] = locate(ws, es, s, alloc, docs, body, uri, ?an);
+    val off_o: Option[usize] = locate(ws, es, alloc, docs, body, uri, ?an);
     if (!is_some[usize](off_o)) { reply_null(alloc, id_raw); ret; }
     val offset: usize = unwrap[usize](off_o);
 
@@ -558,28 +558,28 @@ pub fun prepare_rename(ws: *project.Workspace, es: *editor.EditorSession, s: *se
 # document_symbol: answer textDocument/documentSymbol with a flat list of the
 # file's top-level declarations as DocumentSymbol nodes (name, kind, range,
 # selectionRange).
-pub fun document_symbol(ws: *project.Workspace, es: *editor.EditorSession, s: *sess.Session, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
+pub fun document_symbol(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
     val id_raw: str = json.extract_raw(body, "\"id\"", alloc);
     if (id_raw == nil) { ret; }
 
     var an: Analyzed;
-    val okd: bool = analyze(ws, es, s, docs, uri, ?an);
+    val okd: bool = analyze(ws, es, docs, uri, ?an);
     if (!okd) { reply_empty_array(alloc, id_raw); ret; }
 
-    emit_document_symbols(an, s, alloc, id_raw);
+    emit_document_symbols(an, alloc, id_raw);
 }
 
 # completion: answer textDocument/completion with the in-scope top-level names
 # (module decls, `use` aliases / imports, primitives) as CompletionItems.
-pub fun completion(ws: *project.Workspace, es: *editor.EditorSession, s: *sess.Session, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
+pub fun completion(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
     val id_raw: str = json.extract_raw(body, "\"id\"", alloc);
     if (id_raw == nil) { ret; }
 
     var an: Analyzed;
-    val okc: bool = analyze(ws, es, s, docs, uri, ?an);
+    val okc: bool = analyze(ws, es, docs, uri, ?an);
     if (!okc) { reply_empty_array(alloc, id_raw); ret; }
 
-    emit_completions(an, s, alloc, id_raw);
+    emit_completions(an, alloc, id_raw);
 }
 
 # binding_span: write the binding name span of a param / generic symbol into
@@ -725,12 +725,12 @@ fun free_refs(ws: *project.Workspace, refs: *XRef, n: usize) {
 }
 
 # analyze: resolve the document named by `uri` against the dependency graph of
-# the project root that governs it and populate `out` with its session, file,
+# the project root that governs it and populate `out` with its interner, file,
 # Ast, ResolveResult, governing root, and module id. false when the document is
 # unknown or resolution fails. the module id is the root's synthetic buffer id,
 # matching the one resolution bound local symbols under, so the local /
 # cross-module distinction holds.
-fun analyze(ws: *project.Workspace, es: *editor.EditorSession, s: *sess.Session, docs: *documents.Store, uri: str, out: *Analyzed) bool {
+fun analyze(ws: *project.Workspace, es: *editor.EditorSession, docs: *documents.Store, uri: str, out: *Analyzed) bool {
     if (uri == nil) { ret false; }
     val doc: *documents.Document = documents.find(docs, uri);
     if (doc == nil) { ret false; }
@@ -742,20 +742,20 @@ fun analyze(ws: *project.Workspace, es: *editor.EditorSession, s: *sess.Session,
     out.a  = editor.ast_of(es, doc.file_id);
     if (out.a == nil) { ret false; }
 
-    val fo: Option[*src.SourceFile] = src.get(?s.sources, doc.file_id);
+    val fo: Option[*src.SourceFile] = src.get(project.sources(ws), doc.file_id);
     if (!is_some[*src.SourceFile](fo)) { ret false; }
-    out.s    = s;
-    out.file = unwrap[*src.SourceFile](fo);
-    out.root = root;
-    out.own  = project.own_module(root, doc.file_id);
+    out.interner = project.interner(ws);
+    out.file     = unwrap[*src.SourceFile](fo);
+    out.root     = root;
+    out.own      = project.own_module(root, doc.file_id);
     ret true;
 }
 
 # locate: analyze the target document and resolve the request's cursor position
 # to a byte offset, or none when the document is unknown / unresolvable or the
 # position is invalid (callers fall back to a null / empty reply).
-fun locate(ws: *project.Workspace, es: *editor.EditorSession, s: *sess.Session, alloc: *Allocator, docs: *documents.Store, body: str, uri: str, out: *Analyzed) Option[usize] {
-    if (!analyze(ws, es, s, docs, uri, out)) { ret none[usize](); }
+fun locate(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, body: str, uri: str, out: *Analyzed) Option[usize] {
+    if (!analyze(ws, es, docs, uri, out)) { ret none[usize](); }
 
     val line: i64 = json.extract_number_after(body, "\"position\"", "\"line\"", alloc);
     val ch:   i64 = json.extract_number_after(body, "\"position\"", "\"character\"", alloc);
@@ -989,7 +989,7 @@ fun free_groups(groups: *str, n: usize, alloc: *Allocator) {
 
 # emit_document_symbols: send a DocumentSymbol[] of the file's top-level decls.
 # takes ownership of `id_raw` and frees it.
-fun emit_document_symbols(an: Analyzed, s: *sess.Session, alloc: *Allocator, id_raw: str) {
+fun emit_document_symbols(an: Analyzed, alloc: *Allocator, id_raw: str) {
     val prefix: str = "{\"jsonrpc\":\"2.0\",\"id\":";
     val mid:    str = ",\"result\":[";
     val suffix: str = "]}";
@@ -1001,7 +1001,7 @@ fun emit_document_symbols(an: Analyzed, s: *sess.Session, alloc: *Allocator, id_
 
     var d1: u32 = 0;
     for (d1 < n) {
-        val entry: str = doc_symbol_json(an, s, features.top_level_decl(an.a, d1), alloc);
+        val entry: str = doc_symbol_json(an, features.top_level_decl(an.a, d1), alloc);
         if (entry != nil) {
             if (count > 0) { total = total + 1; }
             total = total + str_len(entry);
@@ -1023,7 +1023,7 @@ fun emit_document_symbols(an: Analyzed, s: *sess.Session, alloc: *Allocator, id_
     var emitted: usize = 0;
     var d2: u32 = 0;
     for (d2 < n) {
-        val entry: str = doc_symbol_json(an, s, features.top_level_decl(an.a, d2), alloc);
+        val entry: str = doc_symbol_json(an, features.top_level_decl(an.a, d2), alloc);
         if (entry != nil) {
             if (emitted > 0) { buf[off] = ','; off = off + 1; }
             off = append(buf, off, entry);
@@ -1042,7 +1042,7 @@ fun emit_document_symbols(an: Analyzed, s: *sess.Session, alloc: *Allocator, id_
 
 # doc_symbol_json: render decl `did` as a DocumentSymbol object, or nil when the
 # decl has no nameable symbol (use / fwd / test / comptime / error).
-fun doc_symbol_json(an: Analyzed, s: *sess.Session, did: id.DeclId, alloc: *Allocator) str {
+fun doc_symbol_json(an: Analyzed, did: id.DeclId, alloc: *Allocator) str {
     val d_opt: Option[*decl.Decl] = ast.get_decl(an.a, did);
     if (!is_some[*decl.Decl](d_opt)) { ret nil; }
     val d: *decl.Decl = unwrap[*decl.Decl](d_opt);
@@ -1109,7 +1109,7 @@ fun decl_lsp_kind(kind: decl.DeclKind) i64 {
 # emit_completions: send a CompletionItem[] of the file's top-level names, each
 # deduped by spelling so a name declared once appears once. takes ownership of
 # `id_raw` and frees it.
-fun emit_completions(an: Analyzed, s: *sess.Session, alloc: *Allocator, id_raw: str) {
+fun emit_completions(an: Analyzed, alloc: *Allocator, id_raw: str) {
     val prefix: str = "{\"jsonrpc\":\"2.0\",\"id\":";
     val mid:    str = ",\"result\":{\"isIncomplete\":false,\"items\":[";
     val suffix: str = "]}}";
@@ -1120,7 +1120,7 @@ fun emit_completions(an: Analyzed, s: *sess.Session, alloc: *Allocator, id_raw: 
     var i1: u32 = 0;
     for (i1 < an.rr.symbol_count) {
         if (completion_first(an, i1)) {
-            val entry: str = completion_json(an, s, i1, alloc);
+            val entry: str = completion_json(an, i1, alloc);
             if (entry != nil) {
                 if (count > 0) { total = total + 1; }
                 total = total + str_len(entry);
@@ -1144,7 +1144,7 @@ fun emit_completions(an: Analyzed, s: *sess.Session, alloc: *Allocator, id_raw: 
     var i2: u32 = 0;
     for (i2 < an.rr.symbol_count) {
         if (completion_first(an, i2)) {
-            val entry: str = completion_json(an, s, i2, alloc);
+            val entry: str = completion_json(an, i2, alloc);
             if (entry != nil) {
                 if (emitted > 0) { buf[off] = ','; off = off + 1; }
                 off = append(buf, off, entry);
@@ -1176,9 +1176,9 @@ fun completion_first(an: Analyzed, sid: res.SymbolId) bool {
 }
 
 # completion_json: render symbol `sid` as a CompletionItem, or nil.
-fun completion_json(an: Analyzed, s: *sess.Session, sid: res.SymbolId, alloc: *Allocator) str {
+fun completion_json(an: Analyzed, sid: res.SymbolId, alloc: *Allocator) str {
     val sym: *res.Symbol = ?an.rr.symbols[sid];
-    val no: Option[str] = intern.lookup(?s.interner, sym.name);
+    val no: Option[str] = intern.lookup(an.interner, sym.name);
     if (!is_some[str](no)) { ret nil; }
     val qname: str = json.quote(unwrap[str](no), alloc);
     if (qname == nil) { ret nil; }

--- a/src/project.mach
+++ b/src/project.mach
@@ -330,9 +330,7 @@ pub fun resolve_doc(w: *Workspace, root: *Root, fid: src.FileId) Result[*res.Res
     val slot: *res.ResolveResult = unwrap_ok[*res.ResolveResult, str](slot_r);
     @slot = unwrap_ok[res.ResolveResult, str](rr_r);
 
-    var stamp: u32 = 0;
-    if (root != nil) { stamp = root.gen; }
-    if (!cache_put(w, fid, slot, a, stamp)) {
+    if (!cache_put(w, fid, slot, a, root_gen(root))) {
         res.dnit_result(slot);
         deallocate[res.ResolveResult](w.alloc, slot, 1);
         ret err[*res.ResolveResult, str]("project: resolve cache allocation failed");
@@ -352,6 +350,15 @@ pub fun own_module(root: *Root, fid: src.FileId) sess.ModuleId {
     var base: u32 = 0;
     if (root != nil) { base = root.own_base; }
     ret (base + fid::u32)::sess.ModuleId;
+}
+
+# root_gen: the generation stamp a buffer's resolve carries under `root` — the
+# root's current build generation, or the reserved 0 for a single-file document
+# (root nil). the single source of the stamp rule, shared by cache_put's write
+# and cache_hit's check so the two sides cannot drift.
+fun root_gen(root: *Root) u32 {
+    if (root == nil) { ret 0; }
+    ret root.gen;
 }
 
 # root_for: the root governing the document at `uri`, loading it on first use,
@@ -1114,9 +1121,7 @@ fun cache_hit(w: *Workspace, fid: src.FileId, a: *ast.Ast, root: *Root) *res.Res
     if (w.cache == nil || fid::u32 >= w.cache_len) { ret nil; }
     val c: *Cached = ?w.cache[fid::u32];
     if (c.rr == nil || c.a != a) { ret nil; }
-    var want: u32 = 0;
-    if (root != nil) { want = root.gen; }
-    if (c.gen != want) { ret nil; }
+    if (c.gen != root_gen(root)) { ret nil; }
     ret c.rr;
 }
 
@@ -1150,16 +1155,22 @@ fun cache_put(w: *Workspace, fid: src.FileId, rr: *res.ResolveResult, a: *ast.As
     ret true;
 }
 
-# free_cached: release and clear the cached ResolveResult for `fid`, if any.
-fun free_cached(w: *Workspace, fid: src.FileId) {
-    if (w.cache == nil || fid::u32 >= w.cache_len) { ret; }
-    val c: *Cached = ?w.cache[fid::u32];
-    if (c.rr == nil) { ret; }
+# release_entry: free a cache slot's owned ResolveResult and zero the slot —
+# the one teardown for a Cached entry, shared by every reclamation path.
+# callers guard `c.rr != nil`.
+fun release_entry(w: *Workspace, c: *Cached) {
     res.dnit_result(c.rr);
     deallocate[res.ResolveResult](w.alloc, c.rr, 1);
     c.rr  = nil;
     c.a   = nil;
     c.gen = 0;
+}
+
+# free_cached: release and clear the cached ResolveResult for `fid`, if any.
+fun free_cached(w: *Workspace, fid: src.FileId) {
+    if (w.cache == nil || fid::u32 >= w.cache_len) { ret; }
+    val c: *Cached = ?w.cache[fid::u32];
+    if (c.rr != nil) { release_entry(w, c); }
 }
 
 # evict_root: release every cached result resolved against root `r`'s current
@@ -1173,13 +1184,7 @@ fun evict_root(w: *Workspace, r: *Root) {
     var i: u32 = 0;
     for (i < w.cache_len) {
         val c: *Cached = ?w.cache[i];
-        if (c.rr != nil && c.gen == r.gen) {
-            res.dnit_result(c.rr);
-            deallocate[res.ResolveResult](w.alloc, c.rr, 1);
-            c.rr  = nil;
-            c.a   = nil;
-            c.gen = 0;
-        }
+        if (c.rr != nil && c.gen == r.gen) { release_entry(w, c); }
         i = i + 1;
     }
 }
@@ -1191,13 +1196,7 @@ fun free_all_cached(w: *Workspace) {
     var i: u32 = 0;
     for (i < w.cache_len) {
         val c: *Cached = ?w.cache[i];
-        if (c.rr != nil) {
-            res.dnit_result(c.rr);
-            deallocate[res.ResolveResult](w.alloc, c.rr, 1);
-            c.rr  = nil;
-            c.a   = nil;
-            c.gen = 0;
-        }
+        if (c.rr != nil) { release_entry(w, c); }
         i = i + 1;
     }
 }

--- a/src/project.mach
+++ b/src/project.mach
@@ -22,11 +22,15 @@
 #
 # module-id namespacing: `driver.build_project` allocates project-local module
 # ids from 0 and writes them into the session's global module registries, so a
-# second build over the same session clobbers the first there. the LSP never
-# reads those session registries — every cross-module lookup (site_of,
+# second build over the same session clobbers the first there. those clobbered
+# registries are never read for a lookup — every cross-module lookup (site_of,
 # module_view, ...) reads the per-`Root` `driver.Project.modules` array, whose
-# ids are private to that project. each `Root` is therefore its own id space and
-# several projects coexist in one shared session without collision; per-root
+# ids are private to that project — and that boundary is structural, not just
+# convention: the `Workspace` is the sole holder of the `*sess.Session`, and
+# feature code receives only the per-root accessors plus the two safe, never-
+# clobbered session services (`interner` / `sources`), so a stray `sess.module_*`
+# read is unreachable from a feature. each `Root` is therefore its own id space
+# and several projects coexist in one shared session without collision; per-root
 # sessions are unnecessary. a buffer resolves under a synthetic id past its
 # root's `module_len`, so a buffer-local symbol's `origin` never equals a
 # loaded dependency's.
@@ -143,7 +147,9 @@ pub rec Root {
 
 # Workspace: the session's project roots plus the per-buffer resolve cache.
 # ---
-# s:            borrowed compiler session (sources, interner, module registry)
+# s:            the compiler session, held solely here; feature code reaches its
+#               safe services through `interner` / `sources`, never the whole
+#               session (whose per-build module registries a second load clobbers)
 # es:           borrowed editor session (buffer parsing)
 # alloc:        allocator for owned storage
 # roots:        array of Root slots (slots with a path are tracked roots)
@@ -185,6 +191,28 @@ pub fun init(s: *sess.Session, es: *editor.EditorSession, alloc: *Allocator) Wor
     w.cache         = nil;
     w.cache_len     = 0;
     ret w;
+}
+
+# interner: the session's shared string interner — the append-only symbol-name
+# registry feature code resolves StrIds through. exposed narrowly so a feature
+# never holds the whole session, whose per-build module registries a second
+# project load clobbers; the interner and source map are the only session
+# services a feature may safely read.
+# ---
+# w:   the workspace
+# ret: the session's interner
+pub fun interner(w: *Workspace) *intern.Interner {
+    ret ?w.s.interner;
+}
+
+# sources: the session's source-file registry, for resolving a FileId to its
+# SourceFile (text + line index). the other safe-to-read session service feature
+# and diagnostics code needs; see `interner` for why the whole session is held back.
+# ---
+# w:   the workspace
+# ret: the session's source map
+pub fun sources(w: *Workspace) *src.SourceMap {
+    ret ?w.s.sources;
 }
 
 # set_watch_active: record that the client delivers

--- a/src/project.mach
+++ b/src/project.mach
@@ -44,7 +44,7 @@
 # on each access reloads a stale root and retries a previously failed one (a
 # since-fixed manifest); with watching active the check is skipped. the resolve
 # cache stamps each entry with the generation of the root build it resolved
-# against (`Root.gen`, a fresh never-reused value per successful build; 0 for a
+# against (`Root.gen`, a fresh value per successful build; 0 reserved for a
 # single-file resolve), so a build's teardown makes every entry from it
 # structurally unhittable — no entry survives its root's reload as a stale hit —
 # while a freed root's entries are evicted per-root rather than by clearing the
@@ -149,8 +149,8 @@ rec Cached {
 # man_mtime:      `mach.toml` mtime at the last load attempt, for the
 #                 conservative reload / retry check
 # lock_mtime:     `mach.lock` mtime at the last load attempt (0 when absent)
-# gen:            generation stamp of the current loaded build — a fresh, never-
-#                 reused value claimed on each successful load, 0 while unloaded;
+# gen:            generation stamp of the current loaded build — a fresh value
+#                 claimed on each successful load, 0 (reserved) while unloaded;
 #                 resolve cache entries carry it, so a reload or free makes the
 #                 prior build's entries unhittable and per-root evictable
 pub rec Root {
@@ -631,10 +631,12 @@ fun try_load(w: *Workspace, r: *Root) bool {
     ret true;
 }
 
-# next_gen: hand out a fresh, never-reused generation stamp. each successful
-# build claims one, so a cache entry's generation identifies its exact build and
-# a reloaded or freed root's stale entries can never match a later build.
+# next_gen: hand out a fresh generation stamp. each successful build claims one,
+# so a cache entry's generation identifies its exact build and a reloaded or
+# freed root's stale entries can never match a later build. 0 is the reserved
+# unloaded / single-file sentinel and is skipped if the sequence ever wraps.
 fun next_gen(w: *Workspace) u32 {
+    if (w.gen_seq == 0) { w.gen_seq = 1; }
     val g: u32 = w.gen_seq;
     w.gen_seq = w.gen_seq + 1;
     ret g;

--- a/src/project.mach
+++ b/src/project.mach
@@ -1167,7 +1167,13 @@ fun release_entry(w: *Workspace, c: *Cached) {
 }
 
 # free_cached: release and clear the cached ResolveResult for `fid`, if any.
-fun free_cached(w: *Workspace, fid: src.FileId) {
+# called before a re-resolve replaces the entry, and by the server on didClose
+# so a retired document's result is reclaimed immediately instead of lingering
+# until its FileId is reused or its root reloads.
+# ---
+# w:   the workspace
+# fid: the buffer whose cached result to drop
+pub fun free_cached(w: *Workspace, fid: src.FileId) {
     if (w.cache == nil || fid::u32 >= w.cache_len) { ret; }
     val c: *Cached = ?w.cache[fid::u32];
     if (c.rr != nil) { release_entry(w, c); }

--- a/src/project.mach
+++ b/src/project.mach
@@ -40,7 +40,13 @@
 # changed file, so the next request rebuilds it from disk. when the client does
 # not deliver watch notifications, a conservative manifest/lockfile mtime check
 # on each access reloads a stale root and retries a previously failed one (a
-# since-fixed manifest); with watching active the check is skipped.
+# since-fixed manifest); with watching active the check is skipped. the resolve
+# cache stamps each entry with the generation of the root build it resolved
+# against (`Root.gen`, a fresh never-reused value per successful build; 0 for a
+# single-file resolve), so a build's teardown makes every entry from it
+# structurally unhittable — no entry survives its root's reload as a stale hit —
+# while a freed root's entries are evicted per-root rather than by clearing the
+# whole cache.
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -104,13 +110,21 @@ pub rec Site {
     owned: bool;
 }
 
-# Cached: one buffer's dep-aware resolve result, keyed by the Ast it was
-# resolved from. the editor replaces a buffer's `*ast.Ast` on every text update
-# (`drop_analysis`), so pointer identity of the Ast is the staleness check —
-# the same contract `editor.resolve` uses for its own cached result.
+# Cached: one buffer's dep-aware resolve result, stamped with the Ast it was
+# resolved from and the generation of the root build it resolved against. the
+# editor replaces a buffer's `*ast.Ast` on every text update (`drop_analysis`),
+# so Ast pointer identity catches a text edit — the same contract
+# `editor.resolve` uses for its own cached result; `gen` catches a cross-root or
+# post-reload staleness, since a result resolved against one build never matches
+# a different build's stamp.
+# ---
+# rr:  the cached dep-aware ResolveResult, owned by the cache
+# a:   the Ast the result was resolved from (text-edit staleness check)
+# gen: generation of the root build it resolved against, or 0 for single-file
 rec Cached {
-    rr: *res.ResolveResult;
-    a:  *ast.Ast;
+    rr:  *res.ResolveResult;
+    a:   *ast.Ast;
+    gen: u32;
 }
 
 # Root: one project root open in the session and the dependency graph built from
@@ -133,6 +147,10 @@ rec Cached {
 # man_mtime:      `mach.toml` mtime at the last load attempt, for the
 #                 conservative reload / retry check
 # lock_mtime:     `mach.lock` mtime at the last load attempt (0 when absent)
+# gen:            generation stamp of the current loaded build — a fresh, never-
+#                 reused value claimed on each successful load, 0 while unloaded;
+#                 resolve cache entries carry it, so a reload or free makes the
+#                 prior build's entries unhittable and per-root evictable
 pub rec Root {
     path:           str;
     loaded:         bool;
@@ -143,6 +161,7 @@ pub rec Root {
     own_base:       u32;
     man_mtime:      i64;
     lock_mtime:     i64;
+    gen:            u32;
 }
 
 # Workspace: the session's project roots plus the per-buffer resolve cache.
@@ -160,6 +179,8 @@ pub rec Root {
 # empty:        the empty dep set used for documents outside any project
 # cache:        per-FileId cache of each buffer's dep-aware ResolveResult
 # cache_len:    number of slots in `cache`
+# gen_seq:      next generation stamp to hand out; each successful root build
+#               claims one, pinning a cache entry's gen to an exact build
 pub rec Workspace {
     s:            *sess.Session;
     es:           *editor.EditorSession;
@@ -170,6 +191,7 @@ pub rec Workspace {
     empty:        res.ResolveDeps;
     cache:        *Cached;
     cache_len:    u32;
+    gen_seq:      u32;
 }
 
 # init: construct an empty workspace over the server's sessions.
@@ -190,6 +212,7 @@ pub fun init(s: *sess.Session, es: *editor.EditorSession, alloc: *Allocator) Wor
     w.empty.count   = 0;
     w.cache         = nil;
     w.cache_len     = 0;
+    w.gen_seq       = 1;
     ret w;
 }
 
@@ -230,7 +253,7 @@ pub fun set_watch_active(w: *Workspace, on: bool) {
 # ---
 # w: workspace to tear down; all owned fields are zeroed
 pub fun dnit(w: *Workspace) {
-    clear_cache(w);
+    free_all_cached(w);
     if (w.cache != nil && w.cache_len > 0) {
         deallocate[Cached](w.alloc, w.cache, w.cache_len::usize);
     }
@@ -260,7 +283,7 @@ pub fun dnit(w: *Workspace) {
 pub fun resolve_doc(w: *Workspace, root: *Root, fid: src.FileId) Result[*res.ResolveResult, str] {
     var a: *ast.Ast = editor.ast_of(w.es, fid);
     if (a != nil) {
-        val hit: *res.ResolveResult = cache_hit(w, fid, a);
+        val hit: *res.ResolveResult = cache_hit(w, fid, a, root);
         if (hit != nil) { ret ok[*res.ResolveResult, str](hit); }
     }
     if (a == nil) {
@@ -300,7 +323,9 @@ pub fun resolve_doc(w: *Workspace, root: *Root, fid: src.FileId) Result[*res.Res
     val slot: *res.ResolveResult = unwrap_ok[*res.ResolveResult, str](slot_r);
     @slot = unwrap_ok[res.ResolveResult, str](rr_r);
 
-    if (!cache_put(w, fid, slot, a)) {
+    var stamp: u32 = 0;
+    if (root != nil) { stamp = root.gen; }
+    if (!cache_put(w, fid, slot, a, stamp)) {
         res.dnit_result(slot);
         deallocate[res.ResolveResult](w.alloc, slot, 1);
         ret err[*res.ResolveResult, str]("project: resolve cache allocation failed");
@@ -533,6 +558,7 @@ fun reset_slot(r: *Root) {
     r.own_base       = 0;
     r.man_mtime      = 0;
     r.lock_mtime     = 0;
+    r.gen            = 0;
 }
 
 # alloc_slot: a reusable dead slot, growing the array when every slot is
@@ -570,9 +596,10 @@ fun alloc_slot(w: *Workspace) *Root {
 # the manifest / lockfile mtimes are recorded at the start of the attempt
 # whether it succeeds or fails, so maybe_reload retries a failed root once those
 # files change instead of pinning the failure for the session. a failure is
-# surfaced (trace log + window/showMessage); on success the whole resolve cache
-# is cleared: results resolved before the load used the empty dep set and the
-# pre-load own_base.
+# surfaced (trace log + window/showMessage); on success the root claims a fresh
+# generation stamp, so any result resolved before the load (against the empty dep
+# set and the pre-load own_base, stamped a different generation) misses the cache
+# rather than being served stale.
 fun try_load(w: *Workspace, r: *Root) bool {
     record_mtimes(w, r);
 
@@ -591,10 +618,19 @@ fun try_load(w: *Workspace, r: *Root) bool {
     r.p        = unwrap_ok[driver.Project, str](pr);
     r.loaded   = true;
     r.own_base = r.p.module_len;
-    clear_cache(w);
+    r.gen      = next_gen(w);
     build_mod_paths(w, r);
     build_deps(w, r);
     ret true;
+}
+
+# next_gen: hand out a fresh, never-reused generation stamp. each successful
+# build claims one, so a cache entry's generation identifies its exact build and
+# a reloaded or freed root's stale entries can never match a later build.
+fun next_gen(w: *Workspace) u32 {
+    val g: u32 = w.gen_seq;
+    w.gen_seq = w.gen_seq + 1;
+    ret g;
 }
 
 # build_mod_paths: snapshot every loaded module's normalized source path into
@@ -648,7 +684,6 @@ fun maybe_reload(w: *Workspace, r: *Root) {
     stat_mtimes(w, r.path, ?man, ?lock);
     if (man == r.man_mtime && lock == r.lock_mtime) { ret; }
     free_root_graph(w, r);
-    clear_cache(w);
     try_load(w, r);
 }
 
@@ -656,7 +691,7 @@ fun maybe_reload(w: *Workspace, r: *Root) {
 # the next request rebuilds it from disk. the LSP trigger is
 # `workspace/didChangeWatchedFiles`; a changed `mach.toml` / `mach.lock` or any
 # source under a root (including a vendored dependency under `dep/`) invalidates
-# that root. the resolve cache is cleared when any root is dropped.
+# that root. each dropped root's cached results are evicted per-root by free_root.
 # ---
 # w:   the workspace
 # uri: the URI of the changed file
@@ -665,18 +700,15 @@ pub fun invalidate_uri(w: *Workspace, uri: str) {
     val norm: str = uri_to_norm(w.alloc, uri);
     if (norm == nil) { ret; }
 
-    var changed: bool = false;
     var i: u32 = 0;
     for (i < w.root_cap) {
         val r: *Root = ?w.roots[i];
         if (r.path != nil && root_covers(w, norm, r.path)) {
             free_root(w, r);
-            changed = true;
         }
         i = i + 1;
     }
     strutil.str_free(w.alloc, norm);
-    if (changed) { clear_cache(w); }
 }
 
 # root_covers: whether `file_norm` (a normalized absolute path) lies within the
@@ -709,14 +741,18 @@ fun free_root(w: *Workspace, r: *Root) {
 
 # free_root_graph: release a root's dep snapshot, module-path snapshot, and
 # loaded project, leaving the slot tracked with its path so it can reload in
-# place.
+# place. the build's cached resolve results are evicted first (so a teardown
+# reclaims them rather than leaving them for the whole-cache sweep), and the
+# generation is cleared so a later build claims a fresh, non-matching one.
 fun free_root_graph(w: *Workspace, r: *Root) {
+    evict_root(w, r);
     free_deps(w, ?r.deps);
     free_mod_paths(w, r);
     if (r.loaded) {
         driver.dnit_project(?r.p);
         r.loaded = false;
     }
+    r.gen = 0;
 }
 
 # record_mtimes: snapshot the root's manifest / lockfile mtimes for the
@@ -1061,18 +1097,25 @@ fun free_deps(w: *Workspace, deps: *res.ResolveDeps) {
 
 # cache_hit: the cached ResolveResult for `fid` when it was resolved from the
 # exact Ast `a` (the editor replaces the Ast pointer on every text update, so
-# pointer identity proves the result is current), or nil.
-fun cache_hit(w: *Workspace, fid: src.FileId, a: *ast.Ast) *res.ResolveResult {
+# pointer identity proves the text is current) and against the same build as
+# `root` (the entry's generation must equal the root's current `gen`, or 0 when
+# resolving single-file), or nil. the generation match is what makes a result
+# from a since-reloaded or different root structurally unhittable.
+fun cache_hit(w: *Workspace, fid: src.FileId, a: *ast.Ast, root: *Root) *res.ResolveResult {
     if (w.cache == nil || fid::u32 >= w.cache_len) { ret nil; }
     val c: *Cached = ?w.cache[fid::u32];
     if (c.rr == nil || c.a != a) { ret nil; }
+    var want: u32 = 0;
+    if (root != nil) { want = root.gen; }
+    if (c.gen != want) { ret nil; }
     ret c.rr;
 }
 
-# cache_put: store `rr` (resolved from Ast `a`) as the cached result for `fid`,
-# growing the cache to cover the FileId and zero-filling any gap. false when
-# the grow allocation fails — the caller owns `rr` and must free it.
-fun cache_put(w: *Workspace, fid: src.FileId, rr: *res.ResolveResult, a: *ast.Ast) bool {
+# cache_put: store `rr` (resolved from Ast `a` against the build stamped `gen`,
+# or 0 for single-file) as the cached result for `fid`, growing the cache to
+# cover the FileId and zero-filling any gap. false when the grow allocation fails
+# — the caller owns `rr` and must free it.
+fun cache_put(w: *Workspace, fid: src.FileId, rr: *res.ResolveResult, a: *ast.Ast, gen: u32) bool {
     val needed: u32 = fid::u32 + 1;
     if (needed > w.cache_len) {
         var new_len: u32 = w.cache_len;
@@ -1089,11 +1132,12 @@ fun cache_put(w: *Workspace, fid: src.FileId, rr: *res.ResolveResult, a: *ast.As
             w.cache = unwrap_ok[*Cached, str](r);
         }
         var z: u32 = w.cache_len;
-        for (z < new_len) { w.cache[z].rr = nil; w.cache[z].a = nil; z = z + 1; }
+        for (z < new_len) { w.cache[z].rr = nil; w.cache[z].a = nil; w.cache[z].gen = 0; z = z + 1; }
         w.cache_len = new_len;
     }
-    w.cache[fid::u32].rr = rr;
-    w.cache[fid::u32].a  = a;
+    w.cache[fid::u32].rr  = rr;
+    w.cache[fid::u32].a   = a;
+    w.cache[fid::u32].gen = gen;
     ret true;
 }
 
@@ -1104,12 +1148,36 @@ fun free_cached(w: *Workspace, fid: src.FileId) {
     if (c.rr == nil) { ret; }
     res.dnit_result(c.rr);
     deallocate[res.ResolveResult](w.alloc, c.rr, 1);
-    c.rr = nil;
-    c.a  = nil;
+    c.rr  = nil;
+    c.a   = nil;
+    c.gen = 0;
 }
 
-# clear_cache: release every cached ResolveResult, keeping the slot array.
-fun clear_cache(w: *Workspace) {
+# evict_root: release every cached result resolved against root `r`'s current
+# build (matched by generation), reclaiming the entries a graph teardown
+# invalidates. a no-op for an unloaded slot (gen 0, no build of its own — and
+# never the single-file entries that also carry gen 0, since those belong to no
+# root). called by free_root_graph at every reload / free, replacing the blanket
+# whole-cache clear.
+fun evict_root(w: *Workspace, r: *Root) {
+    if (w.cache == nil || r.gen == 0) { ret; }
+    var i: u32 = 0;
+    for (i < w.cache_len) {
+        val c: *Cached = ?w.cache[i];
+        if (c.rr != nil && c.gen == r.gen) {
+            res.dnit_result(c.rr);
+            deallocate[res.ResolveResult](w.alloc, c.rr, 1);
+            c.rr  = nil;
+            c.a   = nil;
+            c.gen = 0;
+        }
+        i = i + 1;
+    }
+}
+
+# free_all_cached: release every cached ResolveResult, keeping the slot array.
+# the teardown sweep used by dnit; per-build invalidation goes through evict_root.
+fun free_all_cached(w: *Workspace) {
     if (w.cache == nil) { ret; }
     var i: u32 = 0;
     for (i < w.cache_len) {
@@ -1117,8 +1185,9 @@ fun clear_cache(w: *Workspace) {
         if (c.rr != nil) {
             res.dnit_result(c.rr);
             deallocate[res.ResolveResult](w.alloc, c.rr, 1);
-            c.rr = nil;
-            c.a  = nil;
+            c.rr  = nil;
+            c.a   = nil;
+            c.gen = 0;
         }
         i = i + 1;
     }

--- a/src/project.mach
+++ b/src/project.mach
@@ -25,15 +25,17 @@
 # second build over the same session clobbers the first there. those clobbered
 # registries are never read for a lookup — every cross-module lookup (site_of,
 # module_view, ...) reads the per-`Root` `driver.Project.modules` array, whose
-# ids are private to that project — and that boundary is structural, not just
-# convention: the `Workspace` is the sole holder of the `*sess.Session`, and
-# feature code receives only the per-root accessors plus the two safe, never-
-# clobbered session services (`interner` / `sources`), so a stray `sess.module_*`
-# read is unreachable from a feature. each `Root` is therefore its own id space
-# and several projects coexist in one shared session without collision; per-root
-# sessions are unnecessary. a buffer resolves under a synthetic id past its
-# root's `module_len`, so a buffer-local symbol's `origin` never equals a
-# loaded dependency's.
+# ids are private to that project. the seam guarding that invariant is a
+# narrowed surface, not a language seal: no feature signature carries a
+# `*sess.Session` — feature code is handed only the per-root accessors plus the
+# two never-clobbered session services (`interner` / `sources`) — so reading a
+# session module registry takes deliberately reaching through `Workspace.s` or
+# the vendored `EditorSession.s`, both of which stay readable because mach's
+# `pub` publishes whole recs (no field-level visibility). each `Root` is
+# therefore its own id space and several projects coexist in one shared session
+# without collision; per-root sessions are unnecessary. a buffer resolves under
+# a synthetic id past its root's `module_len`, so a buffer-local symbol's
+# `origin` never equals a loaded dependency's.
 #
 # invalidation: a root's graph is a load-time snapshot. `invalidate_uri` (driven
 # by `workspace/didChangeWatchedFiles`) drops every root whose tree contains the
@@ -166,9 +168,11 @@ pub rec Root {
 
 # Workspace: the session's project roots plus the per-buffer resolve cache.
 # ---
-# s:            the compiler session, held solely here; feature code reaches its
-#               safe services through `interner` / `sources`, never the whole
-#               session (whose per-build module registries a second load clobbers)
+# s:            the compiler session. feature code must reach its safe services
+#               through `interner` / `sources` and never read this field: its
+#               per-build module registries are clobbered on every project load,
+#               and mach's whole-rec `pub` means the field cannot be sealed —
+#               keeping it out of feature paths is the contract
 # es:           borrowed editor session (buffer parsing)
 # alloc:        allocator for owned storage
 # roots:        array of Root slots (slots with a path are tracked roots)
@@ -217,10 +221,12 @@ pub fun init(s: *sess.Session, es: *editor.EditorSession, alloc: *Allocator) Wor
 }
 
 # interner: the session's shared string interner — the append-only symbol-name
-# registry feature code resolves StrIds through. exposed narrowly so a feature
-# never holds the whole session, whose per-build module registries a second
-# project load clobbers; the interner and source map are the only session
-# services a feature may safely read.
+# registry feature code resolves StrIds through. handed out instead of the whole
+# session so no feature signature carries one: the session's per-build module
+# registries are clobbered on every project load, and the interner and source
+# map are the only session services a feature may safely read. (mach's whole-rec
+# `pub` leaves `Workspace.s` technically reachable; the narrowed surface is the
+# guard, not a language seal.)
 # ---
 # w:   the workspace
 # ret: the session's interner
@@ -230,7 +236,8 @@ pub fun interner(w: *Workspace) *intern.Interner {
 
 # sources: the session's source-file registry, for resolving a FileId to its
 # SourceFile (text + line index). the other safe-to-read session service feature
-# and diagnostics code needs; see `interner` for why the whole session is held back.
+# and diagnostics code needs; see `interner` for why the whole session is kept
+# out of feature signatures.
 # ---
 # w:   the workspace
 # ret: the session's source map

--- a/src/server.mach
+++ b/src/server.mach
@@ -326,10 +326,13 @@ fun handle_did_change(srv: *Server, body: str) {
     json.free_str(uri, srv.alloc);
 }
 
-# handle_did_close: retire the document and clear its diagnostics.
+# handle_did_close: retire the document, reclaim its cached resolve result, and
+# clear its diagnostics.
 fun handle_did_close(srv: *Server, body: str) {
     val uri: str = json.extract_after(body, "\"textDocument\"", "\"uri\"", srv.alloc);
     if (uri == nil) { ret; }
+    val doc: *documents.Document = documents.find(?srv.docs, uri);
+    if (doc != nil) { project.free_cached(?srv.ws, doc.file_id); }
     documents.close(?srv.docs, uri);
     diagnostics.clear(srv.alloc, uri);
     json.free_str(uri, srv.alloc);

--- a/src/server.mach
+++ b/src/server.mach
@@ -344,13 +344,13 @@ fun handle_did_close(srv: *Server, body: str) {
 fun handle_feature(srv: *Server, body: str, which: i64) {
     val uri: str = json.extract_after(body, "\"textDocument\"", "\"uri\"", srv.alloc);
 
-    if (which == 0) { language.hover(?srv.ws, ?srv.es, ?srv.s, srv.alloc, ?srv.docs, body, uri); }
-    or (which == 1) { language.definition(?srv.ws, ?srv.es, ?srv.s, srv.alloc, ?srv.docs, body, uri); }
-    or (which == 2) { language.references(?srv.ws, ?srv.es, ?srv.s, srv.alloc, ?srv.docs, body, uri); }
-    or (which == 3) { language.rename(?srv.ws, ?srv.es, ?srv.s, srv.alloc, ?srv.docs, body, uri); }
-    or (which == 4) { language.prepare_rename(?srv.ws, ?srv.es, ?srv.s, srv.alloc, ?srv.docs, body, uri); }
-    or (which == 5) { language.document_symbol(?srv.ws, ?srv.es, ?srv.s, srv.alloc, ?srv.docs, body, uri); }
-    or (which == 6) { language.completion(?srv.ws, ?srv.es, ?srv.s, srv.alloc, ?srv.docs, body, uri); }
+    if (which == 0) { language.hover(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, body, uri); }
+    or (which == 1) { language.definition(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, body, uri); }
+    or (which == 2) { language.references(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, body, uri); }
+    or (which == 3) { language.rename(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, body, uri); }
+    or (which == 4) { language.prepare_rename(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, body, uri); }
+    or (which == 5) { language.document_symbol(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, body, uri); }
+    or (which == 6) { language.completion(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, body, uri); }
 
     if (uri != nil) { json.free_str(uri, srv.alloc); }
 }
@@ -369,7 +369,7 @@ fun publish_for(srv: *Server, uri: str, text: str, is_open: bool) {
         ret;
     }
     val doc: *documents.Document = unwrap_ok[*documents.Document, str](dr);
-    diagnostics.publish(?srv.es, ?srv.s, srv.alloc, uri, doc.file_id);
+    diagnostics.publish(?srv.es, project.sources(?srv.ws), srv.alloc, uri, doc.file_id);
 }
 
 # reply_error: send a JSON-RPC error response for a request that carries an id;

--- a/test/test_invalidation.py
+++ b/test/test_invalidation.py
@@ -161,6 +161,60 @@ def broken_manifest_recovers():
     return failures
 
 
+def reload_rebinds_cached_resolve():
+    """a buffer resolve cached before its root reloads must not be served stale.
+    the other scenarios only shift a declaration's line, which leaves its DeclId
+    intact — so a stale cached cross-module resolve would still read the right
+    declaration off the live (reloaded) graph and pass. here the dep is rewritten
+    to REORDER its declarations, moving `shared`'s DeclId as well as its line: a
+    stale cached resolve carries `shared`'s old DeclId and would now resolve to a
+    different declaration entirely, while a fresh re-resolve lands on `shared`'s
+    new line. asserting the new line proves the cache entry did not survive the
+    reload as a stale hit."""
+    proj, app, lib = _scratch_project()
+    app_uri = file_uri(app)
+    lib_uri = file_uri(lib)
+    failures = []
+    srv = LiveServer()
+    try:
+        srv.send(req(1, "initialize", {"capabilities": {}}))
+        srv.recv_id(1)
+        srv.send(notify("initialized"))
+        srv.send(did_open(app_uri, open(app).read()))
+
+        # warm the cache: this resolve of app is cached against the current build
+        uri1, line1 = _definition_line(srv, app_uri, 30)
+        if uri1 != lib_uri or line1 != DECL_LINE:
+            failures.append(f"definition(shared) before reload: uri {uri1} line {line1}, expected {lib_uri} line {DECL_LINE}")
+
+        new_lib = (
+            "# lib: reordered so shared's declaration id and line both move; a\n"
+            "# cached cross-module resolve served stale would point elsewhere.\n"
+            "pub val LIMIT: i64 = 10;\n"
+            "\n"
+            "\n"
+            "pub fun shared(x: i64) i64 {\n"
+            "    ret x;\n"
+            "}\n"
+        )
+        with open(lib, "w") as f:
+            f.write(new_lib)
+        want_line = new_lib.splitlines().index("pub fun shared(x: i64) i64 {")
+        srv.send(notify("workspace/didChangeWatchedFiles",
+                        {"changes": [{"uri": lib_uri, "type": 2}]}))
+
+        uri2, line2 = _definition_line(srv, app_uri, 31)
+        if uri2 != lib_uri or line2 != want_line:
+            failures.append(f"definition(shared) after reorder reload: uri {uri2} line {line2}, expected {lib_uri} line {want_line} (a stale cached resolve would land elsewhere)")
+
+        srv.send(req(2, "shutdown", None))
+        srv.send(notify("exit"))
+    finally:
+        srv.close()
+        shutil.rmtree(proj, ignore_errors=True)
+    return failures
+
+
 def run():
     """drive the invalidation scenarios; return a list of failure strings."""
     if not os.path.exists(os.path.join(WS, "src", "app.mach")):
@@ -169,6 +223,7 @@ def run():
     failures += watched_files_trigger()
     failures += mtime_fallback_trigger()
     failures += broken_manifest_recovers()
+    failures += reload_rebinds_cached_resolve()
     return failures
 
 


### PR DESCRIPTION
Closes #56.

Hardens the two #46/#54 workspace invariants that were enforced purely by convention.

## 1. Session-registry invariant (narrowed seam)

`driver.build_project` clobbers the session's global module registries on every load; safety rested on "no feature reads them", but `Workspace` exposed a raw `*sess.Session` that `server` threaded into every feature — one future `sess.module_*` call would silently read the wrong/dangling root.

The `*sess.Session` parameter is gone from every feature signature. Feature code (`language`, `diagnostics`) receives only the two safe, never-clobbered services it legitimately needs — the string interner and the source map — via the new `project.interner` / `project.sources` accessors. `server` keeps the session for lifecycle only (init / dnit / workspace construction).

Honest scope of the guarantee: Mach's `pub` publishes whole recs (no field-level visibility), so `Workspace.s` and the vendored `EditorSession.s` remain technically readable from feature code. The seam is a narrowed surface plus documented contract — reading a session module registry now takes deliberately reaching through a documented-off-limits field instead of using a parameter every feature already held — not a language seal. The in-code docs state exactly this.

## 2. Resolve-cache root stamping

The FileId-keyed cache prevented cross-root staleness only via blanket `clear_cache` calls scattered at every root-mutation site. Each entry is now stamped with the generation of the root build it resolved against; every successful build claims a fresh generation (0 reserved as the unloaded/single-file sentinel, skipped on u32 wrap), and `cache_hit` returns an entry only when its generation matches the governing root's current one (via the shared `root_gen` rule, so put and hit cannot drift). A result from a since-reloaded, freed, or different root is structurally unhittable. The blanket clears are gone; eviction is per-root (`free_root_graph` → `evict_root` frees just the torn-down build's entries through the single `release_entry` teardown), the full sweep remains only for `dnit`, and `didClose` reclaims the closed document's entry immediately (the reclamation the blanket clears used to provide incidentally).

## Tests

`make clean && make test` green. Extended the invalidation suite with a reorder-on-reload scenario: the existing line-shift scenarios leave each DeclId intact (a stale cached resolve would still read the right declaration off the live graph and pass), so reordering a dependency's declarations is what actually exercises a surviving stale entry — it would resolve to the wrong declaration if the stamp failed.