### PR TITLE
fix: convert LSP positions UTF-16 ↔ byte at the boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ This server implements the **diagnostics** vertical slice plus the
   affected project root's graph, registered via `client/registerCapability`.
 - Diagnostics: on open/change the buffer text is fed to `mach.lang.editor`
   (`open` / `update` / `diagnostics`); every reported `diagnostic.Diagnostic`
-  is mapped — its byte span through `source.position` to a 0-based LSP range,
-  its severity to the LSP scale — and published via
+  is mapped — its byte span through `positions.range_of` to a 0-based LSP range
+  (UTF-16 columns), its severity to the LSP scale — and published via
   `textDocument/publishDiagnostics`.
 - Language features over the buffer's resolved analysis (`project.resolve_doc`
   + `ast.offset_to_*` + the `resolve.ResolveResult` side tables):
@@ -133,7 +133,7 @@ tracks `branch/main`.
 | `json` | minimal JSON field extraction and response assembly |
 | `documents` | URI ⇄ editor `FileId` registry |
 | `diagnostics` | run `editor.diagnostics`, map spans, publish |
-| `positions` | byte offset ⇄ LSP `(line, character)` and span text |
+| `positions` | byte offset ⇄ LSP `(line, character)` (UTF-16 columns ⇄ bytes) and span text — the single conversion point |
 | `features` | offset → id → symbol query core over the resolve side tables |
 | `project` | per-root project graphs: route a document to its governing root, load each root's module graph, re-resolve a buffer against its root's dependency set, map a symbol to its declaring file's `file://` URI, expose a root's loaded modules for the use-site walk, and invalidate a root on a watched-file change |
 | `language` | hover / definition / references / rename / documentSymbol / completion request bodies |
@@ -174,6 +174,10 @@ each scenario module asserts one surface:
   bumping the manifest mtime for the fallback path) makes the next definition
   serve the shifted declaration line, proving the root's graph reloaded; a
   broken manifest fixed on disk is retried rather than pinned failed.
+- `test_encoding.py` — a buffer with an em dash (3 UTF-8 bytes, 1 UTF-16 unit)
+  before a `g()` call: a definition request at the call's UTF-16 column resolves
+  it (inbound UTF-16→byte) and references reports the use-site at the UTF-16
+  column, not the byte column (outbound byte→UTF-16).
 
 ```sh
 make test          # builds, then runs test/run.py

--- a/src/diagnostics.mach
+++ b/src/diagnostics.mach
@@ -3,7 +3,7 @@
 # the diagnostics vertical slice end-to-end: feed a document's buffer to the
 # editor surface (`editor.diagnostics`), translate every reported
 # `diagnostic.Diagnostic` into an LSP `Diagnostic` — mapping its byte `span`
-# through `source.position` to a 0-based line/character range and its severity
+# through `positions.range_of` to a 0-based UTF-16 range and its severity
 # to the LSP scale — and emit a `textDocument/publishDiagnostics` notification.
 # clearing is the same notification with an empty array.
 
@@ -30,6 +30,7 @@ use editor: mach.lang.editor;
 
 use transport: mls.transport;
 use json:      mls.json;
+use positions: mls.positions;
 
 # LSP diagnostic severities (1 = Error … 4 = Hint).
 val LSP_ERROR:   i64 = 1;
@@ -161,16 +162,11 @@ fun build_entry(sources: *src.SourceMap, d: *diag.Diagnostic, alloc: *Allocator)
     val so: Option[*src.SourceFile] = src.get(sources, d.file_id);
     if (is_some[*src.SourceFile](so)) {
         val sf: *src.SourceFile = unwrap[*src.SourceFile](so);
-        val sp: src.Position = src.position(sf, d.span.offset);
-        start_line = dec(sp.line);
-        start_char = dec(sp.col);
-
-        var end_off: usize = d.span.offset + d.span.len;
-        if (d.span.len == 0) { end_off = d.span.offset; }
-        val ep: src.Position = src.position(sf, end_off);
-        end_line = dec(ep.line);
-        end_char = dec(ep.col);
-        if (end_line == start_line && end_char < start_char) { end_char = start_char; }
+        val r: positions.LspRange = positions.range_of(sf, d.span);
+        start_line = r.start_line;
+        start_char = r.start_char;
+        end_line = r.end_line;
+        end_char = r.end_char;
     }
 
     val severity: i64 = map_severity(d.severity);
@@ -235,12 +231,6 @@ fun build_diagnostic_json(
 
     free_parts(sl, sc, el, ec, sev, qmsg, alloc);
     ret buf::str;
-}
-
-# dec: clamp `n - 1` at 0 (1-based compiler position -> 0-based LSP position).
-fun dec(n: usize) usize {
-    if (n == 0) { ret 0; }
-    ret n - 1;
 }
 
 # slen: length of `s`, treating nil as 0.

--- a/src/positions.mach
+++ b/src/positions.mach
@@ -7,11 +7,13 @@
 # the incoming LSP position to an offset, and every response maps a `token.Span`
 # back to an LSP range. these helpers are the single conversion point.
 #
-# columns are treated as byte columns, matching the diagnostics slice: the
-# editor protocol nominally measures characters in UTF-16 code units, but the
-# whole server (parser spans, `source.position`) is byte-oriented, so a
-# consistent byte interpretation keeps offsets and ranges aligned for ASCII
-# source. multi-byte handling lands with a column-encoding negotiation.
+# the compiler core is byte-oriented (parser spans, `source.position`), so the
+# byte representation stays internal and the conversion to and from the
+# protocol's UTF-16 code-unit `character` happens only here, at the boundary.
+# lines are encoding-agnostic (newlines are single-byte), so only the column is
+# converted: inbound, a UTF-16 column walks the line's UTF-8 to a byte offset;
+# outbound, a byte offset's line prefix is measured in UTF-16 code units. the
+# server advertises no `positionEncoding`, so the client's UTF-16 default holds.
 
 use std.types.bool.bool;
 use std.types.size.usize;
@@ -37,9 +39,9 @@ use token: mach.lang.fe.token;
 # LspRange: a 0-based LSP range, the form a `Location` / hover range needs.
 # ---
 # start_line: 0-based start line
-# start_char: 0-based start character (byte column)
+# start_char: 0-based start character (UTF-16 code-unit column)
 # end_line:   0-based end line
-# end_char:   0-based end character (byte column)
+# end_char:   0-based end character (UTF-16 code-unit column)
 pub rec LspRange {
     start_line: usize;
     start_char: usize;
@@ -48,24 +50,27 @@ pub rec LspRange {
 }
 
 # offset_at: the byte offset of a 0-based LSP (line, character) in `file`, or
-# none when the line is out of range. the character is added to the line's
-# start offset and clamped to the file length.
+# none when the line is out of range. the UTF-16 character column is resolved
+# to a byte offset by walking the line's UTF-8, clamped to the line's end.
 # ---
 # file: the source file the position addresses
 # line: 0-based LSP line
-# ch:   0-based LSP character (byte column)
+# ch:   0-based LSP character (UTF-16 code-unit column)
 # ret:  some(offset) within the file, or none for an out-of-range line
 pub fun offset_at(file: *src.SourceFile, line: usize, ch: usize) Option[usize] {
     val ls: Option[usize] = src.line_start(file, line + 1);
     if (!is_some[usize](ls)) { ret none[usize](); }
-    var off: usize = unwrap[usize](ls) + ch;
-    val text_len: usize = str_len(file.text);
-    if (off > text_len) { off = text_len; }
-    ret some[usize](off);
+    val ls_off: usize = unwrap[usize](ls);
+
+    var le_off: usize = str_len(file.text);
+    if (line + 1 < file.line_len) { le_off = file.line_starts[line + 1]; }
+
+    ret some[usize](u16_col_to_byte(file, ls_off, le_off, ch));
 }
 
 # range_of: the LSP range covering a byte span in `file`. a zero-length span
-# yields an empty range at its offset.
+# yields an empty range at its offset. columns are reported as UTF-16 code-unit
+# offsets within their line.
 # ---
 # file: the source file the span addresses
 # span: the byte range to convert
@@ -74,13 +79,13 @@ pub fun range_of(file: *src.SourceFile, span: token.Span) LspRange {
     var r: LspRange;
     val sp: src.Position = src.position(file, span.offset);
     r.start_line = dec(sp.line);
-    r.start_char = dec(sp.col);
+    r.start_char = u16_col(file, sp.line, span.offset);
 
     var end_off: usize = span.offset + span.len;
     if (span.len == 0) { end_off = span.offset; }
     val ep: src.Position = src.position(file, end_off);
     r.end_line = dec(ep.line);
-    r.end_char = dec(ep.col);
+    r.end_char = u16_col(file, ep.line, end_off);
     if (r.end_line == r.start_line && r.end_char < r.start_char) { r.end_char = r.start_char; }
     ret r;
 }
@@ -106,6 +111,62 @@ pub fun span_text(file: *src.SourceFile, span: token.Span, alloc: *Allocator) st
     mem.raw_copy(buf::ptr, (file.text::usize + span.offset)::ptr, len);
     buf[len] = 0;
     ret buf::str;
+}
+
+# u16_col: the 0-based UTF-16 code-unit column of a byte `offset` on its
+# 1-based `line`, measured by walking the line prefix's UTF-8.
+# ---
+# file:   the source file the offset addresses
+# line:   1-based line the offset falls on (as `source.position` reports)
+# offset: byte offset whose column is measured
+# ret:    0-based UTF-16 code-unit column
+fun u16_col(file: *src.SourceFile, line: usize, offset: usize) usize {
+    var o: usize = file.line_starts[line - 1];
+    var units: usize = 0;
+    for (o < offset) {
+        val b: u8 = file.text[o];
+        units = units + u16_units(b);
+        o = o + u8_seq_len(b);
+    }
+    ret units;
+}
+
+# u16_col_to_byte: the byte offset of a 0-based UTF-16 code-unit column on the
+# line spanning [start, end), or `end` when the column runs past the line. a
+# column landing inside a codepoint snaps to that codepoint's start.
+# ---
+# file:  the source file
+# start: byte offset of the line's first byte
+# end:   byte offset just past the line (exclusive walk bound)
+# col:   0-based UTF-16 code-unit column to locate
+# ret:   the byte offset at that column, clamped to `end`
+fun u16_col_to_byte(file: *src.SourceFile, start: usize, end: usize, col: usize) usize {
+    var o: usize = start;
+    var units: usize = 0;
+    for (o < end) {
+        val b: u8 = file.text[o];
+        val u: usize = u16_units(b);
+        if (units + u > col) { brk; }
+        units = units + u;
+        o = o + u8_seq_len(b);
+    }
+    ret o;
+}
+
+# u8_seq_len: the byte length of the UTF-8 sequence led by `b`; a stray
+# continuation byte counts as 1 so malformed input still advances.
+fun u8_seq_len(b: u8) usize {
+    if (b < 0xC0) { ret 1; }
+    if (b < 0xE0) { ret 2; }
+    if (b < 0xF0) { ret 3; }
+    ret 4;
+}
+
+# u16_units: the UTF-16 code units the codepoint led by `b` encodes to — 2 for a
+# 4-byte sequence (a surrogate pair), 1 otherwise.
+fun u16_units(b: u8) usize {
+    if (b >= 0xF0) { ret 2; }
+    ret 1;
 }
 
 # dec: clamp `n - 1` at 0 (1-based compiler position -> 0-based LSP position).

--- a/test/run.py
+++ b/test/run.py
@@ -13,6 +13,7 @@ import test_crossmodule
 import test_workspace
 import test_multiroot
 import test_invalidation
+import test_encoding
 
 SUITES = [
     ("diagnostics", test_diagnostics.run),
@@ -21,6 +22,7 @@ SUITES = [
     ("workspace", test_workspace.run),
     ("multiroot", test_multiroot.run),
     ("invalidation", test_invalidation.run),
+    ("encoding", test_encoding.run),
 ]
 
 

--- a/test/test_encoding.py
+++ b/test/test_encoding.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""UTF-16 position-encoding round-trip over a buffer with a multibyte character.
+
+the LSP `character` field is UTF-16 code units; the compiler core is byte-
+oriented. this asserts the conversion at the boundary (#65): a request position
+at a UTF-16 column lands on the right byte (inbound), and a reported range's
+column is in UTF-16 units, not bytes (outbound).
+
+the buffer puts an EM DASH (U+2014, 3 UTF-8 bytes / 1 UTF-16 unit) in a string
+literal before a `g()` call on the same line, so that call's byte column (38)
+and UTF-16 column (36) differ. the fixture is sent as raw UTF-8 (not \\uXXXX
+escaped), matching how editor clients deliver non-ASCII text."""
+import json
+import os
+
+from harness import req, notify, pos, by_id, drive, standalone
+
+EM = "—"  # em dash: 3 UTF-8 bytes, 1 UTF-16 code unit
+# line 0: g's declaration (ASCII). line 1: a string holding the em dash, then a
+# g() call whose `g` sits at UTF-16 col 36 but byte col 38.
+SRC = (
+    "fun g() i64 { ret 0; }\n"
+    f'fun f() i64 {{ val s: str = "{EM}"; ret g(); }}\n'
+)
+URI = "file:///enc.mach"
+
+G_U16_COL = 36   # UTF-16 column of the g() call on line 1
+G_BYTE_COL = 38  # its byte column — what a byte-oriented server would wrongly emit
+
+
+def did_open_raw(uri, text):
+    """a didOpen frame whose body is raw UTF-8 (ensure_ascii=False)."""
+    obj = {"jsonrpc": "2.0", "method": "textDocument/didOpen",
+           "params": {"textDocument": {"uri": uri, "languageId": "mach", "version": 1, "text": text}}}
+    body = json.dumps(obj, ensure_ascii=False).encode("utf-8")
+    return b"Content-Length: %d\r\n\r\n%s" % (len(body), body)
+
+
+def run():
+    """drive the encoding round-trip; return a list of failure strings."""
+    frames = [
+        req(1, "initialize", {"capabilities": {}}),
+        notify("initialized"),
+        did_open_raw(URI, SRC),
+        # inbound: a definition request at the g() call's UTF-16 column must
+        # resolve to g's decl on line 0 — only possible if char 36 maps to byte 38.
+        req(20, "textDocument/definition",
+            {"textDocument": {"uri": URI}, "position": pos(1, G_U16_COL)}),
+        # outbound: references on g's decl reports the line-1 use-site; its column
+        # must be the UTF-16 value (36), not the byte value (38).
+        req(30, "textDocument/references",
+            {"textDocument": {"uri": URI}, "position": pos(0, 4),
+             "context": {"includeDeclaration": True}}),
+        req(2, "shutdown", None),
+        notify("exit"),
+    ]
+    code, msgs = drive(frames)
+
+    failures = []
+
+    # inbound: definition lands on g's decl (line 0)
+    dv = (by_id(msgs, 20) or {}).get("result")
+    loc = dv[0] if isinstance(dv, list) and dv else dv
+    if not loc or "range" not in loc:
+        failures.append(
+            f"definition at UTF-16 col {G_U16_COL} returned no Location "
+            "(inbound UTF-16->byte conversion failed)")
+    elif loc["range"]["start"]["line"] != 0:
+        failures.append(
+            f"definition landed on line {loc['range']['start']['line']}, expected 0 (g's decl)")
+
+    # outbound: the line-1 use-site is reported at the UTF-16 column, not the byte column
+    rv = (by_id(msgs, 30) or {}).get("result")
+    if not isinstance(rv, list):
+        failures.append("references result is not an array")
+    else:
+        cols = {r["range"]["start"]["character"] for r in rv
+                if r["range"]["start"]["line"] == 1}
+        if G_U16_COL not in cols:
+            hint = " (byte column leaked)" if G_BYTE_COL in cols else ""
+            failures.append(
+                f"references use-site on line 1 at cols {sorted(cols)}, "
+                f"expected UTF-16 col {G_U16_COL}{hint}")
+
+    if code != 0:
+        failures.append("non-zero exit code after clean shutdown")
+
+    return failures
+
+
+if __name__ == "__main__":
+    standalone("encoding", run)


### PR DESCRIPTION
Closes #65.

## Problem

The LSP `character` field is UTF-16 code units, but the server treated it as a byte column. For ASCII source these coincide; any non-ASCII byte misaligned every inbound position (request → byte offset) and outbound range (span → LSP range). No client offers a `utf-8` `positionEncoding` (Zed and VS Code are both UTF-16-only, verified with the mach-zed owner), so the `utf-8`-negotiation plan the old code deferred to was a dead end — the fix is server-side conversion.

## Fix

Convert only at the single conversion point, `src/positions.mach`, keeping the byte-oriented core untouched:
- **inbound** (`offset_at`): walk the line's UTF-8, counting UTF-16 code units, to land on the byte offset for the requested column (bounded to the line, snapping to codepoint starts).
- **outbound** (`range_of`): measure a byte offset's line prefix in UTF-16 code units.
- 4-byte sequences (astral codepoints) count as 2 UTF-16 units (surrogate pair); 1–3-byte as 1.

`src/diagnostics.mach` mapped spans to ranges with its own inline `source.position` + `dec` (a second byte-column site). Routed it through `positions.range_of` so it inherits the conversion — positions.mach is now the genuine single point — and removed its duplicated mapping + dead `dec`. Dropped the dead utf-8-negotiation note from the module doc.

## Test

New `test/test_encoding.py` (registered in `run.py`): a buffer with an em dash (3 UTF-8 bytes / 1 UTF-16 unit) before a `g()` call, so the call's byte column (38) and UTF-16 column (36) differ. Asserts a definition request at the UTF-16 column resolves `g` (inbound) and references reports the use-site at the UTF-16 column, not the byte column (outbound). Verified it **fails** against the pre-fix byte mapping (definition resolves nothing; references leaks col 38) and passes after.

## Verification

`mach build` clean; **7/7** scenarios pass (the 6 existing + `encoding`). Latent bug (ASCII source unaffected), so no urgent release — landing on dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)