### PR TITLE
test: cover multi-artifact union load (#84)

### DIFF
--- a/test/fixture-multibinary/mach.toml
+++ b/test/fixture-multibinary/mach.toml
@@ -1,0 +1,24 @@
+# multi-artifact fixture for build_project_union (#84): `toolonly` is reachable
+# only through the secondary `tool` binary's entry, outside the primary `app`
+# artifact's closure. a single-artifact load (the union's resolution ctx) omits
+# it; the union over every declared artifact's closure includes it, so workspace
+# references on `core.shared` reach its use-site in toolonly.
+[project]
+id      = "mbfix"
+version = "0.0.0"
+src     = "src"
+target  = "native"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.app]
+entry = "app.mach"
+
+[lib.core]
+entry = "core.mach"
+
+[bin.tool]
+entry = "tool.mach"

--- a/test/fixture-multibinary/src/app.mach
+++ b/test/fixture-multibinary/src/app.mach
@@ -1,0 +1,8 @@
+# app: the primary binary artifact (first declared, so the union's resolution
+# ctx). reaches core.shared directly but never toolonly, so toolonly sits outside
+# the primary artifact's closure.
+use mbfix.core.shared;
+
+fun main() i64 {
+    ret shared();
+}

--- a/test/fixture-multibinary/src/core.mach
+++ b/test/fixture-multibinary/src/core.mach
@@ -1,0 +1,7 @@
+# core: the library artifact's entry; declares the symbol shared across the app
+# and tool artifacts, so references on it must reach use-sites in both closures.
+
+# shared: a value imported and used across the primary and non-primary closures.
+pub fun shared() i64 {
+    ret 42;
+}

--- a/test/fixture-multibinary/src/tool.mach
+++ b/test/fixture-multibinary/src/tool.mach
@@ -1,0 +1,8 @@
+# tool: a secondary binary artifact's entry, the sole path to toolonly. the union
+# over every declared artifact's closure must load toolonly so workspace features
+# see its use-sites.
+use mbfix.toolonly.toolmain;
+
+fun main() i64 {
+    ret toolmain();
+}

--- a/test/fixture-multibinary/src/toolonly.mach
+++ b/test/fixture-multibinary/src/toolonly.mach
@@ -1,0 +1,8 @@
+# toolonly: reachable only through the non-primary `tool` binary's entry. its use
+# of core.shared is in the union graph only when the union covers every artifact's
+# closure, not just the primary's.
+use mbfix.core.shared;
+
+pub fun toolmain() i64 {
+    ret shared();
+}

--- a/test/run.py
+++ b/test/run.py
@@ -17,6 +17,7 @@ import test_invalidation
 import test_encoding
 import test_multitarget
 import test_multitarget_realloc
+import test_multibinary
 
 SUITES = [
     ("diagnostics", test_diagnostics.run),
@@ -29,6 +30,7 @@ SUITES = [
     ("encoding", test_encoding.run),
     ("multitarget", test_multitarget.run),
     ("multitarget-realloc", test_multitarget_realloc.run),
+    ("multibinary", test_multibinary.run),
 ]
 
 

--- a/test/test_multibinary.py
+++ b/test/test_multibinary.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""multi-artifact union coverage (#84): a project declaring more than one artifact
+(here [bin.app], [lib.core], [bin.tool]) loads cleanly — no "multiple artifacts"
+load failure — and the union covers every artifact's closure, not just the
+primary's. fixture-multibinary's `toolonly` is reachable only from the secondary
+`tool` binary's entry; `app` (the primary artifact) never reaches it. with
+`build_project_union` the server still sees toolonly's use of `core.shared`, so
+references on `shared` reach a use-site a single-artifact load would omit."""
+import os
+
+from harness import LiveServer, req, notify, did_open, pos, file_uri, standalone, REPO
+
+MB = os.path.join(REPO, "test", "fixture-multibinary")
+CORE = os.path.join(MB, "src", "core.mach")
+
+# core.mach line 5 (0-based 4): `pub fun shared() i64 {` — decl `shared` at col 8.
+DECL = pos(4, 8)
+
+
+def run():
+    """drive the multi-artifact union scenario; return a list of failure strings."""
+    if not os.path.exists(CORE):
+        return [f"fixture-multibinary not found at {MB}"]
+    core_uri = file_uri(CORE)
+    failures = []
+    srv = LiveServer()
+    try:
+        srv.send(req(1, "initialize", {"capabilities": {}}))
+        srv.recv_id(1)
+        srv.send(notify("initialized"))
+        srv.send(did_open(core_uri, open(CORE).read()))
+
+        srv.send(req(20, "textDocument/references",
+                     {"textDocument": {"uri": core_uri}, "position": DECL,
+                      "context": {"includeDeclaration": True}}))
+        res = (srv.recv_id(20) or {}).get("result")
+        if not isinstance(res, list):
+            failures.append("references(shared) result is not an array — the "
+                            "multi-artifact project failed to load")
+        else:
+            uris = {r.get("uri", "") for r in res}
+            if not any(u.endswith("toolonly.mach") for u in uris):
+                failures.append(
+                    "references(shared) missing the non-primary-artifact-only "
+                    f"use-site (toolonly.mach); got {sorted(uris)} — the union "
+                    "did not cover the secondary `tool` artifact's closure")
+            if not any(u.endswith("app.mach") for u in uris):
+                failures.append(
+                    f"references(shared) missing the primary app.mach use-site; "
+                    f"got {sorted(uris)}")
+
+        srv.send(req(2, "shutdown", None))
+        srv.send(notify("exit"))
+    finally:
+        srv.close()
+    return failures
+
+
+if __name__ == "__main__":
+    standalone("multibinary", run)


### PR DESCRIPTION
Closes #84.

## What

Multi-artifact projects (a `mach.toml` with more than one `[bin.*]`/`[lib.*]`) failed to load in the LSP with `mach.toml: multiple artifacts declared; select one with --bin/--lib`, killing every feature (diagnostics, hover, go-to-def, completion).

The proper fix landed in the compiler (mach #1505): `build_project_union` now unions the import closure over the full **target × artifact** matrix — taking the first declared artifact as the resolution ctx and loading every other artifact's entry too, deduped by FQN. That shipped in **mach 2.4.1**, which the LSP already vendors (`dep/mach` @ `14ce1f3b`).

So **#84 is bump-only**: `driver.build_project_union` is called directly from `src/project.mach`'s load path with no remaining single-artifact gate. No LSP code change was needed.

## Verification

Drove the built `mls` against the real repro, the sibling `co` project (`[lib.co]` + `[bin.co]` + `[bin.tmp]`): it loads with **no** "multiple artifacts" / load-failure message, and `textDocument/definition` on `model.Model` from `src/bin/sim.mach` — a module reachable **only** from the non-primary `bin.co` entry — resolves into `src/core/model.mach`. Both #84 conditions hold on the real project.

## Test

Locked in with a self-contained fixture + suite (no code change):

- `test/fixture-multibinary/` declares `[bin.app]` (primary), `[lib.core]`, `[bin.tool]`; `toolonly` is reachable **only** from the non-primary `tool` binary's entry.
- `test/test_multibinary.py` loads it and asserts `textDocument/references` on `core.shared` reaches `toolonly.mach`'s use-site (the non-primary-artifact-only closure) and the primary `app.mach`'s — proving the union covers every artifact's closure, not just the primary's.
- Wired into `test/run.py` SUITES (alongside the existing `multitarget` / `multitarget-realloc`).

`mach build` clean (mach 2.4.1); full `python3 test/run.py` green (11/11 suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)