### PR TITLE
fix: bump dep/mach to mach 2.4.1 (union-walk crash fix) + multi-target integration coverage

### DIFF
--- a/mach.lock
+++ b/mach.lock
@@ -8,4 +8,4 @@ commit = "2e95444191a98e8dd6419faeaff1a6fc23515d3a"
 [deps.mach]
 url = "https://github.com/octalide/mach"
 ref = "branch/main"
-commit = "8c2a034a88099dea0bbbdbc64e2b329112d1cfa4"
+commit = "5585b7f52ae4d35cbe493bb4ed60995981603fa0"

--- a/mach.lock
+++ b/mach.lock
@@ -8,4 +8,4 @@ commit = "2e95444191a98e8dd6419faeaff1a6fc23515d3a"
 [deps.mach]
 url = "https://github.com/octalide/mach"
 ref = "branch/main"
-commit = "5585b7f52ae4d35cbe493bb4ed60995981603fa0"
+commit = "14ce1f3b966d7ac9012e6c3ccb8153be13d7726b"

--- a/test/fixture-multitarget-realloc/mach.toml
+++ b/test/fixture-multitarget-realloc/mach.toml
@@ -1,0 +1,29 @@
+# realloc-mid-walk regression fixture (#91 / mach#1540): three targets diverging
+# on both OS and arch. main's `$if` chain takes the windows branch (importing 24
+# leaf modules — enough to cross the compiler's INITIAL_MODULE_CAP of 16 and force
+# a `p.modules` realloc mid-walk) and the linux branch (one more leaf). under the
+# union build the load-walk visits both taken branches; pre-fix mach the realloc
+# in the first dangled the cached module entry the second deref'd -> SIGSEGV.
+[project]
+id      = "rtfix"
+version = "0.0.0"
+src     = "src"
+target  = "native"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.windows]
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[bin.rtfix]
+entry = "main.mach"

--- a/test/fixture-multitarget-realloc/src/lx.mach
+++ b/test/fixture-multitarget-realloc/src/lx.mach
@@ -1,0 +1,4 @@
+# lx: the linux-branch leaf, loaded after the windows branch's realloc. the
+# test resolves a request onto `lxval` to prove the union loaded it and the
+# server survived the post-realloc walk.
+pub fun lxval() i32 { ret 99; }

--- a/test/fixture-multitarget-realloc/src/main.mach
+++ b/test/fixture-multitarget-realloc/src/main.mach
@@ -1,0 +1,40 @@
+# main: a 2-branch target-gated $if. the windows branch imports 24 leaf modules
+# (w00..w23) — crossing the compiler's INITIAL_MODULE_CAP (16) so loading it grows
+# `p.modules` mid-walk; the linux branch imports one more leaf (lx). under the
+# union build both branches are taken (windows and the two linux targets), so the
+# load-walk visits the linux branch after the windows realloc — the use-after-
+# realloc that crashed pre-fix (#91 / mach#1540). lx.mach is loaded only via the
+# linux branch, so a cross-module request reaching it proves the union loaded and
+# the server survived the walk.
+$if ($mach.build.os == $mach.os.windows) {
+    use rtfix.w00;
+    use rtfix.w01;
+    use rtfix.w02;
+    use rtfix.w03;
+    use rtfix.w04;
+    use rtfix.w05;
+    use rtfix.w06;
+    use rtfix.w07;
+    use rtfix.w08;
+    use rtfix.w09;
+    use rtfix.w10;
+    use rtfix.w11;
+    use rtfix.w12;
+    use rtfix.w13;
+    use rtfix.w14;
+    use rtfix.w15;
+    use rtfix.w16;
+    use rtfix.w17;
+    use rtfix.w18;
+    use rtfix.w19;
+    use rtfix.w20;
+    use rtfix.w21;
+    use rtfix.w22;
+    use rtfix.w23;
+} $or ($mach.build.os == $mach.os.linux) {
+    use rtfix.lx;
+}
+
+fun main() i32 {
+    ret 0;
+}

--- a/test/fixture-multitarget-realloc/src/w00.mach
+++ b/test/fixture-multitarget-realloc/src/w00.mach
@@ -1,0 +1,3 @@
+# w00: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f00() i32 { ret 0; }

--- a/test/fixture-multitarget-realloc/src/w01.mach
+++ b/test/fixture-multitarget-realloc/src/w01.mach
@@ -1,0 +1,3 @@
+# w01: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f01() i32 { ret 1; }

--- a/test/fixture-multitarget-realloc/src/w02.mach
+++ b/test/fixture-multitarget-realloc/src/w02.mach
@@ -1,0 +1,3 @@
+# w02: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f02() i32 { ret 2; }

--- a/test/fixture-multitarget-realloc/src/w03.mach
+++ b/test/fixture-multitarget-realloc/src/w03.mach
@@ -1,0 +1,3 @@
+# w03: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f03() i32 { ret 3; }

--- a/test/fixture-multitarget-realloc/src/w04.mach
+++ b/test/fixture-multitarget-realloc/src/w04.mach
@@ -1,0 +1,3 @@
+# w04: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f04() i32 { ret 4; }

--- a/test/fixture-multitarget-realloc/src/w05.mach
+++ b/test/fixture-multitarget-realloc/src/w05.mach
@@ -1,0 +1,3 @@
+# w05: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f05() i32 { ret 5; }

--- a/test/fixture-multitarget-realloc/src/w06.mach
+++ b/test/fixture-multitarget-realloc/src/w06.mach
@@ -1,0 +1,3 @@
+# w06: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f06() i32 { ret 6; }

--- a/test/fixture-multitarget-realloc/src/w07.mach
+++ b/test/fixture-multitarget-realloc/src/w07.mach
@@ -1,0 +1,3 @@
+# w07: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f07() i32 { ret 7; }

--- a/test/fixture-multitarget-realloc/src/w08.mach
+++ b/test/fixture-multitarget-realloc/src/w08.mach
@@ -1,0 +1,3 @@
+# w08: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f08() i32 { ret 8; }

--- a/test/fixture-multitarget-realloc/src/w09.mach
+++ b/test/fixture-multitarget-realloc/src/w09.mach
@@ -1,0 +1,3 @@
+# w09: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f09() i32 { ret 9; }

--- a/test/fixture-multitarget-realloc/src/w10.mach
+++ b/test/fixture-multitarget-realloc/src/w10.mach
@@ -1,0 +1,3 @@
+# w10: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f10() i32 { ret 10; }

--- a/test/fixture-multitarget-realloc/src/w11.mach
+++ b/test/fixture-multitarget-realloc/src/w11.mach
@@ -1,0 +1,3 @@
+# w11: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f11() i32 { ret 11; }

--- a/test/fixture-multitarget-realloc/src/w12.mach
+++ b/test/fixture-multitarget-realloc/src/w12.mach
@@ -1,0 +1,3 @@
+# w12: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f12() i32 { ret 12; }

--- a/test/fixture-multitarget-realloc/src/w13.mach
+++ b/test/fixture-multitarget-realloc/src/w13.mach
@@ -1,0 +1,3 @@
+# w13: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f13() i32 { ret 13; }

--- a/test/fixture-multitarget-realloc/src/w14.mach
+++ b/test/fixture-multitarget-realloc/src/w14.mach
@@ -1,0 +1,3 @@
+# w14: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f14() i32 { ret 14; }

--- a/test/fixture-multitarget-realloc/src/w15.mach
+++ b/test/fixture-multitarget-realloc/src/w15.mach
@@ -1,0 +1,3 @@
+# w15: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f15() i32 { ret 15; }

--- a/test/fixture-multitarget-realloc/src/w16.mach
+++ b/test/fixture-multitarget-realloc/src/w16.mach
@@ -1,0 +1,3 @@
+# w16: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f16() i32 { ret 16; }

--- a/test/fixture-multitarget-realloc/src/w17.mach
+++ b/test/fixture-multitarget-realloc/src/w17.mach
@@ -1,0 +1,3 @@
+# w17: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f17() i32 { ret 17; }

--- a/test/fixture-multitarget-realloc/src/w18.mach
+++ b/test/fixture-multitarget-realloc/src/w18.mach
@@ -1,0 +1,3 @@
+# w18: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f18() i32 { ret 18; }

--- a/test/fixture-multitarget-realloc/src/w19.mach
+++ b/test/fixture-multitarget-realloc/src/w19.mach
@@ -1,0 +1,3 @@
+# w19: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f19() i32 { ret 19; }

--- a/test/fixture-multitarget-realloc/src/w20.mach
+++ b/test/fixture-multitarget-realloc/src/w20.mach
@@ -1,0 +1,3 @@
+# w20: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f20() i32 { ret 20; }

--- a/test/fixture-multitarget-realloc/src/w21.mach
+++ b/test/fixture-multitarget-realloc/src/w21.mach
@@ -1,0 +1,3 @@
+# w21: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f21() i32 { ret 21; }

--- a/test/fixture-multitarget-realloc/src/w22.mach
+++ b/test/fixture-multitarget-realloc/src/w22.mach
@@ -1,0 +1,3 @@
+# w22: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f22() i32 { ret 22; }

--- a/test/fixture-multitarget-realloc/src/w23.mach
+++ b/test/fixture-multitarget-realloc/src/w23.mach
@@ -1,0 +1,3 @@
+# w23: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f23() i32 { ret 23; }

--- a/test/run.py
+++ b/test/run.py
@@ -16,6 +16,7 @@ import test_multiroot
 import test_invalidation
 import test_encoding
 import test_multitarget
+import test_multitarget_realloc
 
 SUITES = [
     ("diagnostics", test_diagnostics.run),
@@ -27,6 +28,7 @@ SUITES = [
     ("invalidation", test_invalidation.run),
     ("encoding", test_encoding.run),
     ("multitarget", test_multitarget.run),
+    ("multitarget-realloc", test_multitarget_realloc.run),
 ]
 
 

--- a/test/test_multitarget_realloc.py
+++ b/test/test_multitarget_realloc.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""multi-target union realloc regression (#91 / mach#1540): loading a real
+multi-target project drove the compiler's `walk_comptime_if_union` through a
+use-after-realloc and segfaulted the server. the crash needed all three: union
+mode (multiple `[target.*]`), 2+ taken `$if` branches diverging on OS *and* arch,
+and an earlier taken branch importing enough modules to cross the compiler's
+INITIAL_MODULE_CAP (16) and realloc `p.modules` mid-walk.
+
+fixture-multitarget-realloc reproduces it: three targets (linux x86_64, windows
+x86_64, linux aarch64), a windows branch importing 24 leaf modules (the realloc)
+and a linux branch importing one more (`lx`, deref'd post-realloc). opening
+main.mach triggers the union build; pre-fix mach this segfaults the server. the
+test asserts the server survives the load and that a cross-module request reaches
+`lx`, which the union loads only via the linux branch."""
+import os
+
+from harness import LiveServer, req, notify, did_open, pos, file_uri, standalone, REPO
+
+RT = os.path.join(REPO, "test", "fixture-multitarget-realloc")
+MAIN = os.path.join(RT, "src", "main.mach")
+LX = os.path.join(RT, "src", "lx.mach")
+
+# lx.mach: `pub fun lxval()` is the 4th line (3 comment lines above it), so the
+# 0-based decl `lxval` is at line 3, col 8.
+LXVAL = pos(3, 8)
+
+
+def run():
+    """drive the realloc union scenario; return a list of failure strings."""
+    if not os.path.exists(MAIN):
+        return [f"fixture-multitarget-realloc not found at {RT}"]
+    main_uri = file_uri(MAIN)
+    lx_uri = file_uri(LX)
+    root_uri = file_uri(RT)
+    failures = []
+    srv = LiveServer()
+    try:
+        srv.send(req(1, "initialize",
+                     {"rootUri": root_uri,
+                      "workspaceFolders": [{"uri": root_uri, "name": "rtfix"}],
+                      "capabilities": {}}))
+        if srv.recv_id(1) is None:
+            return ["server did not answer initialize (crashed during startup?)"]
+        srv.send(notify("initialized"))
+
+        # opening both documents; the union build is lazy, so the realloc walk
+        # fires on the first feature request below, not on didOpen.
+        srv.send(did_open(main_uri, open(MAIN).read()))
+        srv.send(did_open(lx_uri, open(LX).read()))
+
+        # references on lx's decl drives the union load (lx is reachable only via
+        # the linux branch). pre-fix the walk segfaults here mid-request, so no
+        # response arrives; a sane array proves the union loaded lx and survived.
+        srv.send(req(20, "textDocument/references",
+                     {"textDocument": {"uri": lx_uri}, "position": LXVAL,
+                      "context": {"includeDeclaration": True}}))
+        res = srv.recv_id(20)
+        if res is None:
+            # the server died during the union load — don't send into the dead
+            # pipe; close() below surfaces the signal.
+            failures.append(
+                "no response to references(lxval) — the server died during the "
+                "multi-target union load (the #91/mach#1540 realloc crash)")
+            return failures
+        result = res.get("result")
+        if not isinstance(result, list):
+            failures.append("references(lxval) result is not an array")
+        elif not any(r.get("uri", "").endswith("lx.mach") for r in result):
+            failures.append(
+                "references(lxval) missing lx.mach's own decl — the union did "
+                f"not load the linux-branch leaf; got {sorted(r.get('uri','') for r in result)}")
+
+        # a second request the server can only answer if it is still alive after
+        # the load — the liveness assertion the bare didOpen cannot make.
+        srv.send(req(21, "textDocument/hover",
+                     {"textDocument": {"uri": lx_uri}, "position": LXVAL}))
+        if srv.recv_id(21) is None:
+            failures.append(
+                "no response to a follow-up request — the server is not alive "
+                "after the multi-target union load")
+            return failures
+
+        srv.send(req(2, "shutdown", None))
+        srv.send(notify("exit"))
+    finally:
+        code = srv.close()
+        # a clean shutdown exits 0; a signal kill (SIGSEGV) surfaces as a negative
+        # return code, so flag it even if a response slipped through.
+        if code is not None and code < 0:
+            failures.append(f"server exited on signal {-code} (SIGSEGV=11 is the #91 crash)")
+    return failures
+
+
+if __name__ == "__main__":
+    standalone("multitarget-realloc", run)


### PR DESCRIPTION
Vendors **octalide/mach#1540** — the use-after-realloc in `walk_comptime_if_union` that SIGSEGV'd the LSP loading any real multi-target project (the cause of the Zed restart loop in #91).

## Change
- `dep/mach` 8c2a034 (v2.4.0) → 5585b7f5 (mach 2.4.1 main tip, includes the #1540 fix).

## Verified
- `mach build` clean; `python3 test/run.py` all 9 suites pass.
- The mach compiler project (linux + windows + linux-arm64 → the 3-target union that crashed) now **loads crash-free** (server alive, cross-module hover served, ~44s).

## TODO before ready
- [ ] Add a multi-OS/arch (≥3-target) integration fixture whose union load crosses the `p.modules` realloc boundary, so this crash class can't regress (the coverage gap that hid #91).

Closes #91.