### PR TITLE
fix: bounded reloads via the v1.5.5 driver reload contract (#55)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ and retries a previously failed load once the manifest is fixed — but bare
 source edits are only picked up through a watch notification (or a manifest /
 lockfile touch).
 
+Reloads are **bounded**: one compiler session is reused for the whole editor
+session, and each rebuild follows the driver's reload contract — sources dedup
+by path (re-reading a root's closure reuses `FileId`s instead of growing the
+session source map) and `driver.dnit_project` frees the dropped graph and resets
+the session's per-build registries, so a long-lived session with frequent saves
+does not grow without bound. Each reload still re-parses and re-resolves the
+whole closure; incremental (per-module) rebuild is an upstream follow-up.
+
 > **Module-id namespacing:** `driver.build_project` numbers modules from 0 and
 > writes them into the session's global module registries, so a second build
 > over the same session clobbers the first there. The server sidesteps this by

--- a/test/test_invalidation.py
+++ b/test/test_invalidation.py
@@ -215,6 +215,46 @@ def reload_rebinds_cached_resolve():
     return failures
 
 
+def reload_repeats_stay_correct():
+    """the reload contract is per-save and long-lived: one Session is reused
+    across every rebuild (build_project -> dnit_project -> rebuild), with sources
+    deduped by path so the SourceMap does not grow (#55). drive many successive
+    edit+reload rounds on one session and assert each serves the freshly shifted
+    declaration — exercising the dnit_project/rebuild cycle repeatedly, which a
+    teardown that corrupted or leaked the session across reloads would fail."""
+    proj, app, lib = _scratch_project()
+    app_uri = file_uri(app)
+    lib_uri = file_uri(lib)
+    rounds = 5
+    failures = []
+    srv = LiveServer()
+    try:
+        srv.send(req(1, "initialize", {"capabilities": {}}))
+        srv.recv_id(1)
+        srv.send(notify("initialized"))
+        srv.send(did_open(app_uri, open(app).read()))
+
+        uri0, line0 = _definition_line(srv, app_uri, 20)
+        if uri0 != lib_uri or line0 != DECL_LINE:
+            failures.append(f"definition(shared) before reloads: uri {uri0} line {line0}, expected {lib_uri} line {DECL_LINE}")
+
+        for i in range(rounds):
+            _shift_decl(lib)
+            srv.send(notify("workspace/didChangeWatchedFiles",
+                            {"changes": [{"uri": lib_uri, "type": 2}]}))
+            want = DECL_LINE + SHIFT * (i + 1)
+            uri, line = _definition_line(srv, app_uri, 100 + i)
+            if uri != lib_uri or line != want:
+                failures.append(f"definition(shared) after reload {i + 1}/{rounds}: uri {uri} line {line}, expected {lib_uri} line {want}")
+
+        srv.send(req(2, "shutdown", None))
+        srv.send(notify("exit"))
+    finally:
+        srv.close()
+        shutil.rmtree(proj, ignore_errors=True)
+    return failures
+
+
 def run():
     """drive the invalidation scenarios; return a list of failure strings."""
     if not os.path.exists(os.path.join(WS, "src", "app.mach")):
@@ -224,6 +264,7 @@ def run():
     failures += mtime_fallback_trigger()
     failures += broken_manifest_recovers()
     failures += reload_rebinds_cached_resolve()
+    failures += reload_repeats_stay_correct()
     return failures
 
 


### PR DESCRIPTION
Closes #55. Cascade step 2/3 — **stacked on #71** (base `feat/68-driver-api-v1.5.5`; retarget to dev once #71 merges).

## What

#55's crash-half — the session `SourceMap` growing without bound on every save (old `source.add` never deduped; old `dnit_project` freed ASTs but not the session registries) — is **resolved by the v1.5.5 bump** (#71): the driver now dedups sources by path (`source.load`) and `dnit_project` resets the session's per-build registries.

mach-lsp already conformed to the reload contract, so **no LSP code change was needed** — verified by reading the lifecycle:
- ONE shared `sess.Session` for the whole editor session (`Workspace.s`).
- per reload: `driver.build_project` (try_load) → use → `driver.dnit_project` (free_root_graph on invalidation) → rebuild.
- buffers enter only via `editor.open`/`editor.update` (→ `sess.load_source`, deduped, id-stable); no direct `source.add` anywhere that would bypass dedup.

So a long-lived session with frequent saves no longer grows without bound.

## Test

New `reload_repeats_stay_correct` scenario in `test_invalidation.py`: five successive edit+reload rounds on one session, asserting each serves the freshly shifted declaration — exercising the `build_project → dnit_project → rebuild` cycle repeatedly (a teardown that corrupted or leaked the session across reloads would fail it). Over-stdio can't measure memory directly; the driver's own bounded-growth test (mach #1389) covers that, and this guards the LSP-side contract's repeatability.

## Scope

This fixes #55's memory-growth half. The per-save **full-rebuild latency** (each reload re-parses/re-resolves the whole closure) is the transparent perf follow-up tracked upstream as mach #1164 — **not** built here (no incrementality), per direction.

## Verification

build clean; **7/7** scenarios pass against v1.5.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)