### PR TITLE
fix(completion): guard nil symbol table on parse-error buffers

### DIFF
--- a/src/features.mach
+++ b/src/features.mach
@@ -579,6 +579,8 @@ pub fun type_ref_span(a: *ast.Ast, rr: *res.ResolveResult, tid: id.TypeId, targe
 # ret: true when the symbol is a top-level completion candidate
 pub fun completion_candidate(rr: *res.ResolveResult, sid: res.SymbolId) bool {
     if (sid >= rr.symbol_count) { ret false; }
+    # resolver can emit count > 0 with a nil table on malformed input
+    if (rr.symbols == nil) { ret false; }
     val sym: *res.Symbol = ?rr.symbols[sid];
     if (sym.name == intern.STR_NIL) { ret false; }
     if (sym.kind == res.SYM_PARAM)   { ret false; }

--- a/src/language.mach
+++ b/src/language.mach
@@ -1112,6 +1112,9 @@ fun decl_lsp_kind(kind: decl.DeclKind) i64 {
 # deduped by spelling so a name declared once appears once. takes ownership of
 # `id_raw` and frees it.
 fun emit_completions(an: Analyzed, alloc: *Allocator, id_raw: str) {
+    # resolver can emit symbol_count > 0 with a nil table on malformed input
+    if (an.rr.symbols == nil) { reply_empty_array(alloc, id_raw); ret; }
+
     val prefix: str = "{\"jsonrpc\":\"2.0\",\"id\":";
     val mid:    str = ",\"result\":{\"isIncomplete\":false,\"items\":[";
     val suffix: str = "]}}";

--- a/src/server.mach
+++ b/src/server.mach
@@ -183,6 +183,10 @@ fun dispatch(srv: *Server, msg: *transport.Message) {
         json.free_str(method, srv.alloc);
         ret;
     }
+    if (str_equals(method, "workspace/didChangeConfiguration")) {
+        json.free_str(method, srv.alloc);
+        ret;
+    }
     if (str_equals(method, "workspace/didChangeWatchedFiles")) {
         json.free_str(method, srv.alloc);
         handle_did_change_watched_files(srv, body);

--- a/test/run.py
+++ b/test/run.py
@@ -16,6 +16,7 @@ import test_multiroot
 import test_invalidation
 import test_encoding
 import test_multitarget
+import test_errorsafe
 
 SUITES = [
     ("diagnostics", test_diagnostics.run),
@@ -27,6 +28,7 @@ SUITES = [
     ("invalidation", test_invalidation.run),
     ("encoding", test_encoding.run),
     ("multitarget", test_multitarget.run),
+    ("errorsafe", test_errorsafe.run),
 ]
 
 

--- a/test/test_errorsafe.py
+++ b/test/test_errorsafe.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""error-safety scenarios: features that must not crash the server when the
+buffer contains a parse error. regression for #79 — completion over a
+parse-error buffer previously caused a nil symbol-table deref and killed the
+process."""
+from harness import drive, req, notify, did_open, pos, by_id, standalone
+
+# a parse error: bare integer `2` as a statement is syntactically invalid
+SRC_ERR = "fun f(a: i64) i64 { 2 }\n"
+URI = "file:///parse_err.mach"
+
+
+def run():
+    """drive error-safety scenarios; return a list of failure strings."""
+    frames = [
+        req(1, "initialize", {"capabilities": {}}),
+        notify("initialized"),
+        did_open(URI, SRC_ERR),
+        req(10, "textDocument/completion", {"textDocument": {"uri": URI}, "position": pos(0, 20)}),
+        req(2, "shutdown", None),
+        notify("exit"),
+    ]
+    code, msgs = drive(frames)
+
+    failures = []
+
+    # server must stay alive: shutdown must receive a reply
+    shut = by_id(msgs, 2)
+    if shut is None:
+        failures.append("server did not reply to shutdown — likely crashed on completion over parse-error buffer")
+
+    # completion must return a result (empty array is fine, error is not)
+    cpv = by_id(msgs, 10)
+    if cpv is None:
+        failures.append("server did not reply to completion over parse-error buffer")
+    elif "error" in cpv:
+        failures.append(f"completion over parse-error buffer returned an error: {cpv['error']}")
+    else:
+        result = cpv.get("result")
+        if result is None:
+            failures.append("completion over parse-error buffer returned null result")
+        else:
+            items = result.get("items") if isinstance(result, dict) else result
+            if items is None:
+                failures.append("completion result missing 'items' field")
+
+    if code != 0:
+        failures.append(f"server exited with non-zero code {code} after parse-error completion")
+
+    return failures
+
+
+if __name__ == "__main__":
+    standalone("errorsafe", run)


### PR DESCRIPTION
## Summary

- Guards `an.rr.symbols == nil` at the top of `emit_completions()` in `src/language.mach`, bailing to an empty completion list — mirrors the invariant at `project.mach:1166` that the rest of the codebase already honors.
- Adds the same nil-table guard to `completion_candidate` in `src/features.mach` (which directly dereferences `rr.symbols[sid]`), making the function independently safe.
- Adds a no-op handler for `workspace/didChangeConfiguration` in `src/server.mach` so it no longer hits the unhandled-method log path on every config push.
- Adds regression test `test/test_errorsafe.py` that opens a parse-error buffer, fires `textDocument/completion`, and asserts the server stays alive and returns a result (empty array acceptable).

## Test plan

- [ ] `make test` — full suite (10 scenarios) passes, including the new `errorsafe` scenario.
- [ ] The new `errorsafe` scenario fails against the pre-fix build (server drops the connection / shutdown receives no reply).
- [ ] No `dep/mach` submodule changes.

Closes #79