### PR TITLE
docs(readme): correct stale compiler-dependency refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ The server binary is produced at `out/linux/debug/bin/mls`.
 `dep/mach` (id `mach`) provides the `mach.lang.*` namespace, including the
 `mach.lang.editor` query surface this server binds to; `dep/mach-std` (id
 `std`) provides `std.*`. Both are declared as git dependencies in `mach.toml`
-and fetched by `mach dep pull`; `mach-std` tracks `branch/dev` and `mach` is pinned to `v1.4.0`.
+and fetched by `mach dep pull`; `mach-std` is pinned to `v0.6.0` and `mach`
+tracks `branch/main`.
 
 ## Architecture
 


### PR DESCRIPTION
Reconciles the README "How the compiler dependency is wired" section with the actual `mach.toml` pins: `mach-std` = `v0.6.0` (was documented as `branch/dev`) and `mach` = `branch/main` (was documented as pinned to `v1.4.0`).

Documents the **current** state. The dep-pin directive's float of `mach-std` to `branch/main` (#68) is blocked on a compiler-API adaptation (see #68); when it lands, this line updates to both deps on `branch/main`.

Docs-only; no code or behavior change.

Closes #66