### PR TITLE
fix: surface out-of-closure imports with a published diagnostic (#78)

### DIFF
--- a/src/diagnostics.mach
+++ b/src/diagnostics.mach
@@ -31,6 +31,7 @@ use editor: mach.lang.editor;
 use transport: mls.transport;
 use json:      mls.json;
 use positions: mls.positions;
+use project:   mls.project;
 
 # LSP diagnostic severities (1 = Error … 4 = Hint).
 val LSP_ERROR:   i64 = 1;
@@ -41,15 +42,25 @@ val LSP_HINT:    i64 = 4;
 # MAX_DIAGNOSTICS: cap on diagnostics published per document, to bound message size.
 val MAX_DIAGNOSTICS: usize = 200;
 
-# publish: analyze `uri`'s buffer and send its current diagnostics.
+# publish: analyze `uri`'s buffer and send its current diagnostics. a document
+# governed by a project root is analyzed dep-aware (`project.diagnose_doc`) so
+# its name-resolution diagnostics — including an import of a module outside the
+# project's dep closure — are surfaced, keeping the published diagnostics
+# consistent with what go-to-definition can resolve (#78). a document under no
+# project resolves single-file (`editor.diagnostics`, parse-only), so its
+# cross-module `use`s are not flagged against an empty dep set.
 # ---
+# w:       the workspace, for routing the document to its governing root
 # es:      editor session holding the buffer
 # sources: source map whose SourceFiles resolve spans to positions
 # alloc:   allocator for the message buffers
 # uri:     document URI to report on
 # fid:     editor FileId of the document's buffer
-pub fun publish(es: *editor.EditorSession, sources: *src.SourceMap, alloc: *Allocator, uri: str, fid: src.FileId) {
-    val dr: Result[*diag.DiagList, str] = editor.diagnostics(es, fid);
+pub fun publish(w: *project.Workspace, es: *editor.EditorSession, sources: *src.SourceMap, alloc: *Allocator, uri: str, fid: src.FileId) {
+    val root: *project.Root = project.root_for(w, uri);
+    var dr: Result[*diag.DiagList, str];
+    if (root != nil) { dr = project.diagnose_doc(w, root, fid); }
+    or              { dr = editor.diagnostics(es, fid); }
     if (is_err[*diag.DiagList, str](dr)) {
         clear(alloc, uri);
         ret;

--- a/src/project.mach
+++ b/src/project.mach
@@ -89,6 +89,7 @@ use src:      mach.lang.source;
 use editor:   mach.lang.editor;
 use intern:   mach.lang.intern;
 use ast:      mach.lang.fe.ast;
+use diag:     mach.lang.diagnostic;
 use res:      mach.lang.fe.resolve;
 use comptime: mach.lang.fe.comptime;
 use driver:   mach.lang.driver;
@@ -307,7 +308,22 @@ pub fun resolve_doc(w: *Workspace, root: *Root, fid: src.FileId) Result[*res.Res
         if (is_err[*ast.Ast, str](pr)) { ret err[*res.ResolveResult, str](unwrap_err[*ast.Ast, str](pr)); }
         a = unwrap_ok[*ast.Ast, str](pr);
     }
+    ret resolve_fresh(w, root, fid, a);
+}
 
+# resolve_fresh: re-resolve buffer `a` (FileId `fid`) against `root`'s dep set
+# unconditionally — the cache-miss core shared by `resolve_doc` (after its cache
+# check) and `diagnose_doc` (which forces a fresh parse to repopulate the session
+# DiagList). drops any prior cached result for `fid`, resolves with `res.resolve`,
+# and caches the new result. the resolve's diagnostics land on the session
+# DiagList, which `diagnose_doc` then publishes.
+# ---
+# w:    the workspace
+# root: the root governing the document, or nil for a single-file document
+# fid:  FileId of the open buffer
+# a:    the buffer's current parsed Ast
+# ret:  a borrowed pointer to the cached ResolveResult, or an error
+fun resolve_fresh(w: *Workspace, root: *Root, fid: src.FileId, a: *ast.Ast) Result[*res.ResolveResult, str] {
     free_cached(w, fid);
 
     # resolve under the same comptime environment the project's own modules
@@ -345,6 +361,35 @@ pub fun resolve_doc(w: *Workspace, root: *Root, fid: src.FileId) Result[*res.Res
         ret err[*res.ResolveResult, str]("project: resolve cache allocation failed");
     }
     ret ok[*res.ResolveResult, str](slot);
+}
+
+# diagnose_doc: parse and dep-aware-resolve the buffer governed by `root`,
+# returning the session DiagList populated with both its syntactic and its
+# name-resolution diagnostics. resolving against `root.deps` — the same dep set
+# go-to-definition uses — is what makes an import of a module outside the
+# project's dep closure surface its `imported module is not in the dep set`
+# diagnostic instead of binding silently to SYMBOL_NIL, so the published
+# diagnostics and what the features can resolve no longer disagree (#78). the
+# dep-aware ResolveResult is cached as a side effect, so a feature request on the
+# same unedited buffer reuses it. the fresh parse resets the session DiagList and
+# emits this buffer's lex / parse diagnostics; the resolve appends its own.
+# `root` must be non-nil: a single-file document keeps the editor's parse-only
+# diagnostics so its cross-module `use`s are not flagged against an empty dep set.
+# ---
+# w:    the workspace
+# root: the root governing the document (non-nil)
+# fid:  FileId of the open buffer
+# ret:  a borrowed pointer to the session DiagList, or an error
+pub fun diagnose_doc(w: *Workspace, root: *Root, fid: src.FileId) Result[*diag.DiagList, str] {
+    val pr: Result[*ast.Ast, str] = editor.parse(w.es, fid);
+    if (is_err[*ast.Ast, str](pr)) { ret err[*diag.DiagList, str](unwrap_err[*ast.Ast, str](pr)); }
+    val a: *ast.Ast = unwrap_ok[*ast.Ast, str](pr);
+
+    val rr: Result[*res.ResolveResult, str] = resolve_fresh(w, root, fid, a);
+    if (is_err[*res.ResolveResult, str](rr)) {
+        ret err[*diag.DiagList, str](unwrap_err[*res.ResolveResult, str](rr));
+    }
+    ret ok[*diag.DiagList, str](?w.s.diags);
 }
 
 # own_module: the synthetic module id a buffer resolves under for `root`. offset

--- a/src/server.mach
+++ b/src/server.mach
@@ -376,7 +376,7 @@ fun publish_for(srv: *Server, uri: str, text: str, is_open: bool) {
         ret;
     }
     val doc: *documents.Document = unwrap_ok[*documents.Document, str](dr);
-    diagnostics.publish(?srv.es, project.sources(?srv.ws), srv.alloc, uri, doc.file_id);
+    diagnostics.publish(?srv.ws, ?srv.es, project.sources(?srv.ws), srv.alloc, uri, doc.file_id);
 }
 
 # reply_error: send a JSON-RPC error response for a request that carries an id;

--- a/test/fixture-outofclosure/mach.toml
+++ b/test/fixture-outofclosure/mach.toml
@@ -1,0 +1,28 @@
+# out-of-closure import fixture (#78). the only declared artifact's entry
+# (app.mach) imports just std.types.size, so the project's dep closure — the
+# union of every declared target's transitive imports, snapshotted into
+# root.deps — never loads std.types.option. opening the orphan buffer
+# outofclosure.mach (in src/ but reachable from no artifact entry) lets the
+# test assert that its `use std.types.option` import is surfaced as a published
+# diagnostic instead of resolving silently.
+#
+# depends on the repo's vendored mach-std (reached via `dep = "../../dep"`), the
+# same layout as test/fixture, so the server's own build_project_union loads it.
+[project]
+id      = "outofclosure"
+version = "0.0.0"
+src     = "src"
+dep     = "../../dep"
+target  = "native"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.outofclosure]
+entry = "app.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "v0.6.0"

--- a/test/fixture-outofclosure/src/app.mach
+++ b/test/fixture-outofclosure/src/app.mach
@@ -1,0 +1,11 @@
+# the project entry. it imports only std.types.size, so the dep closure loads
+# std.types.size but never std.types.option — the precondition the #78 test
+# relies on. no artifact reaches outofclosure.mach, so that buffer's
+# std.types.option import stays outside the snapshot.
+
+use std.types.size.usize;
+
+# main: the binary entry, referencing only the in-closure usize.
+fun main() usize {
+    ret 0;
+}

--- a/test/fixture-outofclosure/src/outofclosure.mach
+++ b/test/fixture-outofclosure/src/outofclosure.mach
@@ -1,0 +1,15 @@
+# an orphan buffer: no artifact entry reaches it, so std.types.option is never
+# loaded into the project's dep closure. every reference through `opt` is
+# out-of-closure. before #78 these resolved silently to nothing with no
+# diagnostic; now the import surfaces "imported module is not in the dep set".
+# std.types.size is in the closure, so usize binds — keeping the diagnostics
+# focused on the out-of-closure `opt`.
+
+use std.types.size.usize;
+use opt: std.types.option;
+
+# f: references the out-of-closure alias as a type, both in a parameter and the
+# return position.
+fun f(o: opt.Option[usize]) opt.Option[usize] {
+    ret o;
+}

--- a/test/run.py
+++ b/test/run.py
@@ -18,6 +18,7 @@ import test_encoding
 import test_multitarget
 import test_multitarget_realloc
 import test_multibinary
+import test_outofclosure
 
 SUITES = [
     ("diagnostics", test_diagnostics.run),
@@ -31,6 +32,7 @@ SUITES = [
     ("multitarget", test_multitarget.run),
     ("multitarget-realloc", test_multitarget_realloc.run),
     ("multibinary", test_multibinary.run),
+    ("outofclosure", test_outofclosure.run),
 ]
 
 

--- a/test/test_outofclosure.py
+++ b/test/test_outofclosure.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""out-of-closure import diagnostics (#78).
+
+a project whose entry imports only std.types.size never loads std.types.option
+into its dep closure. opening a buffer under that root which imports
+std.types.option must now PUBLISH a diagnostic ("imported module is not in the
+dep set") instead of resolving silently to nothing — keeping the published
+diagnostics consistent with go-to-definition's inability to bind the symbol. a
+control buffer importing only the in-closure std.types.size must stay clean (no
+false positives from the dep-aware diagnostics pass)."""
+import os
+
+from harness import drive, req, notify, did_open, by_id, file_uri, standalone, REPO
+
+FIXTURE = os.path.join(REPO, "test", "fixture-outofclosure")
+OOC = os.path.join(FIXTURE, "src", "outofclosure.mach")
+APP = os.path.join(FIXTURE, "src", "app.mach")
+OOC_URI = file_uri(OOC)
+APP_URI = file_uri(APP)
+
+
+def _diags_for(msgs, uri):
+    """the diagnostics array of the last publishDiagnostics for `uri`, or None."""
+    pubs = [m for m in msgs
+            if m.get("method") == "textDocument/publishDiagnostics"
+            and m["params"]["uri"] == uri]
+    if not pubs:
+        return None
+    return pubs[-1]["params"]["diagnostics"]
+
+
+def run():
+    """drive the out-of-closure diagnostics scenario; return failure strings."""
+    if not os.path.exists(OOC) or not os.path.exists(APP):
+        return [f"fixture not found under {FIXTURE}"]
+
+    ooc_text = open(OOC).read()
+    app_text = open(APP).read()
+    frames = [
+        req(1, "initialize", {"capabilities": {}}),
+        notify("initialized"),
+        did_open(OOC_URI, ooc_text),
+        did_open(APP_URI, app_text),
+        req(2, "shutdown", None),
+        notify("exit"),
+    ]
+    code, msgs = drive(frames)
+
+    failures = []
+
+    init = by_id(msgs, 1)
+    if not init or "result" not in init or "capabilities" not in init["result"]:
+        failures.append("missing/invalid initialize result")
+
+    # the out-of-closure import must surface a diagnostic, not resolve silently.
+    ooc = _diags_for(msgs, OOC_URI)
+    if ooc is None:
+        failures.append("no publishDiagnostics for the out-of-closure buffer")
+    elif not ooc:
+        failures.append("out-of-closure import produced 0 diagnostics (the #78 silence)")
+    else:
+        msgs_text = " ".join(d.get("message", "") for d in ooc)
+        if "dep set" not in msgs_text:
+            failures.append(
+                f"out-of-closure diagnostics do not name the missing dep set: {msgs_text!r}")
+        d0 = ooc[0]
+        if "range" not in d0 or "start" not in d0["range"] or "end" not in d0["range"]:
+            failures.append("out-of-closure diagnostic missing range")
+        if "severity" not in d0:
+            failures.append("out-of-closure diagnostic missing severity")
+
+    # the in-closure control must stay clean: no false positives.
+    app = _diags_for(msgs, APP_URI)
+    if app is None:
+        failures.append("no publishDiagnostics for the in-closure control buffer")
+    elif app:
+        failures.append(f"in-closure control buffer produced diagnostics: {app!r}")
+
+    sh = by_id(msgs, 2)
+    if not sh or "result" not in sh:
+        failures.append("missing shutdown result")
+    if code != 0:
+        failures.append("non-zero exit code after clean shutdown")
+
+    return failures
+
+
+if __name__ == "__main__":
+    standalone("outofclosure", run)


### PR DESCRIPTION
Closes #78

## Problem

When an open buffer imports a module that is **not in the project's dep closure** (the union of every declared target's transitive imports, snapshotted into `root.deps`), every reference through that import resolved silently to `SYMBOL_NIL` — go-to-definition / hover returned null — **and no diagnostic was published**. It affected all import kinds (function, type, value, alias ident).

## Root cause

The two analysis passes used different dep sets:

- **Features** (`textDocument/definition`, hover, …) go through `project.resolve_doc` → `res.resolve` against `root.deps`. This *does* emit `imported module is not in the dep set` for an out-of-closure import.
- **Published diagnostics** went through `editor.diagnostics`, which runs only tokenize + parse (`editor.mach`) — **purely syntactic, no name resolution at all**. So name-resolution diagnostics (out-of-closure imports, unresolved identifiers, …) were never surfaced.

The two passes disagreed and only the silent one (features) was observable.

## Fix

Route the publish path through the **same dep-aware resolve the features use**. `diagnostics.publish` now calls a new `project.diagnose_doc` for any document governed by a project root: it forces a fresh parse (resetting the session `DiagList` and emitting the buffer's lex/parse diagnostics) and then resolves against `root.deps`, appending name-resolution diagnostics — including the out-of-closure import error. The dep-aware `ResolveResult` is cached as a side effect, so a following feature request on the same unedited buffer reuses it (one resolve, not two).

Documents under no project keep parse-only `editor.diagnostics`, so a rootless scratch file's cross-module `use`s are not falsely flagged against an empty dep set.

`resolve_doc`'s cache-miss core is factored out into a shared `resolve_fresh` so `resolve_doc` and `diagnose_doc` resolve and cache identically.

### Why this is the structural fix, not a patch

The project closure is *defined* by the manifest's declared targets; a buffer importing outside it references a module that is genuinely not part of the project, so an error is the correct outcome. Surfacing the resolver's existing diagnostic makes go-to-definition's (correct) silence consistent with a visible explanation, rather than widening the closure to swallow arbitrary buffer imports — which would contradict the snapshot architecture.

## Test

Adds `test/fixture-outofclosure` (entrypoint imports only `std.types.size`, so its closure excludes `std.types.option`) plus a buffer that imports `std.types.option`, and `test/test_outofclosure.py` asserting:
- the out-of-closure import **publishes** an `imported module is not in the dep set` diagnostic, and
- a control buffer importing only the in-closure `std.types.size` publishes **no** diagnostics (no false positives).

Wired into `test/run.py` SUITES. Full `python3 test/run.py` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)