### PR TITLE
fix: vendored-dep files outside any outer closure are read-only in their own root

### DIFF
--- a/src/language.mach
+++ b/src/language.mach
@@ -600,12 +600,14 @@ fun binding_span(an: Analyzed, sid: res.SymbolId, out: *token.Span) bool {
 # is only renameable when the buffer itself is the editor's to rewrite: its
 # on-disk twin (when the buffer is a loaded module's file — e.g. a dependency
 # source opened via go-to-definition, whose symbols all resolve buffer-locally)
-# must also be project-owned. a buffer with no twin (a scratch file, or one
-# outside the loaded graph) renames buffer-local.
+# must also be project-owned. a buffer with no twin renames buffer-local — unless
+# its governing root is a vendored dependency project, whose every file is
+# read-only even outside that root's own graph closure (a vendored dep source the
+# outer project never imports still routes to its own vendored root).
 fun renameable(ws: *project.Workspace, root: *project.Root, uri: str, sym: *res.Symbol, sr: features.SymbolRef) bool {
     if (!sr.local) { ret project.is_project_module(ws, root, sym.origin); }
     val twin_o: Option[sess.ModuleId] = project.module_for_uri(ws, root, uri);
-    if (!is_some[sess.ModuleId](twin_o)) { ret true; }
+    if (!is_some[sess.ModuleId](twin_o)) { ret !project.root_vendored(root); }
     ret project.is_project_module(ws, root, unwrap[sess.ModuleId](twin_o));
 }
 

--- a/src/project.mach
+++ b/src/project.mach
@@ -153,6 +153,12 @@ rec Cached {
 #                 claimed on each successful load, 0 (reserved) while unloaded;
 #                 resolve cache entries carry it, so a reload or free makes the
 #                 prior build's entries unhittable and per-root evictable
+# vendored:       whether this root's own directory lies under some outer
+#                 project's declared vendor dir — i.e. the whole root is a
+#                 vendored dependency project, so none of its files are the
+#                 editor's to rewrite, regardless of any loaded graph's closure.
+#                 intrinsic to the path (computed at load_root from the ancestor
+#                 manifests), not to the routing that materialized the root
 pub rec Root {
     path:           str;
     loaded:         bool;
@@ -164,6 +170,7 @@ pub rec Root {
     man_mtime:      i64;
     lock_mtime:     i64;
     gen:            u32;
+    vendored:       bool;
 }
 
 # Workspace: the session's project roots plus the per-buffer resolve cache.
@@ -549,14 +556,48 @@ fun containing_root(w: *Workspace, uri: str, doc_root: str) *Root {
 }
 
 # load_root: claim a slot for `root_path` (taking ownership of the string) and
-# build its graph. on failure the slot is kept as a remembered failed load and
-# nil is returned; on success the loaded Root pointer is returned.
+# build its graph. the vendored flag is stamped once here — intrinsic to the
+# path, so every root-creating path (root_for's fresh-root load, ancestor_root's
+# speculative loads) gets it correct, and it survives in-place reloads (which keep
+# the slot). on failure the slot is kept as a remembered failed load and nil is
+# returned; on success the loaded Root pointer is returned.
 fun load_root(w: *Workspace, root_path: str) *Root {
     val slot: *Root = alloc_slot(w);
     if (slot == nil) { strutil.str_free(w.alloc, root_path); ret nil; }
-    slot.path = root_path;
+    slot.path     = root_path;
+    slot.vendored = vendored_under_ancestor(w, root_path);
     if (try_load(w, slot)) { ret slot; }
     ret nil;
+}
+
+# vendored_under_ancestor: whether `root_path`'s own directory lies under some
+# strict-ancestor project's declared vendor dir — i.e. this root is a vendored
+# dependency of an outer project. climbs the chain of ancestor manifest dirs
+# strictly above `root_path` (the same dirs ancestor_root walks), asking
+# vendors_enclosing of each; true on the first whose declared dep vendor dir
+# encloses `root_path`. this is a property of the path, not of how the root was
+# reached: a root materialized as an outer vendoring project for a deeper dep is
+# still flagged when it itself sits under a grandparent's vendor dir, which is
+# correct — its own sources remain a vendored dependency. a root with no such
+# ancestor (a top-level project, even one that loads dep modules) is not vendored.
+fun vendored_under_ancestor(w: *Workspace, root_path: str) bool {
+    var cur: str = root_path;
+    var result: bool = false;
+    var done: bool = false;
+    for (!done) {
+        val anc: str = project_root_for(w.alloc, cur);
+        if (cur != root_path) { strutil.str_free(w.alloc, cur); }
+        if (anc == nil) { done = true; }
+        or {
+            if (vendors_enclosing(w, anc, root_path)) {
+                strutil.str_free(w.alloc, anc);
+                result = true;
+                done   = true;
+            }
+            or { cur = anc; }
+        }
+    }
+    ret result;
 }
 
 # reset_slot: zero a Root slot's fields, marking it dead and reusable. owned
@@ -573,6 +614,7 @@ fun reset_slot(r: *Root) {
     r.man_mtime      = 0;
     r.lock_mtime     = 0;
     r.gen            = 0;
+    r.vendored       = false;
 }
 
 # alloc_slot: a reusable dead slot, growing the array when every slot is
@@ -954,10 +996,25 @@ fun module_for_norm(root: *Root, norm: str) Option[sess.ModuleId] {
     ret none[sess.ModuleId]();
 }
 
+# root_vendored: whether `root`'s whole tree is a vendored dependency project
+# (its directory lies under an outer project's declared vendor dir), so none of
+# its files are the editor's to rewrite. nil root is not vendored. the per-root
+# read-only signal the rename gate consults for a buffer with no loaded twin,
+# where the per-module is_project_module check has nothing to key on.
+# ---
+# root: the root governing the request, or nil
+# ret:  true when the root is a vendored dependency project
+pub fun root_vendored(root: *Root) bool {
+    if (root == nil) { ret false; }
+    ret root.vendored;
+}
+
 # is_project_module: whether loaded module `mid` in `root` belongs to the user's
-# own project rather than a vendored dependency — true iff its fully-qualified
-# path's head segment is the project id. rename gates cross-file edits on it so a
-# dependency's declaration (e.g. a std symbol) is never rewritten.
+# own editable project rather than a vendored dependency — false outright when
+# the whole root is a vendored dependency project (root_vendored), otherwise true
+# iff the module's fully-qualified path's head segment is the project id. rename
+# gates cross-file edits on it so a dependency's declaration (e.g. a std symbol,
+# or any file of a vendored project) is never rewritten.
 # ---
 # w:    the workspace
 # root: the root governing the request, or nil
@@ -966,6 +1023,7 @@ fun module_for_norm(root: *Root, norm: str) Option[sess.ModuleId] {
 pub fun is_project_module(w: *Workspace, root: *Root, mid: sess.ModuleId) bool {
     val m: *driver.ModuleEntry = module_entry(root, mid);
     if (m == nil) { ret false; }
+    if (root.vendored) { ret false; }
     val id_opt:  Option[str] = intern.lookup(?w.s.interner, root.p.config.id);
     val fqn_opt: Option[str] = intern.lookup(?w.s.interner, m.fqn);
     if (!is_some[str](id_opt) || !is_some[str](fqn_opt)) { ret false; }

--- a/test/test_crossmodule.py
+++ b/test/test_crossmodule.py
@@ -33,6 +33,9 @@ SCRATCH_SRC = "fun lone() i64 { ret 1; }\n"
 NESTED = os.path.join(REPO, "test", "fixture-nested")
 NESTED_LEAF = os.path.join(NESTED, "dep", "mid", "dep", "leaf", "src", "lib.mach")
 NESTED_MID_API = os.path.join(NESTED, "dep", "mid", "src", "api.mach")
+# mid's entry module: in mid's own closure but NOT in `outer`'s (outer imports
+# only mid.api), so no outer graph ever holds it.
+NESTED_MID_LIB = os.path.join(NESTED, "dep", "mid", "src", "lib.mach")
 
 
 def check_dep_definition(failures, msg, dv):
@@ -323,6 +326,53 @@ def nested_dep_first_scenario():
     return failures
 
 
+def nested_outside_closure_scenario():
+    """a vendored dependency's source that no outer project's graph ever holds —
+    mid's entry (lib.mach) is in mid's own closure but outside `outer`'s, which
+    imports only mid.api — must still refuse rename: mid's own root is discovered
+    under `outer`'s declared vendor dir, so it loads as a read-only vendored
+    project rather than a renameable one (regression #62: such a file routed to
+    its own dep root and wrongly offered a rename)."""
+    if not os.path.exists(NESTED):
+        return [f"nested fixture not found at {NESTED}"]
+    lib_text, lib_pos = _decl_pos(NESTED_MID_LIB, "mid_main")
+    if lib_text is None:
+        return ["mid_main declaration not found in fixture-nested"]
+
+    lib_uri = file_uri(NESTED_MID_LIB)
+    frames = [
+        req(1, "initialize", {"capabilities": {}}),
+        notify("initialized"),
+        # opened cold, before any project document
+        did_open(lib_uri, lib_text),
+        req(20, "textDocument/prepareRename",
+            {"textDocument": {"uri": lib_uri}, "position": lib_pos}),
+        req(21, "textDocument/rename",
+            {"textDocument": {"uri": lib_uri}, "position": lib_pos, "newName": "nope"}),
+        # references must keep working on the vendored source
+        req(22, "textDocument/references",
+            {"textDocument": {"uri": lib_uri}, "position": lib_pos,
+             "context": {"includeDeclaration": True}}),
+        req(2, "shutdown", None),
+        notify("exit"),
+    ]
+    code, msgs = drive(frames)
+
+    failures = []
+    prv = (by_id(msgs, 20) or {}).get("result", "missing")
+    if prv is not None:
+        failures.append(f"prepareRename(mid_main, outside outer's closure) should be null, got {prv!r}")
+    rnv = (by_id(msgs, 21) or {}).get("result")
+    if not isinstance(rnv, dict) or rnv.get("changes") != {}:
+        failures.append(f"rename(mid_main, outside outer's closure) should be an empty WorkspaceEdit, got {rnv!r}")
+    rfv = (by_id(msgs, 22) or {}).get("result")
+    if not isinstance(rfv, list) or not any(e.get("uri") == lib_uri for e in rfv):
+        failures.append(f"references(mid_main) should still find the in-buffer decl, got {rfv!r}")
+    if code != 0:
+        failures.append("non-zero exit code after clean shutdown")
+    return failures
+
+
 def run():
     """drive the cross-module scenarios; return a list of failure strings."""
     if not os.path.exists(APP):
@@ -334,6 +384,7 @@ def run():
     failures += dep_buffer_rename_scenario()
     failures += dep_buffer_first_scenario()
     failures += nested_dep_first_scenario()
+    failures += nested_outside_closure_scenario()
     return failures
 
 


### PR DESCRIPTION
Closes #62.

## Problem

PR #61 routes a dependency-tree document to the outermost vendoring project whose loaded graph holds it. Residual gap: a dep-tree file that is **not** in any outer project's import closure (e.g. a dep module the outer project never imports) still fell through to `load_root` on its own dep root and became project-owned there — `prepareRename` offered a range and `rename` rewrote the vendored source.

## Fix

Generalize the read-only invariant from "dependency module of a loaded graph" to "file of a vendored project."

**Where the flag lives / is computed (`src/project.mach`):**
- New `Root.vendored` — whether the root's own directory lies under some outer project's declared vendor dir.
- `vendored_under_ancestor` climbs the ancestor manifest chain strictly above the root and asks the existing `vendors_enclosing` of each; true on the first whose declared dep vendor dir encloses the root. It only *parses* manifests, never builds — so the #61 speculative-build perf gate is untouched.
- Stamped once in `load_root`, so **every** root-creating path gets it correct (`root_for`'s fresh-root load and `ancestor_root`'s speculative loads both go through `load_root`), and it survives in-place reloads (which keep the slot).
- `is_project_module` returns false for any module of a vendored root; `root_vendored` exposes the per-root signal.

**Reached both ways:** `vendored` is intrinsic to the path, not to the routing that materialized the root. A root reached as an outer vendoring project for a *deeper* dep (e.g. `mid` hosting `leaf`) is still flagged when it itself sits under a grandparent's vendor dir — correct, since its own sources remain a vendored dependency. A top-level project that merely loads dep modules has no enclosing ancestor and is **not** vendored.

**Consuming gate (`src/language.mach`):** `renameable` already gated cross-module and twinned buffer-local symbols through `is_project_module` (now vendored-aware). Its no-twin branch assumed a twinless buffer is a scratch file; it now returns `!root_vendored(root)`, so a vendored dep source outside its own root's closure is refused too. references / hover / definition are untouched — only mutation is gated.

## Test coverage

`test/test_crossmodule.py::nested_outside_closure_scenario`: opens `fixture-nested/dep/mid/src/lib.mach` (mid's entry — in mid's own closure, never in `outer`'s) cold and asserts `prepareRename` is null, `rename` is an empty edit, and `references` still finds the in-buffer decl.

**Verified pre-fix:** the new scenario fails on the current build — `prepareRename` returns a range and `rename` emits a `WorkspaceEdit` rewriting `lib.mach`. With the fix it passes.

## Suite

`make clean && make test` green; suite runtime ~19.9s (baseline ~19.8s — perf gate holds).