### PR TITLE
fix(diagnostics): decouple project load from the publish hot path

### DIFF
--- a/src/diagnostics.mach
+++ b/src/diagnostics.mach
@@ -43,12 +43,17 @@ val LSP_HINT:    i64 = 4;
 val MAX_DIAGNOSTICS: usize = 200;
 
 # publish: analyze `uri`'s buffer and send its current diagnostics. a document
-# governed by a project root is analyzed dep-aware (`project.diagnose_doc`) so
-# its name-resolution diagnostics — including an import of a module outside the
-# project's dep closure — are surfaced, keeping the published diagnostics
-# consistent with what go-to-definition can resolve (#78). a document under no
-# project resolves single-file (`editor.diagnostics`, parse-only), so its
-# cross-module `use`s are not flagged against an empty dep set.
+# governed by an already-loaded project root is analyzed dep-aware
+# (`project.diagnose_doc`) so its name-resolution diagnostics — including an
+# import of a module outside the project's dep closure — are surfaced, keeping
+# the published diagnostics consistent with what go-to-definition can resolve
+# (#78). a document under no loaded project resolves single-file
+# (`editor.diagnostics`, parse-only), so its cross-module `use`s are not flagged
+# against an empty dep set. the governing-root lookup is load-free
+# (`root_for_loaded`): publishing must never trigger a project build, so opening
+# or editing a buffer stays instant — the project loads lazily on the first
+# feature request, after which the server re-publishes the now-loaded buffers
+# (#96).
 # ---
 # w:       the workspace, for routing the document to its governing root
 # es:      editor session holding the buffer
@@ -57,7 +62,7 @@ val MAX_DIAGNOSTICS: usize = 200;
 # uri:     document URI to report on
 # fid:     editor FileId of the document's buffer
 pub fun publish(w: *project.Workspace, es: *editor.EditorSession, sources: *src.SourceMap, alloc: *Allocator, uri: str, fid: src.FileId) {
-    val root: *project.Root = project.root_for(w, uri);
+    val root: *project.Root = project.root_for_loaded(w, uri);
     var dr: Result[*diag.DiagList, str];
     if (root != nil) { dr = project.diagnose_doc(w, root, fid); }
     or              { dr = editor.diagnostics(es, fid); }

--- a/src/documents.mach
+++ b/src/documents.mach
@@ -148,6 +148,28 @@ pub fun close(st: *Store, uri: str) {
     d.in_use = false;
 }
 
+# slot_count: the number of Document slots in the store. paired with `at` to
+# walk every live document — the re-publish-after-load sweep iterates
+# [0, slot_count) and skips slots whose `in_use` is false.
+# ---
+# st:  the store
+# ret: the slot-array length
+pub fun slot_count(st: *Store) usize {
+    ret st.len;
+}
+
+# at: the Document in slot `idx`, or nil when out of range. the slot may be
+# retired (`in_use` false) — callers check that. for the open-document sweep
+# that re-publishes diagnostics once a project finishes loading.
+# ---
+# st:  the store
+# idx: slot index in [0, slot_count)
+# ret: the slot's Document, or nil
+pub fun at(st: *Store, idx: usize) *Document {
+    if (st.docs == nil || idx >= st.len) { ret nil; }
+    ret ?st.docs[idx];
+}
+
 # find: the tracked Document for `uri`, or nil when not open.
 # ---
 # st:  the store

--- a/src/project.mach
+++ b/src/project.mach
@@ -195,6 +195,9 @@ pub rec Root {
 # cache_len:    number of slots in `cache`
 # gen_seq:      next generation stamp to hand out; each successful root build
 #               claims one, pinning a cache entry's gen to an exact build
+# load_epoch:   monotonic counter bumped on every successful root build, so the
+#               server can tell a feature request triggered a lazy load and
+#               re-publish diagnostics for the now-loaded buffers (#96)
 pub rec Workspace {
     s:            *sess.Session;
     es:           *editor.EditorSession;
@@ -206,6 +209,7 @@ pub rec Workspace {
     cache:        *Cached;
     cache_len:    u32;
     gen_seq:      u32;
+    load_epoch:   u32;
 }
 
 # init: construct an empty workspace over the server's sessions.
@@ -227,6 +231,7 @@ pub fun init(s: *sess.Session, es: *editor.EditorSession, alloc: *Allocator) Wor
     w.cache         = nil;
     w.cache_len     = 0;
     w.gen_seq       = 1;
+    w.load_epoch    = 0;
     ret w;
 }
 
@@ -264,6 +269,18 @@ pub fun sources(w: *Workspace) *src.SourceMap {
 # on: whether file watching is active
 pub fun set_watch_active(w: *Workspace, on: bool) {
     w.watch_active = on;
+}
+
+# load_epoch: the workspace's current load epoch — a counter bumped on every
+# successful root build. the server snapshots it around a feature request; a
+# change means a lazy project load completed, so the open buffers it now governs
+# can have their diagnostics re-published with semantic (dep-aware) results
+# without waiting for an edit (#96).
+# ---
+# w:   the workspace
+# ret: the current load epoch
+pub fun load_epoch(w: *Workspace) u32 {
+    ret w.load_epoch;
 }
 
 # dnit: release the resolve cache and every loaded root.
@@ -457,6 +474,36 @@ pub fun root_for(w: *Workspace, uri: str) *Root {
     ret load_root(w, doc_root);
 }
 
+# root_for_loaded: the root governing the document at `uri` ONLY when it is
+# already loaded — never triggering a build. unlike `root_for`, this neither
+# loads a fresh root nor speculatively loads a vendoring ancestor nor reloads a
+# stale one; it returns nil when no loaded root holds the document. the
+# diagnostics publish path uses this so opening or editing a buffer publishes
+# instantly (parse-only) instead of blocking on a ~tens-of-seconds project build
+# (#96); the project still loads lazily on the first feature request, where
+# `root_for` runs. a document already governed by a loaded root resolves
+# dep-aware as before (#78). matches `root_for`'s routing: a loaded twin rooted
+# elsewhere wins, else the document's own root when it is loaded.
+# ---
+# w:   the workspace
+# uri: the document's URI
+# ret: a borrowed pointer to the governing loaded Root, or nil
+pub fun root_for_loaded(w: *Workspace, uri: str) *Root {
+    if (uri == nil) { ret nil; }
+
+    # a loaded root rooted elsewhere holding the document governs it read-only,
+    # exactly as in root_for — checked without reloading.
+    val twin: *Root = containing_root_loaded(w, uri);
+    if (twin != nil) { ret twin; }
+
+    val doc_root: str = document_root(w, uri);
+    if (doc_root == nil) { ret nil; }
+    val existing: *Root = find_root(w, doc_root);
+    strutil.str_free(w.alloc, doc_root);
+    if (existing != nil && existing.loaded) { ret existing; }
+    ret nil;
+}
+
 # ancestor_root: load-and-prefer the outermost project that vendors the document
 # at `uri` (whose own fresh root is `doc_root`) and whose loaded graph holds it.
 # walks the chain of ancestor manifest dirs strictly above `dir` (`doc_root` on
@@ -602,6 +649,32 @@ fun containing_root(w: *Workspace, uri: str, doc_root: str) *Root {
     ret found;
 }
 
+# containing_root_loaded: the load-free counterpart of `containing_root` for the
+# diagnostics publish path — the outermost already-loaded root whose graph holds
+# the document at `uri`, without the per-candidate `maybe_reload` (which would
+# rebuild a stale root). selection is identical otherwise: the shortest holding
+# root path wins, so a vendored module routes to the project that vendors it. nil
+# when no loaded root holds the document. staleness is reconciled on the feature
+# path's `root_for`, never on publish.
+fun containing_root_loaded(w: *Workspace, uri: str) *Root {
+    if (w.roots == nil) { ret nil; }
+    val norm: str = uri_to_norm(w.alloc, uri);
+    if (norm == nil) { ret nil; }
+    var found: *Root = nil;
+    var i: u32 = 0;
+    for (i < w.root_cap) {
+        val r: *Root = ?w.roots[i];
+        if (r.path != nil && r.loaded
+            && is_some[sess.ModuleId](module_for_norm(r, norm))
+            && (found == nil || str_len(r.path) < str_len(found.path))) {
+            found = r;
+        }
+        i = i + 1;
+    }
+    strutil.str_free(w.alloc, norm);
+    ret found;
+}
+
 # load_root: claim a slot for `root_path` (taking ownership of the string) and
 # build its graph. the vendored flag is stamped once here — intrinsic to the
 # path, so every root-creating path (root_for's fresh-root load, ancestor_root's
@@ -724,6 +797,7 @@ fun try_load(w: *Workspace, r: *Root) bool {
     r.loaded   = true;
     r.own_base = r.p.module_len;
     r.gen      = next_gen(w);
+    w.load_epoch = w.load_epoch + 1;
     build_mod_paths(w, r);
     build_deps(w, r);
     ret true;

--- a/src/server.mach
+++ b/src/server.mach
@@ -351,6 +351,11 @@ fun handle_did_close(srv: *Server, body: str) {
 fun handle_feature(srv: *Server, body: str, which: i64) {
     val uri: str = json.extract_after(body, "\"textDocument\"", "\"uri\"", srv.alloc);
 
+    # a feature request resolves dep-aware via project.root_for, which loads the
+    # governing project lazily on first use. snapshot the load epoch so a load
+    # triggered here re-publishes the now-loaded buffers' diagnostics (#96).
+    val epoch_before: u32 = project.load_epoch(?srv.ws);
+
     if (which == 0) { language.hover(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, body, uri); }
     or (which == 1) { language.definition(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, body, uri); }
     or (which == 2) { language.references(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, body, uri); }
@@ -360,6 +365,27 @@ fun handle_feature(srv: *Server, body: str, which: i64) {
     or (which == 6) { language.completion(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, body, uri); }
 
     if (uri != nil) { json.free_str(uri, srv.alloc); }
+
+    if (project.load_epoch(?srv.ws) != epoch_before) { republish_loaded(srv); }
+}
+
+# republish_loaded: re-publish diagnostics for every open document now governed
+# by a loaded project root. run after a feature request triggers a lazy load
+# (#96): the buffers under the freshly-loaded root were published parse-only on
+# open, so this upgrades them to dep-aware semantic diagnostics — including any
+# out-of-closure import the load now flags — without the user touching the file.
+# the publish path is load-free, so a buffer under no loaded root simply
+# re-publishes its parse-only diagnostics (unchanged), and nothing new is built.
+fun republish_loaded(srv: *Server) {
+    val n: usize = documents.slot_count(?srv.docs);
+    var i: usize = 0;
+    for (i < n) {
+        val d: *documents.Document = documents.at(?srv.docs, i);
+        if (d != nil && d.in_use && d.uri != nil) {
+            diagnostics.publish(?srv.ws, ?srv.es, project.sources(?srv.ws), srv.alloc, d.uri, d.file_id);
+        }
+        i = i + 1;
+    }
 }
 
 # publish_for: register/update `uri`'s buffer and publish its diagnostics.

--- a/test/run.py
+++ b/test/run.py
@@ -19,6 +19,7 @@ import test_multitarget
 import test_multitarget_realloc
 import test_multibinary
 import test_outofclosure
+import test_hotpath
 
 SUITES = [
     ("diagnostics", test_diagnostics.run),
@@ -33,6 +34,7 @@ SUITES = [
     ("multitarget-realloc", test_multitarget_realloc.run),
     ("multibinary", test_multibinary.run),
     ("outofclosure", test_outofclosure.run),
+    ("hotpath", test_hotpath.run),
 ]
 
 

--- a/test/test_hotpath.py
+++ b/test/test_hotpath.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""diagnostics publish never triggers a project load (#96).
+
+#78 routed publish through project.root_for, which loads the project on first
+use — putting the full ~tens-of-seconds build on the didOpen/didChange hot path
+and freezing the single-threaded server. the fix decouples them: publish uses a
+load-free lookup, so an open buffer publishes parse-only until a feature request
+loads the project, after which the server re-publishes dep-aware.
+
+this asserts the decoupling by behavior, not timing: the out-of-closure import
+diagnostic (a dep-aware, name-resolution result that only exists once the
+project's dep closure is known) must be ABSENT from the buffer's publish on
+didOpen — proving publish did not load the project — and must APPEAR only after
+a definition request triggers the load and the re-publish."""
+import os
+
+from harness import drive, req, notify, did_open, pos, by_id, file_uri, standalone, REPO
+
+FIXTURE = os.path.join(REPO, "test", "fixture-outofclosure")
+OOC = os.path.join(FIXTURE, "src", "outofclosure.mach")
+APP = os.path.join(FIXTURE, "src", "app.mach")
+OOC_URI = file_uri(OOC)
+APP_URI = file_uri(APP)
+
+
+def _pubs_for(msgs, uri):
+    """every publishDiagnostics diagnostics-array for `uri`, in order."""
+    return [m["params"]["diagnostics"] for m in msgs
+            if m.get("method") == "textDocument/publishDiagnostics"
+            and m["params"]["uri"] == uri]
+
+
+def _has_depset(diags):
+    """whether any diagnostic names the missing dep set (the dep-aware signal)."""
+    return any("dep set" in d.get("message", "") for d in diags)
+
+
+def run():
+    """drive open-then-load and assert publish stays off the load path."""
+    if not os.path.exists(OOC) or not os.path.exists(APP):
+        return [f"fixture not found under {FIXTURE}"]
+
+    ooc_text = open(OOC).read()
+    app_text = open(APP).read()
+
+    # open both buffers, then issue a definition that triggers the lazy load.
+    # the definition's id (2) lets us split publishes into pre-load (on open)
+    # and post-load (re-published by the server after the load).
+    frames = [
+        req(1, "initialize", {"capabilities": {}}),
+        notify("initialized"),
+        did_open(OOC_URI, ooc_text),
+        did_open(APP_URI, app_text),
+        req(2, "textDocument/definition",
+            {"textDocument": {"uri": APP_URI}, "position": pos(8, 11)}),
+        req(3, "shutdown", None),
+        notify("exit"),
+    ]
+    code, msgs = drive(frames)
+
+    failures = []
+
+    # the out-of-closure buffer must publish on open (the editor sees diagnostics
+    # immediately) and that first publish must be parse-only — no dep-set
+    # diagnostic, proving publish did not load the project's dep closure.
+    ooc_pubs = _pubs_for(msgs, OOC_URI)
+    if not ooc_pubs:
+        failures.append("no publishDiagnostics for the out-of-closure buffer on open")
+    else:
+        if _has_depset(ooc_pubs[0]):
+            failures.append(
+                "first publish carried a dep-aware diagnostic — publish loaded the "
+                "project on the hot path (the #96 regression)")
+        # after the definition loads the project, the server must re-publish the
+        # buffer with the dep-aware out-of-closure diagnostic.
+        if not _has_depset(ooc_pubs[-1]):
+            failures.append(
+                "out-of-closure diagnostic never appeared after the load — "
+                "re-publish-after-load did not fire")
+
+    # the definition request must still be answered (the load happened on the
+    # feature path, as before #78), so the server stayed responsive.
+    if by_id(msgs, 2) is None:
+        failures.append("no response to the definition request")
+
+    sh = by_id(msgs, 3)
+    if not sh or "result" not in sh:
+        failures.append("missing shutdown result")
+    if code != 0:
+        failures.append("non-zero exit code after clean shutdown")
+
+    return failures
+
+
+if __name__ == "__main__":
+    standalone("hotpath", run)

--- a/test/test_outofclosure.py
+++ b/test/test_outofclosure.py
@@ -1,16 +1,22 @@
 #!/usr/bin/env python3
-"""out-of-closure import diagnostics (#78).
+"""out-of-closure import diagnostics (#78), re-published after a lazy load (#96).
 
 a project whose entry imports only std.types.size never loads std.types.option
 into its dep closure. opening a buffer under that root which imports
-std.types.option must now PUBLISH a diagnostic ("imported module is not in the
-dep set") instead of resolving silently to nothing — keeping the published
+std.types.option must PUBLISH a diagnostic ("imported module is not in the dep
+set") instead of resolving silently to nothing — keeping the published
 diagnostics consistent with go-to-definition's inability to bind the symbol. a
 control buffer importing only the in-closure std.types.size must stay clean (no
-false positives from the dep-aware diagnostics pass)."""
+false positives from the dep-aware diagnostics pass).
+
+since #96 the project no longer loads on didOpen (that put the full build on the
+hot path and froze the server); the open buffers publish parse-only until a
+feature request loads the project, after which the server re-publishes their
+diagnostics dep-aware. so this drives a `definition` (which triggers the load)
+between the opens and shutdown, then asserts the re-published diagnostic."""
 import os
 
-from harness import drive, req, notify, did_open, by_id, file_uri, standalone, REPO
+from harness import drive, req, notify, did_open, pos, by_id, file_uri, standalone, REPO
 
 FIXTURE = os.path.join(REPO, "test", "fixture-outofclosure")
 OOC = os.path.join(FIXTURE, "src", "outofclosure.mach")
@@ -36,12 +42,18 @@ def run():
 
     ooc_text = open(OOC).read()
     app_text = open(APP).read()
+    # a definition request on the entry buffer's `usize` triggers the lazy
+    # project load (#96 moved the load off the didOpen hot path); the server
+    # then re-publishes the open buffers' diagnostics dep-aware, surfacing the
+    # out-of-closure import without an edit.
     frames = [
         req(1, "initialize", {"capabilities": {}}),
         notify("initialized"),
         did_open(OOC_URI, ooc_text),
         did_open(APP_URI, app_text),
-        req(2, "shutdown", None),
+        req(2, "textDocument/definition",
+            {"textDocument": {"uri": APP_URI}, "position": pos(8, 11)}),
+        req(3, "shutdown", None),
         notify("exit"),
     ]
     code, msgs = drive(frames)
@@ -76,7 +88,7 @@ def run():
     elif app:
         failures.append(f"in-closure control buffer produced diagnostics: {app!r}")
 
-    sh = by_id(msgs, 2)
+    sh = by_id(msgs, 3)
     if not sh or "result" not in sh:
         failures.append("missing shutdown result")
     if code != 0:


### PR DESCRIPTION
Closes #96

## Problem
#78 (PR #94) routed `diagnostics.publish` through `project.root_for`, which **loads the project on first use** (`build_project_union`, ~tens of seconds on the compiler). That moved the full project build onto the **didOpen/didChange hot path**: opening a large project (editors auto-open several files) froze the single-threaded server for tens of seconds, so the client declared it dead and restart-looped it.

## Fix — decouple load from the diagnostics path
- **`project.root_for_loaded`** — a load-free governing-root lookup. Returns the root **only when already loaded**; never triggers a build (no fresh load, no speculative ancestor load, no `maybe_reload`). Mirrors `root_for`'s routing (loaded twin wins, else the document's own loaded root).
- **`diagnostics.publish`** uses it: a loaded root governs the uri → `diagnose_doc` (dep-aware, the #78 win, warm resolve ~0.02s); else → `editor.diagnostics` (parse-only, instant, exactly as before #78). **Publish never loads.**
- Feature requests (hover/def/… via `root_for`) keep loading lazily as before — unchanged.
- **Re-publish after a lazy load** — `Workspace.load_epoch` bumps on each successful build; `handle_feature` snapshots it around the request and, when it changed, re-publishes diagnostics for every open buffer (load-free). Semantic diagnostics (incl. out-of-closure imports) appear once the project loads, without an edit.

## Verification
- `mach build` clean.
- Full `python3 test/run.py` green, including `outofclosure` (#78) — now via re-publish-after-load.
- New regression test: didOpen on a project fixture publishes **without** triggering a build (asserted by behavior); the semantic diagnostic appears only after a feature request loads the project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)