### PR TITLE
feat: multi-target coverage via build_project_union (#58)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ and retries a previously failed load once the manifest is fixed — but bare
 source edits are only picked up through a watch notification (or a manifest /
 lockfile touch).
 
+Reloads are **bounded**: one compiler session is reused for the whole editor
+session, and each rebuild follows the driver's reload contract — sources dedup
+by path (re-reading a root's closure reuses `FileId`s instead of growing the
+session source map) and `driver.dnit_project` frees the dropped graph and resets
+the session's per-build registries, so a long-lived session with frequent saves
+does not grow without bound. Each reload still re-parses and re-resolves the
+whole closure; incremental (per-module) rebuild is an upstream follow-up.
+
 > **Module-id namespacing:** `driver.build_project` numbers modules from 0 and
 > writes them into the session's global module registries, so a second build
 > over the same session clobbers the first there. The server sidesteps this by

--- a/README.md
+++ b/README.md
@@ -108,9 +108,12 @@ whole closure; incremental (per-module) rebuild is an upstream follow-up.
 > a non-default target's `$if` gate — a windows-only import while the host builds
 > for linux, say — is in the graph, and references / rename cover its use-sites
 > (modules are deduplicated by FQN, so one shared between targets yields no
-> duplicate locations or edits). The union resolves under the default target's
-> comptime context. A module reachable from no declared target at all — imported
-> by nothing — stays outside, having no entry to analyze it through.
+> duplicate locations or edits). Two residual limits: resolution runs under the
+> **default** target's comptime context, so a use-site behind a *non-default*
+> target's `$if` *inside* a module is present but not in the resolve index until
+> per-target resolution lands upstream; and a module reachable from no declared
+> target at all — imported by nothing — stays outside, having no entry to
+> analyze it through.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ This server implements the **diagnostics** vertical slice plus the
 The server keeps a **per-root** map of project graphs: each open document is
 routed to the project root that governs its path (the nearest ancestor
 `mach.toml`), and that root's module graph is loaded from disk on first use
-(`mls.project` runs the compiler's own `driver.build_project` over the manifest
-and `dep/` tree, snapshotting every loaded module's exports into a dependency
-set). The buffer is then re-resolved against its root's dep set, so several
+(`mls.project` runs the compiler's own `driver.build_project_union` over the
+manifest and `dep/` tree — the union of every declared target's import closure —
+snapshotting every loaded module's exports into a dependency set). The buffer is then re-resolved against its root's dep set, so several
 projects open in one session resolve independently. A document that is a
 dependency module of another root — one already loaded (e.g. a dep source opened
 via go-to-definition), or the project whose manifest declares the document's own
@@ -95,21 +95,22 @@ the session's per-build registries, so a long-lived session with frequent saves
 does not grow without bound. Each reload still re-parses and re-resolves the
 whole closure; incremental (per-module) rebuild is an upstream follow-up.
 
-> **Module-id namespacing:** `driver.build_project` numbers modules from 0 and
-> writes them into the session's global module registries, so a second build
+> **Module-id namespacing:** `driver.build_project_union` numbers modules from 0
+> and writes them into the session's global module registries, so a second build
 > over the same session clobbers the first there. The server sidesteps this by
 > never reading those session registries — every cross-module lookup reads the
 > per-root `driver.Project.modules` array, whose ids are private to that project
 > — so several graphs coexist in one shared session (and one source map /
 > interner) without collision, and no per-root sessions are needed.
 
-> **Scope note:** each root's graph is the import-reachable module closure of the
-> manifest's default target (the compiler's own DFS load), so project files
-> outside that closure — secondary `bin` targets, modules nothing imports — are
-> still not in the graph: references cannot see their use-sites and rename
-> silently leaves them untouched. Loading every declared target per root would
-> need path-deduplicated multi-graph merging (to avoid duplicate edits for
-> modules shared between targets) and is deferred.
+> **Scope note:** each root's graph is the **union of every declared target's**
+> import closure (`driver.build_project_union`), so a module reachable only under
+> a non-default target's `$if` gate — a windows-only import while the host builds
+> for linux, say — is in the graph, and references / rename cover its use-sites
+> (modules are deduplicated by FQN, so one shared between targets yields no
+> duplicate locations or edits). The union resolves under the default target's
+> comptime context. A module reachable from no declared target at all — imported
+> by nothing — stays outside, having no entry to analyze it through.
 
 ## Building
 

--- a/src/project.mach
+++ b/src/project.mach
@@ -4,8 +4,10 @@
 # an empty dependency set, so any symbol imported through a `use` binds to
 # SYMBOL_NIL and go-to-definition / references / hover cannot reach it. this
 # module closes that gap: for each project root open in the session it loads a
-# module graph from disk through the compiler's own `driver.build_project`
-# (manifest + lockfile + the `dep/` tree), snapshots every loaded module's
+# module graph from disk through the compiler's own `driver.build_project_union`
+# (manifest + lockfile + the `dep/` tree — the union of every declared target's
+# import closure, so modules reachable only via a non-default target are present),
+# snapshots every loaded module's
 # public surface into a `res.ResolveDeps`, and re-resolves an open buffer
 # against that dep set with `res.resolve` directly — the lower-level API the
 # editor's `resolve` wraps.
@@ -20,9 +22,9 @@
 # under no `mach.toml` resolves single-file (empty dep set). the legacy "one
 # project per session" behaviour is just the one-Root case.
 #
-# module-id namespacing: `driver.build_project` allocates project-local module
-# ids from 0 and writes them into the session's global module registries, so a
-# second build over the same session clobbers the first there. those clobbered
+# module-id namespacing: `driver.build_project_union` allocates project-local
+# module ids from 0 and writes them into the session's global module registries,
+# so a second build over the same session clobbers the first there. those clobbered
 # registries are never read for a lookup — every cross-module lookup (site_of,
 # module_view, ...) reads the per-`Root` `driver.Project.modules` array, whose
 # ids are private to that project. the seam guarding that invariant is a
@@ -648,7 +650,9 @@ fun alloc_slot(w: *Workspace) *Root {
     ret ?w.roots[old_cap];
 }
 
-# try_load: run build_project for `r.path` and snapshot the dep set into `r`.
+# try_load: run build_project_union for `r.path` and snapshot the dep set into
+# `r` (the union of every declared target's closure, so cross-file features cover
+# modules reachable only via a non-default target).
 # the manifest / lockfile mtimes are recorded at the start of the attempt
 # whether it succeeds or fails, so maybe_reload retries a failed root once those
 # files change instead of pinning the failure for the session. a failure is
@@ -665,7 +669,7 @@ fun try_load(w: *Workspace, r: *Root) bool {
         ret false;
     }
 
-    val pr: Result[driver.Project, str] = driver.build_project(w.s, r.path, "");
+    val pr: Result[driver.Project, str] = driver.build_project_union(w.s, r.path);
     if (is_err[driver.Project, str](pr)) {
         report_load_failure(w, r.path, unwrap_err[driver.Project, str](pr));
         ret false;

--- a/test/fixture-multitarget/mach.toml
+++ b/test/fixture-multitarget/mach.toml
@@ -1,0 +1,23 @@
+# multi-target fixture for build_project_union (#58): `winonly` is imported by
+# the entry module only under the windows target's $if gate, so it is outside the
+# default (linux) target's import closure. a single-target build omits it; the
+# union build (every declared target's closure) includes it, so workspace
+# references / rename reach its use-site of `common.shared`.
+[project]
+id      = "mtfix"
+version = "0.0.0"
+src     = "src"
+target  = "native"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.windows]
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
+
+[bin.mtfix]
+entry = "main.mach"

--- a/test/fixture-multitarget/src/common.mach
+++ b/test/fixture-multitarget/src/common.mach
@@ -1,0 +1,7 @@
+# common: declares the pub symbol used by both the default-reachable entry and
+# the windows-only module, so references on it must reach both under the union.
+
+# shared: a value imported and used across the default and windows-only modules.
+pub fun shared() i64 {
+    ret 42;
+}

--- a/test/fixture-multitarget/src/main.mach
+++ b/test/fixture-multitarget/src/main.mach
@@ -1,0 +1,12 @@
+# main: the default entry. imports common.shared (used here) and, only under the
+# windows target, the winonly module — so winonly is outside the default (linux)
+# closure but present in the union build.
+use mtfix.common.shared;
+
+$if ($mach.target.os == $mach.os.windows) {
+    use mtfix.winonly;
+}
+
+fun main() i64 {
+    ret shared();
+}

--- a/test/fixture-multitarget/src/winonly.mach
+++ b/test/fixture-multitarget/src/winonly.mach
@@ -1,0 +1,7 @@
+# winonly: imported by main only under the windows target. its use of
+# common.shared is in the graph only when the union covers non-default targets.
+use mtfix.common.shared;
+
+pub fun winentry() i64 {
+    ret shared();
+}

--- a/test/run.py
+++ b/test/run.py
@@ -14,6 +14,7 @@ import test_workspace
 import test_multiroot
 import test_invalidation
 import test_encoding
+import test_multitarget
 
 SUITES = [
     ("diagnostics", test_diagnostics.run),
@@ -23,6 +24,7 @@ SUITES = [
     ("multiroot", test_multiroot.run),
     ("invalidation", test_invalidation.run),
     ("encoding", test_encoding.run),
+    ("multitarget", test_multitarget.run),
 ]
 
 

--- a/test/test_invalidation.py
+++ b/test/test_invalidation.py
@@ -215,6 +215,46 @@ def reload_rebinds_cached_resolve():
     return failures
 
 
+def reload_repeats_stay_correct():
+    """the reload contract is per-save and long-lived: one Session is reused
+    across every rebuild (build_project -> dnit_project -> rebuild), with sources
+    deduped by path so the SourceMap does not grow (#55). drive many successive
+    edit+reload rounds on one session and assert each serves the freshly shifted
+    declaration — exercising the dnit_project/rebuild cycle repeatedly, which a
+    teardown that corrupted or leaked the session across reloads would fail."""
+    proj, app, lib = _scratch_project()
+    app_uri = file_uri(app)
+    lib_uri = file_uri(lib)
+    rounds = 5
+    failures = []
+    srv = LiveServer()
+    try:
+        srv.send(req(1, "initialize", {"capabilities": {}}))
+        srv.recv_id(1)
+        srv.send(notify("initialized"))
+        srv.send(did_open(app_uri, open(app).read()))
+
+        uri0, line0 = _definition_line(srv, app_uri, 20)
+        if uri0 != lib_uri or line0 != DECL_LINE:
+            failures.append(f"definition(shared) before reloads: uri {uri0} line {line0}, expected {lib_uri} line {DECL_LINE}")
+
+        for i in range(rounds):
+            _shift_decl(lib)
+            srv.send(notify("workspace/didChangeWatchedFiles",
+                            {"changes": [{"uri": lib_uri, "type": 2}]}))
+            want = DECL_LINE + SHIFT * (i + 1)
+            uri, line = _definition_line(srv, app_uri, 100 + i)
+            if uri != lib_uri or line != want:
+                failures.append(f"definition(shared) after reload {i + 1}/{rounds}: uri {uri} line {line}, expected {lib_uri} line {want}")
+
+        srv.send(req(2, "shutdown", None))
+        srv.send(notify("exit"))
+    finally:
+        srv.close()
+        shutil.rmtree(proj, ignore_errors=True)
+    return failures
+
+
 def run():
     """drive the invalidation scenarios; return a list of failure strings."""
     if not os.path.exists(os.path.join(WS, "src", "app.mach")):
@@ -224,6 +264,7 @@ def run():
     failures += mtime_fallback_trigger()
     failures += broken_manifest_recovers()
     failures += reload_rebinds_cached_resolve()
+    failures += reload_repeats_stay_correct()
     return failures
 
 

--- a/test/test_multitarget.py
+++ b/test/test_multitarget.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""multi-target union coverage (#58): a module imported only under a non-default
+target's `$if` gate is still in the workspace graph, so references reach its
+use-sites. fixture-multitarget's `winonly` is imported by `main` only under the
+windows target; with `build_project_union` the linux-host server still sees
+winonly's use of `common.shared`, which a default-target-only build would omit."""
+import os
+
+from harness import LiveServer, req, notify, did_open, pos, file_uri, standalone, REPO
+
+MT = os.path.join(REPO, "test", "fixture-multitarget")
+COMMON = os.path.join(MT, "src", "common.mach")
+
+# common.mach line 4: `pub fun shared() i64 {` — decl `shared` at col 8.
+DECL = pos(4, 8)
+
+
+def run():
+    """drive the multi-target union scenario; return a list of failure strings."""
+    if not os.path.exists(COMMON):
+        return [f"fixture-multitarget not found at {MT}"]
+    common_uri = file_uri(COMMON)
+    failures = []
+    srv = LiveServer()
+    try:
+        srv.send(req(1, "initialize", {"capabilities": {}}))
+        srv.recv_id(1)
+        srv.send(notify("initialized"))
+        srv.send(did_open(common_uri, open(COMMON).read()))
+
+        srv.send(req(20, "textDocument/references",
+                     {"textDocument": {"uri": common_uri}, "position": DECL,
+                      "context": {"includeDeclaration": True}}))
+        res = (srv.recv_id(20) or {}).get("result")
+        if not isinstance(res, list):
+            failures.append("references(shared) result is not an array")
+        else:
+            uris = {r.get("uri", "") for r in res}
+            if not any(u.endswith("winonly.mach") for u in uris):
+                failures.append(
+                    "references(shared) missing the windows-only use-site "
+                    f"(winonly.mach); got {sorted(uris)} — the union did not "
+                    "cover the non-default target")
+            if not any(u.endswith("main.mach") for u in uris):
+                failures.append(
+                    f"references(shared) missing the main.mach use-site; got {sorted(uris)}")
+
+        srv.send(req(2, "shutdown", None))
+        srv.send(notify("exit"))
+    finally:
+        srv.close()
+    return failures
+
+
+if __name__ == "__main__":
+    standalone("multitarget", run)


### PR DESCRIPTION
Closes #58. Cascade step 3/3 — **stacked on #72 → #71** (base `fix/55-reload-contract`; retarget to dev as the stack merges).

## What

Switches each root's load from `driver.build_project(s, root, "")` (default target only) to `driver.build_project_union(s, root)` — the union of every declared target's import closure, deduped by FQN (#1391). A module reachable only under a non-default target's `$if` gate (e.g. a windows-only import while the host builds for linux) is now in the root graph, so **references and rename cover its use-sites** instead of silently skipping them. The union resolves under the default target's comptime context.

This removes the documented out-of-closure limitation; only modules reachable from *no* declared target (imported by nothing) remain outside.

## Test

New `fixture-multitarget` + `test_multitarget.py`: `main` imports `winonly` only under `$if ($mach.target.os == $mach.os.windows)`, and `winonly` uses `common.shared`. `references(shared)` must include winonly.mach's use-site — present only because the union covers the non-default (windows) target. **Negative-checked:** under the old `build_project` the test fails (references returns only common + main; winonly missing); under `build_project_union` it passes. Validated empirically on v1.5.5.

## Verification

build clean; **8/8** scenarios pass.

## Docs

README scope note revised (non-default-target modules now covered; FQN-dedup noted), module-id and per-root-load notes updated to `build_project_union`; project.mach header/try_load docs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)