### PR TITLE
test(alias): regression for aliased-import member go-to-def (#75)

### DIFF
--- a/test/fixture-alias/mach.toml
+++ b/test/fixture-alias/mach.toml
@@ -1,0 +1,23 @@
+# fixture project for the aliased-import member go-to-definition test (#75). it
+# depends on the repo's vendored mach-std (reached via `dep = "../../dep"`) so
+# the language server can resolve a module-alias qualified member to its
+# declaration on disk. it is read by the server's own build_project, never by
+# the installed `mach` toolchain.
+[project]
+id      = "aliasfix"
+version = "0.0.0"
+src     = "src"
+dep     = "../../dep"
+target  = "native"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.aliasfix]
+entry = "app.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "v0.6.0"

--- a/test/fixture-alias/src/app.mach
+++ b/test/fixture-alias/src/app.mach
@@ -1,0 +1,20 @@
+# aliased-import member resolution fixture (#75): `use strmod: std.types.string;`
+# binds the std string module under an alias, and `strmod.str_len` is a
+# qualified member access whose go-to-definition must reach str_len's
+# declaration inside dep/mach-std.
+
+use std.types.size.usize;
+use std.types.string.str;
+
+use strmod: std.types.string;
+
+# length: calls the aliased module's str_len via qualified member access.
+fun length(s: str) usize {
+    ret strmod.str_len(s);
+}
+
+# twice: a second use-site of the aliased member, so references finds more than
+# one in-buffer occurrence.
+fun twice(s: str) usize {
+    ret strmod.str_len(s) + strmod.str_len(s);
+}

--- a/test/run.py
+++ b/test/run.py
@@ -10,6 +10,7 @@ import sys
 import test_diagnostics
 import test_features
 import test_crossmodule
+import test_alias
 import test_workspace
 import test_multiroot
 import test_invalidation
@@ -20,6 +21,7 @@ SUITES = [
     ("diagnostics", test_diagnostics.run),
     ("features", test_features.run),
     ("crossmodule", test_crossmodule.run),
+    ("alias", test_alias.run),
     ("workspace", test_workspace.run),
     ("multiroot", test_multiroot.run),
     ("invalidation", test_invalidation.run),

--- a/test/test_alias.py
+++ b/test/test_alias.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""aliased-import member go-to-definition (#75) over test/fixture-alias.
+
+the fixture binds the std string module under an alias (`use strmod:
+std.types.string;`) and calls `strmod.str_len(s)`. definition / hover /
+references on the member name `str_len` must reach str_len's declaration inside
+dep/mach-std, exactly as a directly `use`d symbol does — a module-alias
+qualified member is a resolved cross-module reference, not an unresolved field
+access."""
+import os
+
+from harness import drive, req, notify, did_open, pos, by_id, file_uri, standalone, REPO
+
+FIXTURE = os.path.join(REPO, "test", "fixture-alias")
+APP = os.path.join(FIXTURE, "src", "app.mach")
+URI = file_uri(APP)
+
+# the canonical URI of str_len's declaring file; the emitted location must match
+# it exactly (no '..' segments), or clients cannot correlate it with a buffer.
+DEP_STRING_URI = file_uri(os.path.join(REPO, "dep", "mach-std", "src", "types", "string.mach"))
+
+
+def _member_pos():
+    """position of the `str_len` member token in the first code (non-comment)
+    `strmod.str_len` occurrence."""
+    for i, line in enumerate(open(APP).read().splitlines()):
+        if line.lstrip().startswith("#"):
+            continue
+        c = line.find("strmod.str_len")
+        if c >= 0:
+            return pos(i, c + len("strmod."))
+    return None
+
+
+def member_scenario():
+    """definition / hover / references on the aliased module's member."""
+    mpos = _member_pos()
+    if mpos is None:
+        return ["strmod.str_len call not found in fixture-alias app.mach"]
+    text = open(APP).read()
+    frames = [
+        req(1, "initialize", {"capabilities": {}}),
+        notify("initialized"),
+        did_open(URI, text),
+        req(20, "textDocument/definition", {"textDocument": {"uri": URI}, "position": mpos}),
+        req(21, "textDocument/hover", {"textDocument": {"uri": URI}, "position": mpos}),
+        req(22, "textDocument/references",
+            {"textDocument": {"uri": URI}, "position": mpos,
+             "context": {"includeDeclaration": True}}),
+        req(2, "shutdown", None),
+        notify("exit"),
+    ]
+    code, msgs = drive(frames)
+
+    failures = []
+
+    dv = (by_id(msgs, 20) or {}).get("result")
+    if not dv or "uri" not in dv:
+        failures.append("definition(strmod.str_len) returned no Location")
+    elif dv["uri"] != DEP_STRING_URI:
+        failures.append(f"definition(strmod.str_len) uri is not the dep decl: {dv['uri']} != {DEP_STRING_URI}")
+
+    hv = (by_id(msgs, 21) or {}).get("result")
+    if not hv or "contents" not in hv:
+        failures.append("hover(strmod.str_len) returned no contents")
+    else:
+        hval = hv["contents"].get("value", "")
+        if "str_len" not in hval:
+            failures.append("hover(strmod.str_len) value does not mention 'str_len'")
+        if "fun" not in hval:
+            failures.append(f"hover(strmod.str_len) value does not render a signature: {hval!r}")
+
+    rv = (by_id(msgs, 22) or {}).get("result")
+    if not isinstance(rv, list):
+        failures.append("references(strmod.str_len) result is not an array")
+    else:
+        uris = [e.get("uri", "") for e in rv]
+        if DEP_STRING_URI not in uris:
+            failures.append(f"references(strmod.str_len) has no canonical dep decl location (got {sorted(set(uris))})")
+        if not any(u == URI for u in uris):
+            failures.append("references(strmod.str_len) has no in-buffer use-site")
+
+    if code != 0:
+        failures.append("non-zero exit code after clean shutdown")
+    return failures
+
+
+def run():
+    """drive the aliased-import scenarios; return a list of failure strings."""
+    if not os.path.exists(APP):
+        return [f"fixture not found at {APP}"]
+    return member_scenario()
+
+
+if __name__ == "__main__":
+    standalone("alias", run)


### PR DESCRIPTION
Closes #75.

## TL;DR

The reported failure — go-to-definition doing nothing on the **member of an aliased import** (`use foo: a.b.c;` then `foo.member()`) — **does not reproduce on `dev`**. At the currently-pinned mach **v1.5.5**, alias-qualified member go-to-def works for every valid scenario tested. The root cause is **compiler-side and already fixed**; this PR adds only the missing regression coverage so it can't silently regress on a future dep bump.

## Diagnosis

- The compiler resolver populates `expr_resolved` for an `EXPR_KIND_MEMBER` whose base is a module alias, via `bind_member_qualified` in `mach.lang.fe.resolve` (introduced 2026-06-02, present in v1.5.5). It looks the leaf up among the aliased module's exports and records a `SYM_IMPORTED` symbol on the member node.
- The LSP side is correct: `features.ref_at` reads `expr_resolved[member]`, `name_span_of_expr` returns the member token span, `project.site_of` routes to the declaring dependency module by `origin`, and `definition_name_span` recovers the decl name span. No LSP change is required.
- **Counterfactual proof:** temporarily neutering `bind_member_qualified` (binding only the object, skipping the qualified-member lookup) and rebuilding reproduces the exact reported symptom — definition returns no Location, hover returns no contents, references finds nothing. Restoring it makes all three work again. The resolver function is precisely what makes the feature work.

The most likely cause of the original report is a **stale LSP binary** built against a mach predating `bind_member_qualified`. Rebuilding/reinstalling `mach-lsp` resolves it.

## This PR

- `test/fixture-alias/` — a project that binds the std string module under an alias and calls `strmod.str_len(s)`.
- `test/test_alias.py` — asserts definition / hover / references on the member reach `str_len`'s declaration in `dep/mach-std`.
- wired into `test/run.py` (new `alias` scenario).

Full suite (`make test`) is green, including the new scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)