### PR TITLE
fix(fixture): migrate $mach.target.os to $mach.build.os for 2.0.0

### DIFF
--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,7 @@
 [project]
 id      = "mls"
 name    = "Mach Language Server"
-version = "0.5.0"
+version = "0.5.1"
 src     = "src"
 dep     = "dep"
 target  = "native"

--- a/test/fixture-multitarget/src/main.mach
+++ b/test/fixture-multitarget/src/main.mach
@@ -3,7 +3,7 @@
 # closure but present in the union build.
 use mtfix.common.shared;
 
-$if ($mach.target.os == $mach.os.windows) {
+$if ($mach.build.os == $mach.os.windows) {
     use mtfix.winonly;
 }
 


### PR DESCRIPTION
## Summary

- `$mach.target.*` was removed in Mach 2.0.0 (comptime collapse — the `$mach.target.*` subtree no longer exists; the resolved-build path is `$mach.build.*`).
- Updates the one affected file: `test/fixture-multitarget/src/main.mach` line 6.
- No LSP source files needed changes — completion and symbol resolution are fully delegated to the compiler's resolver with no hardcoded comptime-root tables.
- Bumps mach-lsp own semver `0.5.0` → `0.5.1` (patch).

Closes #87

## Test plan

- [ ] Build `mach-lsp` against a Mach 2.0.0 compiler and confirm the multitarget fixture still compiles and `make test` passes (deferred — Mach compiler not available in CI here).
- [ ] Confirm `test/fixture-multitarget/src/main.mach` parses cleanly under 2.0.0 (`$mach.build.os` is the correct path per `doc/language/comptime-mach.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)