### PR TITLE
test(alias): cover type-member and value-member go-to-def paths (#75)

### DIFF
--- a/test/fixture-alias/src/app.mach
+++ b/test/fixture-alias/src/app.mach
@@ -1,14 +1,17 @@
 # aliased-import member resolution fixture (#75): `use strmod: std.types.string;`
-# binds the std string module under an alias, and `strmod.str_len` is a
-# qualified member access whose go-to-definition must reach str_len's
-# declaration inside dep/mach-std.
+# binds the std string module under an alias, and a qualified member access must
+# reach the member's declaration inside dep/mach-std. covers the three distinct
+# resolution paths: a function member (`strmod.str_len`, via expr_resolved), a
+# type member (`strmod.str`, via type_resolved), and a value member (`bln.true`).
 
 use std.types.size.usize;
 use std.types.string.str;
+use std.types.bool.bool;
 
 use strmod: std.types.string;
+use bln:    std.types.bool;
 
-# length: calls the aliased module's str_len via qualified member access.
+# length: calls the aliased module's str_len via a qualified member access.
 fun length(s: str) usize {
     ret strmod.str_len(s);
 }
@@ -17,4 +20,15 @@ fun length(s: str) usize {
 # one in-buffer occurrence.
 fun twice(s: str) usize {
     ret strmod.str_len(s) + strmod.str_len(s);
+}
+
+# typed: references the aliased module's pub type `str` as a qualified type
+# member (the type_resolved path) in the parameter position.
+fun typed(s: strmod.str) usize {
+    ret strmod.str_len(s);
+}
+
+# flag: references the aliased bool module's `true` value as a value member.
+fun flag() bool {
+    ret bln.true;
 }

--- a/test/test_alias.py
+++ b/test/test_alias.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 """aliased-import member go-to-definition (#75) over test/fixture-alias.
 
-the fixture binds the std string module under an alias (`use strmod:
-std.types.string;`) and calls `strmod.str_len(s)`. definition / hover /
-references on the member name `str_len` must reach str_len's declaration inside
-dep/mach-std, exactly as a directly `use`d symbol does — a module-alias
-qualified member is a resolved cross-module reference, not an unresolved field
-access."""
+the fixture binds the std string and bool modules under aliases (`use strmod:
+std.types.string;`, `use bln: std.types.bool;`) and references their members.
+go-to-definition / hover / references on a qualified member must reach the
+member's declaration inside dep/mach-std, exactly as a directly `use`d symbol
+does — a module-alias qualified member is a resolved cross-module reference, not
+an unresolved field access. the three member kinds exercise distinct resolution
+paths: a function member (expr_resolved), a type member (type_resolved), and a
+value member."""
 import os
 
 from harness import drive, req, notify, did_open, pos, by_id, file_uri, standalone, REPO
@@ -15,26 +17,28 @@ FIXTURE = os.path.join(REPO, "test", "fixture-alias")
 APP = os.path.join(FIXTURE, "src", "app.mach")
 URI = file_uri(APP)
 
-# the canonical URI of str_len's declaring file; the emitted location must match
-# it exactly (no '..' segments), or clients cannot correlate it with a buffer.
+# canonical URIs of the declaring files; emitted locations must match exactly
+# (no '..' segments), or clients cannot correlate them with buffers.
 DEP_STRING_URI = file_uri(os.path.join(REPO, "dep", "mach-std", "src", "types", "string.mach"))
+DEP_BOOL_URI = file_uri(os.path.join(REPO, "dep", "mach-std", "src", "types", "bool.mach"))
 
 
-def _member_pos():
-    """position of the `str_len` member token in the first code (non-comment)
-    `strmod.str_len` occurrence."""
+def _member_pos(qualified):
+    """position of the member token in the first code (non-comment) occurrence of
+    `qualified` (an `alias.member` spelling), or None."""
+    alias = qualified.split(".", 1)[0]
     for i, line in enumerate(open(APP).read().splitlines()):
         if line.lstrip().startswith("#"):
             continue
-        c = line.find("strmod.str_len")
+        c = line.find(qualified)
         if c >= 0:
-            return pos(i, c + len("strmod."))
+            return pos(i, c + len(alias) + 1)
     return None
 
 
 def member_scenario():
-    """definition / hover / references on the aliased module's member."""
-    mpos = _member_pos()
+    """definition / hover / references on the aliased module's function member."""
+    mpos = _member_pos("strmod.str_len")
     if mpos is None:
         return ["strmod.str_len call not found in fixture-alias app.mach"]
     text = open(APP).read()
@@ -85,11 +89,52 @@ def member_scenario():
     return failures
 
 
+def type_value_scenario():
+    """definition on a qualified type member (`strmod.str`, the type_resolved
+    path) and a qualified value member (`bln.true`) — distinct from the function
+    member's expr_resolved path."""
+    tpos = _member_pos("strmod.str)")  # the `str` type in `s: strmod.str)`
+    vpos = _member_pos("bln.true")
+    if tpos is None:
+        return ["strmod.str type member not found in fixture-alias app.mach"]
+    if vpos is None:
+        return ["bln.true value member not found in fixture-alias app.mach"]
+    text = open(APP).read()
+    frames = [
+        req(1, "initialize", {"capabilities": {}}),
+        notify("initialized"),
+        did_open(URI, text),
+        req(30, "textDocument/definition", {"textDocument": {"uri": URI}, "position": tpos}),
+        req(31, "textDocument/definition", {"textDocument": {"uri": URI}, "position": vpos}),
+        req(2, "shutdown", None),
+        notify("exit"),
+    ]
+    code, msgs = drive(frames)
+
+    failures = []
+
+    tv = (by_id(msgs, 30) or {}).get("result")
+    if not tv or "uri" not in tv:
+        failures.append("definition(strmod.str type member) returned no Location")
+    elif tv["uri"] != DEP_STRING_URI:
+        failures.append(f"definition(strmod.str type member) uri is not the dep decl: {tv['uri']} != {DEP_STRING_URI}")
+
+    vv = (by_id(msgs, 31) or {}).get("result")
+    if not vv or "uri" not in vv:
+        failures.append("definition(bln.true value member) returned no Location")
+    elif vv["uri"] != DEP_BOOL_URI:
+        failures.append(f"definition(bln.true value member) uri is not the dep decl: {vv['uri']} != {DEP_BOOL_URI}")
+
+    if code != 0:
+        failures.append("non-zero exit code after clean shutdown")
+    return failures
+
+
 def run():
     """drive the aliased-import scenarios; return a list of failure strings."""
     if not os.path.exists(APP):
         return [f"fixture not found at {APP}"]
-    return member_scenario()
+    return member_scenario() + type_value_scenario()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up to #75 / #76. The merged regression (#76) covered only the **function** member path (`expr_resolved`). This extends `test_alias.py` to lock the two other distinct resolution paths for aliased-import members, all verified working on mach v1.5.5:

- **type member** `strmod.str` — resolves via the `type_resolved` table / `ref_at` type branch (a separate path from function members).
- **value member** `bln.true` — a qualified `pub val`.

Both reach the member's declaration in `dep/mach-std` (`string.mach` / `bool.mach`). The fixture aliases `std.types.bool` alongside `std.types.string`; both modules are in the project closure, so resolution is exercised end-to-end.

Local `make test` is green (mach-lsp has no CI), including the extended `alias` scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)