### PR TITLE
fix(server): eager project load with progress signalling (#79)

### DIFF
--- a/src/project.mach
+++ b/src/project.mach
@@ -412,6 +412,30 @@ pub fun root_for(w: *Workspace, uri: str) *Root {
     ret load_root(w, doc_root);
 }
 
+# load_workspace_root: eagerly load the project governing the workspace root
+# directory at `dir_uri`, so the slow whole-closure graph build happens once at
+# startup off the request path rather than lazily on the first cross-module
+# feature request (the freeze of #79). finds the nearest project root at or above
+# the directory and, when it is not already tracked, builds it through the same
+# `load_root` path a first request would take, so a later request find_roots the
+# warmed slot instead of rebuilding it. best-effort: a load failure is reported
+# from within try_load and left as a remembered failed slot, exactly as a lazy
+# load's would be. a no-op when the URI is non-file, the directory lies outside
+# any project (single-file mode), or the root is already tracked.
+# ---
+# w:       the workspace
+# dir_uri: the workspace root directory's `file://` URI
+pub fun load_workspace_root(w: *Workspace, dir_uri: str) {
+    if (dir_uri == nil) { ret; }
+    val dir: str = uri_to_path(w.alloc, dir_uri);
+    if (dir == nil) { ret; }
+    val root: str = project_root_at(w.alloc, dir);
+    strutil.str_free(w.alloc, dir);
+    if (root == nil) { ret; }
+    if (find_root(w, root) != nil) { strutil.str_free(w.alloc, root); ret; }
+    load_root(w, root);
+}
+
 # ancestor_root: load-and-prefer the outermost project that vendors the document
 # at `uri` (whose own fresh root is `doc_root`) and whose loaded graph holds it.
 # walks the chain of ancestor manifest dirs strictly above `dir` (`doc_root` on
@@ -1348,6 +1372,40 @@ fun project_root_for(alloc: *Allocator, file_path: str) str {
         }
         strutil.str_free(alloc, dir);
         dir = up;
+    }
+    ret nil;
+}
+
+# project_root_at: the nearest directory at or above `dir` that holds a
+# `mach.toml`, as an owned string, or nil when none exists. unlike
+# `project_root_for` — which treats its argument as a file and begins the search
+# at its parent — this checks `dir` itself first, so a workspace-root directory
+# whose own `mach.toml` roots the project is found (the eager-load entry takes a
+# directory URI, not a file). walks up to the filesystem root with `path.parent`
+# / `path.join`.
+fun project_root_at(alloc: *Allocator, dir: str) str {
+    val dup_r: Result[str, str] = strutil.str_dup(alloc, dir);
+    if (is_err[str, str](dup_r)) { ret nil; }
+    var cur: str = unwrap_ok[str, str](dup_r);
+
+    for (true) {
+        val cand_r: Result[pathlib.Path, str] = pathlib.join(alloc, cur, "mach.toml");
+        if (is_err[pathlib.Path, str](cand_r)) { strutil.str_free(alloc, cur); ret nil; }
+        val cand: str = unwrap_ok[pathlib.Path, str](cand_r);
+        val found: bool = fs.is_file(cand);
+        strutil.str_free(alloc, cand);
+        if (found) { ret cur; }
+
+        val up_r: Result[pathlib.Path, str] = pathlib.parent(alloc, cur);
+        if (is_err[pathlib.Path, str](up_r)) { strutil.str_free(alloc, cur); ret nil; }
+        val up: str = unwrap_ok[pathlib.Path, str](up_r);
+        if (str_equals(up, cur)) {
+            strutil.str_free(alloc, up);
+            strutil.str_free(alloc, cur);
+            ret nil;
+        }
+        strutil.str_free(alloc, cur);
+        cur = up;
     }
     ret nil;
 }

--- a/src/server.mach
+++ b/src/server.mach
@@ -55,6 +55,12 @@ pub val STATUS_EXITED:        u8 = 3;
 # ws:            per-root project graphs backing cross-module analysis
 # watch_dynamic: whether the client supports dynamic file-watch registration
 #                (`workspace/didChangeWatchedFiles`), advertised at initialize
+# progress:      whether the client supports `window/workDoneProgress`, so the
+#                eager project load is wrapped in a progress span rather than a
+#                single fallback notification
+# root_uri:      owned `file://` URI of the workspace root captured at initialize
+#                (rootUri / first workspaceFolder / rootPath), eagerly loaded at
+#                `initialized`; nil in single-file mode
 pub rec Server {
     status:        u8;
     exit_code:     i64;
@@ -64,6 +70,8 @@ pub rec Server {
     docs:          documents.Store;
     ws:            project.Workspace;
     watch_dynamic: bool;
+    progress:      bool;
+    root_uri:      str;
 }
 
 # init: build a server over the given allocator.
@@ -76,6 +84,8 @@ pub fun init(srv: *Server, alloc: *Allocator) bool {
     srv.exit_code = 0;
     srv.alloc = alloc;
     srv.watch_dynamic = false;
+    srv.progress = false;
+    srv.root_uri = nil;
 
     val sr: Result[sess.Session, str] = sess.init(alloc);
     if (is_err[sess.Session, str](sr)) { ret false; }
@@ -91,6 +101,7 @@ pub fun init(srv: *Server, alloc: *Allocator) bool {
 # ---
 # srv: server to tear down
 pub fun dnit(srv: *Server) {
+    if (srv.root_uri != nil) { json.free_str(srv.root_uri, srv.alloc); srv.root_uri = nil; }
     documents.dnit(?srv.docs);
     project.dnit(?srv.ws);
     editor.dnit(?srv.es);
@@ -246,6 +257,16 @@ fun handle_initialize(srv: *Server, body: str) {
     # `initialized` only sends one when it will be honoured.
     srv.watch_dynamic = json.extract_bool_after(body, "\"didChangeWatchedFiles\"", "\"dynamicRegistration\"", srv.alloc);
 
+    # remember whether the client supports work-done progress, so the eager load
+    # at `initialized` can report a live, long-running operation instead of a
+    # single fallback notification.
+    srv.progress = json.extract_bool_after(body, "\"window\"", "\"workDoneProgress\"", srv.alloc);
+
+    # capture the workspace root for the eager load at `initialized`: prefer the
+    # rootUri, then the first workspaceFolder, then the deprecated rootPath
+    # (rewritten as a file:// URI). nil leaves the server in single-file mode.
+    srv.root_uri = capture_root(srv, body);
+
     val prefix: str = "{\"jsonrpc\":\"2.0\",\"id\":";
     val result: str = ",\"result\":{\"capabilities\":{\"textDocumentSync\":1,\"hoverProvider\":true,\"definitionProvider\":true,\"referencesProvider\":true,\"renameProvider\":{\"prepareProvider\":true},\"documentSymbolProvider\":true,\"completionProvider\":{\"triggerCharacters\":[\".\"]}},\"serverInfo\":{\"name\":\"mach-lsp\"}}}";
     send_concat2(srv, prefix, id, result);
@@ -255,18 +276,83 @@ fun handle_initialize(srv: *Server, body: str) {
     trace.log("initialized\n");
 }
 
-# handle_initialized: once the client signals it is ready, register file
-# watchers for the manifest, lockfile, and source trees so a dep-graph change
-# (pulling deps, editing a dep source) triggers `workspace/didChangeWatchedFiles`
-# and the affected project root is rebuilt. only sent when the client advertised
-# dynamic registration; clients without it fall back to the server's mtime check.
+# handle_initialized: once the client signals it is ready, register file watchers
+# for the manifest, lockfile, and source trees so a dep-graph change (pulling
+# deps, editing a dep source) triggers `workspace/didChangeWatchedFiles` and the
+# affected project root is rebuilt (only when the client advertised dynamic
+# registration; clients without it fall back to the server's mtime check), then
+# eagerly build the captured workspace project so the slow whole-closure load
+# happens here, off the request path, rather than freezing the first feature
+# request (#79).
 fun handle_initialized(srv: *Server) {
-    if (!srv.watch_dynamic) { ret; }
-    val reg: str = "{\"jsonrpc\":\"2.0\",\"id\":\"mls/registerWatchers\",\"method\":\"client/registerCapability\",\"params\":{\"registrations\":[{\"id\":\"mls-watched-files\",\"method\":\"workspace/didChangeWatchedFiles\",\"registerOptions\":{\"watchers\":[{\"globPattern\":\"**/mach.toml\"},{\"globPattern\":\"**/mach.lock\"},{\"globPattern\":\"**/*.mach\"}]}}]}}";
-    transport.send_message(reg, srv.alloc);
-    # the watcher now covers manifest / lockfile changes; skip the per-request
-    # mtime fallback check.
-    project.set_watch_active(?srv.ws, true);
+    if (srv.watch_dynamic) {
+        val reg: str = "{\"jsonrpc\":\"2.0\",\"id\":\"mls/registerWatchers\",\"method\":\"client/registerCapability\",\"params\":{\"registrations\":[{\"id\":\"mls-watched-files\",\"method\":\"workspace/didChangeWatchedFiles\",\"registerOptions\":{\"watchers\":[{\"globPattern\":\"**/mach.toml\"},{\"globPattern\":\"**/mach.lock\"},{\"globPattern\":\"**/*.mach\"}]}}]}}";
+        transport.send_message(reg, srv.alloc);
+        # the watcher now covers manifest / lockfile changes; skip the per-request
+        # mtime fallback check.
+        project.set_watch_active(?srv.ws, true);
+    }
+    eager_load(srv);
+}
+
+# eager_load: build the captured workspace project now, at startup, instead of on
+# the first cross-module feature request, so no client request is ever left
+# hanging on the slow whole-closure build (#79). the load still blocks the
+# single-threaded message loop for its full duration — unavoidable without
+# threads — but it happens once, off the request path, and is wrapped in a
+# work-done-progress span so a client that supports it sees a live, long-running
+# operation rather than an unresponsive server. because the loop is blocked, no
+# `report` update can be sent mid-build; only `begin` (before) and `end` (after).
+# clients without `window.workDoneProgress` get a single showMessage instead. a
+# no-op in single-file mode (no workspace root captured at initialize).
+fun eager_load(srv: *Server) {
+    if (srv.root_uri == nil) { ret; }
+
+    if (srv.progress) {
+        transport.send_message("{\"jsonrpc\":\"2.0\",\"id\":\"mls/loadProgress\",\"method\":\"window/workDoneProgress/create\",\"params\":{\"token\":\"mls/load\"}}", srv.alloc);
+        transport.send_message("{\"jsonrpc\":\"2.0\",\"method\":\"$/progress\",\"params\":{\"token\":\"mls/load\",\"value\":{\"kind\":\"begin\",\"title\":\"Loading Mach project\"}}}", srv.alloc);
+    }
+    or {
+        transport.send_message("{\"jsonrpc\":\"2.0\",\"method\":\"window/showMessage\",\"params\":{\"type\":3,\"message\":\"mach-lsp: loading project...\"}}", srv.alloc);
+    }
+
+    project.load_workspace_root(?srv.ws, srv.root_uri);
+
+    if (srv.progress) {
+        transport.send_message("{\"jsonrpc\":\"2.0\",\"method\":\"$/progress\",\"params\":{\"token\":\"mls/load\",\"value\":{\"kind\":\"end\"}}}", srv.alloc);
+    }
+}
+
+# capture_root: the workspace root `file://` URI from the initialize params, as an
+# owned string, or nil for a single-file session. prefers `rootUri`, then the
+# first `workspaceFolders` entry's `uri`, then the deprecated `rootPath` rewritten
+# as a `file://` URI.
+fun capture_root(srv: *Server, body: str) str {
+    var uri: str = json.extract_string(body, "\"rootUri\"", srv.alloc);
+    if (uri != nil) { ret uri; }
+    uri = json.extract_after(body, "\"workspaceFolders\"", "\"uri\"", srv.alloc);
+    if (uri != nil) { ret uri; }
+    val path: str = json.extract_string(body, "\"rootPath\"", srv.alloc);
+    if (path == nil) { ret nil; }
+    val out: str = path_to_uri(srv, path);
+    json.free_str(path, srv.alloc);
+    ret out;
+}
+
+# path_to_uri: a `file://` URI for an absolute filesystem `path`, owned by the
+# caller, or nil on allocation failure. the minimal inverse used for the
+# deprecated rootPath fallback; project-side decoding (`uri_to_path`) reverses it.
+fun path_to_uri(srv: *Server, path: str) str {
+    val scheme: str = "file://";
+    val total: usize = flen(scheme) + flen(path);
+    val r: Result[*u8, str] = allocate[u8](srv.alloc, total + 1);
+    if (is_err[*u8, str](r)) { ret nil; }
+    val buf: *u8 = unwrap_ok[*u8, str](r);
+    var off: usize = 0;
+    off = fappend(buf, off, scheme);
+    off = fappend(buf, off, path);
+    buf[off] = 0;
+    ret buf::str;
 }
 
 # handle_did_change_watched_files: invalidate every project root whose tree

--- a/test/harness.py
+++ b/test/harness.py
@@ -162,6 +162,32 @@ class LiveServer:
                 return None
             self.buf += chunk
 
+    def collect_until(self, want_id, timeout=60):
+        """read and return every message up to and including the response with id
+        `want_id` — server-initiated requests ($/progress, workDoneProgress/create)
+        and notifications included, in arrival order — or the messages seen so far
+        on timeout. lets a scenario observe what the server emits around a request
+        rather than discarding it like recv_id."""
+        out = []
+        deadline = time.time() + timeout
+        while True:
+            msg = self._pop()
+            if msg is not None:
+                out.append(msg)
+                if msg.get("id") == want_id:
+                    return out
+                continue
+            remaining = deadline - time.time()
+            if remaining <= 0:
+                return out
+            r, _, _ = select.select([self.proc.stdout], [], [], remaining)
+            if not r:
+                return out
+            chunk = os.read(self.proc.stdout.fileno(), 65536)
+            if not chunk:
+                return out
+            self.buf += chunk
+
     def close(self, timeout=10):
         """close stdin and wait for the server to exit; returns the exit code."""
         try:

--- a/test/run.py
+++ b/test/run.py
@@ -16,6 +16,7 @@ import test_multiroot
 import test_invalidation
 import test_encoding
 import test_multitarget
+import test_eager
 
 SUITES = [
     ("diagnostics", test_diagnostics.run),
@@ -27,6 +28,7 @@ SUITES = [
     ("invalidation", test_invalidation.run),
     ("encoding", test_encoding.run),
     ("multitarget", test_multitarget.run),
+    ("eager", test_eager.run),
 ]
 
 

--- a/test/test_eager.py
+++ b/test/test_eager.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""eager project-load scenarios (#79).
+
+when the client supplies a workspace root at initialize, the server builds that
+project's whole import closure once at `initialized` — off the request path —
+instead of lazily on the first cross-module feature request, where the long
+build would leave the request hanging and the client declaring the server dead.
+
+the build still blocks the single-threaded loop for its full duration; the win
+is that it happens once, at startup, wrapped in a liveness signal. these tests
+assert that signal (a work-done-progress span when the client supports it, a
+single showMessage when it does not) and that the warmed project still serves a
+cross-module request correctly. timing is not asserted — only behaviour."""
+import os
+
+from harness import (LiveServer, req, notify, did_open, pos, file_uri,
+                     standalone, FIXTURE, REPO)
+
+APP = os.path.join(FIXTURE, "src", "app.mach")
+URI = file_uri(APP)
+ROOT_URI = file_uri(FIXTURE)
+DEP_STRING_URI = file_uri(os.path.join(REPO, "dep", "mach-std", "src", "types", "string.mach"))
+
+# app.mach line 10: `    ret str_len(s);` — `str_len` use, name at col 10.
+STR_LEN = pos(10, 10)
+
+
+def _progress(msgs):
+    """the $/progress notifications in `msgs`, as a list of (kind, token)."""
+    out = []
+    for m in msgs:
+        if m.get("method") == "$/progress":
+            v = m.get("params", {}).get("value", {})
+            out.append((v.get("kind"), m.get("params", {}).get("token")))
+    return out
+
+
+def progress_scenario():
+    """with window.workDoneProgress, `initialized` creates a progress token and
+    emits a begin/end span around the eager load, and the warmed project then
+    answers a cross-module definition into the dependency."""
+    text = open(APP).read()
+    ls = LiveServer()
+    ls.send(req(1, "initialize",
+                {"rootUri": ROOT_URI, "capabilities": {"window": {"workDoneProgress": True}}}))
+    if ls.recv_id(1) is None:
+        return ["initialize got no response"]
+    ls.send(notify("initialized"))
+    ls.send(did_open(URI, text))
+    ls.send(req(20, "textDocument/definition",
+                {"textDocument": {"uri": URI}, "position": STR_LEN}))
+    msgs = ls.collect_until(20)
+    ls.send(req(2, "shutdown", None))
+    ls.send(notify("exit"))
+    code = ls.close()
+
+    failures = []
+
+    create = next((m for m in msgs
+                   if m.get("method") == "window/workDoneProgress/create"), None)
+    if create is None:
+        failures.append("no window/workDoneProgress/create request was sent")
+        token = None
+    else:
+        token = create.get("params", {}).get("token")
+        if not token:
+            failures.append("workDoneProgress/create carried no token")
+
+    prog = _progress(msgs)
+    kinds = [k for k, _ in prog]
+    if "begin" not in kinds:
+        failures.append(f"no $/progress begin around the eager load (got {kinds})")
+    if "end" not in kinds:
+        failures.append(f"no $/progress end around the eager load (got {kinds})")
+    if token is not None:
+        if any(t != token for _, t in prog):
+            failures.append(f"a $/progress token did not match the created token {token!r}: {prog}")
+
+    dv = next((m.get("result") for m in msgs if m.get("id") == 20), None)
+    if not dv or dv.get("uri") != DEP_STRING_URI:
+        failures.append(f"definition(str_len) after eager load did not reach the dep decl: {dv}")
+
+    if code != 0:
+        failures.append("non-zero exit code after clean shutdown")
+    return failures
+
+
+def fallback_scenario():
+    """without window.workDoneProgress, the eager load falls back to a single
+    showMessage and sends no $/progress; the project is still warmed and serves
+    a cross-module definition."""
+    text = open(APP).read()
+    ls = LiveServer()
+    ls.send(req(1, "initialize", {"rootUri": ROOT_URI, "capabilities": {}}))
+    if ls.recv_id(1) is None:
+        return ["initialize got no response"]
+    ls.send(notify("initialized"))
+    ls.send(did_open(URI, text))
+    ls.send(req(20, "textDocument/definition",
+                {"textDocument": {"uri": URI}, "position": STR_LEN}))
+    msgs = ls.collect_until(20)
+    ls.send(req(2, "shutdown", None))
+    ls.send(notify("exit"))
+    code = ls.close()
+
+    failures = []
+
+    if _progress(msgs):
+        failures.append("a $/progress span was sent without window.workDoneProgress")
+    if any(m.get("method") == "window/workDoneProgress/create" for m in msgs):
+        failures.append("workDoneProgress/create was sent without the capability")
+
+    show = next((m for m in msgs if m.get("method") == "window/showMessage"), None)
+    if show is None:
+        failures.append("no showMessage fallback for a progress-less client")
+    elif "loading" not in show.get("params", {}).get("message", "").lower():
+        failures.append(f"showMessage fallback did not mention loading: {show}")
+
+    dv = next((m.get("result") for m in msgs if m.get("id") == 20), None)
+    if not dv or dv.get("uri") != DEP_STRING_URI:
+        failures.append(f"definition(str_len) after fallback eager load did not reach the dep decl: {dv}")
+
+    if code != 0:
+        failures.append("non-zero exit code after clean shutdown")
+    return failures
+
+
+def single_file_scenario():
+    """no workspace root: the server stays in single-file mode — no eager load,
+    no progress span, no showMessage — and a local symbol still resolves."""
+    src = "fun lone() i64 { ret 1; }\n"
+    uri = "file:///scratch.mach"
+    ls = LiveServer()
+    ls.send(req(1, "initialize",
+                {"capabilities": {"window": {"workDoneProgress": True}}}))
+    if ls.recv_id(1) is None:
+        return ["initialize got no response"]
+    ls.send(notify("initialized"))
+    ls.send(did_open(uri, src))
+    ls.send(req(20, "textDocument/definition",
+                {"textDocument": {"uri": uri}, "position": pos(0, 5)}))
+    msgs = ls.collect_until(20)
+    ls.send(req(2, "shutdown", None))
+    ls.send(notify("exit"))
+    code = ls.close()
+
+    failures = []
+    if _progress(msgs):
+        failures.append("a $/progress span was sent in single-file mode")
+    if any(m.get("method") == "window/workDoneProgress/create" for m in msgs):
+        failures.append("workDoneProgress/create was sent in single-file mode")
+    if any(m.get("method") == "window/showMessage" for m in msgs):
+        failures.append("a showMessage was sent in single-file mode")
+
+    dv = next((m.get("result") for m in msgs if m.get("id") == 20), None)
+    if not dv or dv.get("uri") != uri:
+        failures.append(f"definition(lone) did not resolve locally in single-file mode: {dv}")
+
+    if code != 0:
+        failures.append("non-zero exit code after clean shutdown")
+    return failures
+
+
+def run():
+    """drive the eager-load scenarios; return a list of failure strings."""
+    if not os.path.exists(APP):
+        return [f"fixture not found at {APP}"]
+    failures = []
+    failures += progress_scenario()
+    failures += fallback_scenario()
+    failures += single_file_scenario()
+    return failures
+
+
+if __name__ == "__main__":
+    standalone("eager", run)


### PR DESCRIPTION
Refs #79.

## Problem

The server is single-threaded. The project's whole import closure was built **lazily on the first cross-module feature request** (hover / completion / definition / references), inside `project.root_for` → `load_root` → `try_load` → `driver.build_project_union`. Parsing + resolving that closure blocks the message loop for the build's full duration:

- template (`std` only): ~0.6s
- mach-lsp (pulls in the whole `mach` compiler): ~22s
- mach compiler buffer: ~33s

So the first feature request hangs for that long. The editor (Zed) declares the unresponsive server dead and restarts it, which re-triggers the build on the next request → restart loop → permanent hang. (Diagnostics were never affected — they use the separate fast `editor.diagnostics` path.)

After the first build the result is cached (~0.02s per later request, even after edits); the freeze is purely the one-time closure build, on the request path.

## Fix

Move the load **off the request path** and signal liveness during it:

1. **Eager load at `initialized`.** Capture the workspace root at `initialize` (`rootUri`, else first `workspaceFolders[].uri`, else deprecated `rootPath`), and build the project once at `initialized` via a new `project.load_workspace_root` — the same `load_root` path a first request would take, so later requests find the warm slot instead of rebuilding. `initialized` is chosen over `initialize` because it is a notification (no response is owed), so nothing the client is blocked on hangs during the build; it is earlier than any feature request and earlier than `didOpen`. Single-file sessions (no root) skip the load entirely.

2. **Progress signalling (`window/workDoneProgress`).** Gated on the client capability. When supported: `window/workDoneProgress/create` (token) + `$/progress` `begin` before the build, `$/progress` `end` after. The single-threaded loop is blocked during the build, so **no `report` updates are possible mid-build** — only `begin` then `end`. Clients without the capability get a single `window/showMessage` ("loading project...") instead; clients with neither are unaffected (no behaviour change).

### Design choice: `initialized` over `didOpen`

Eager-loading at `initialized` covers the dominant case (the client's own project, opened with a `rootUri` — Zed always sends one) with a single, well-scoped load before any feature request exists. `didOpen` eager-loading (for a file whose root the workspace root didn't capture, e.g. a second unrelated project folder) is deliberately **not** added here: it would slow the fast diagnostics path and the multi-folder case is rare. Those secondary roots still lazy-load on first request, exactly as before. Possible follow-up.

## Honest limitation

This still blocks the loop for the full build duration — **unavoidable without threads** (`std` has none). The win is precise: the build happens **once, at startup, off the request path, with a liveness signal**, so no individual client request is ever left hanging. Reducing the absolute build time is a separate compiler concern (octalide/mach#1510).

`begin → (silence during build) → end` with a fire-and-forget `create` (the loop can't wait for the create response) is slightly out of spec. Whether Zed tolerates it — and stays alive across the silent build — is the thing to verify in-editor, which is why this is **Refs #79, not Closes**.

## Verification

The build firing was instrumented (a temporary probe in `try_load`, since reverted) and driven with a `rootUri`:

```
recv: initialized
PROBE try_load build          <- build happens here, during initialized
recv: textDocument/didOpen
recv: textDocument/definition (id 20)
recv: textDocument/hover      (id 21)
```

Build probe count: **1**. The definition and hover requests trigger **no** rebuild — served from the warm cache. Message arrival order to the client: `workDoneProgress/create`, `$/progress begin`, `$/progress end`, `publishDiagnostics`, response 20, response 21 — the progress span (and the build) complete before any feature response, confirming the cost is off the request path.

## Tests

New `test/test_eager.py` (added to `make test`): asserts the progress span (create + begin/end, matching tokens) with `window.workDoneProgress`, the `showMessage` fallback without it, and neither in single-file mode — each with a cross-module definition served correctly from the warmed project. Behaviour, not timing, is asserted. Adds `LiveServer.collect_until` to observe server-initiated messages.

```
[ OK ] diagnostics
[ OK ] features
[ OK ] crossmodule
[ OK ] alias
[ OK ] workspace
[ OK ] multiroot
[ OK ] invalidation
[ OK ] encoding
[ OK ] multitarget
[ OK ] eager

PASSED: all scenarios
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)