### PR TITLE
release: v0.6.0

### DIFF
--- a/mach.lock
+++ b/mach.lock
@@ -8,4 +8,4 @@ commit = "2e95444191a98e8dd6419faeaff1a6fc23515d3a"
 [deps.mach]
 url = "https://github.com/octalide/mach"
 ref = "branch/main"
-commit = "8c2a034a88099dea0bbbdbc64e2b329112d1cfa4"
+commit = "5585b7f52ae4d35cbe493bb4ed60995981603fa0"

--- a/mach.lock
+++ b/mach.lock
@@ -8,4 +8,4 @@ commit = "2e95444191a98e8dd6419faeaff1a6fc23515d3a"
 [deps.mach]
 url = "https://github.com/octalide/mach"
 ref = "branch/main"
-commit = "5585b7f52ae4d35cbe493bb4ed60995981603fa0"
+commit = "14ce1f3b966d7ac9012e6c3ccb8153be13d7726b"

--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,7 @@
 [project]
 id      = "mls"
 name    = "Mach Language Server"
-version = "0.5.2"
+version = "0.6.0"
 src     = "src"
 dep     = "dep"
 target  = "native"

--- a/src/diagnostics.mach
+++ b/src/diagnostics.mach
@@ -43,12 +43,17 @@ val LSP_HINT:    i64 = 4;
 val MAX_DIAGNOSTICS: usize = 200;
 
 # publish: analyze `uri`'s buffer and send its current diagnostics. a document
-# governed by a project root is analyzed dep-aware (`project.diagnose_doc`) so
-# its name-resolution diagnostics — including an import of a module outside the
-# project's dep closure — are surfaced, keeping the published diagnostics
-# consistent with what go-to-definition can resolve (#78). a document under no
-# project resolves single-file (`editor.diagnostics`, parse-only), so its
-# cross-module `use`s are not flagged against an empty dep set.
+# governed by an already-loaded project root is analyzed dep-aware
+# (`project.diagnose_doc`) so its name-resolution diagnostics — including an
+# import of a module outside the project's dep closure — are surfaced, keeping
+# the published diagnostics consistent with what go-to-definition can resolve
+# (#78). a document under no loaded project resolves single-file
+# (`editor.diagnostics`, parse-only), so its cross-module `use`s are not flagged
+# against an empty dep set. the governing-root lookup is load-free
+# (`root_for_loaded`): publishing must never trigger a project build, so opening
+# or editing a buffer stays instant — the project loads lazily on the first
+# feature request, after which the server re-publishes the now-loaded buffers
+# (#96).
 # ---
 # w:       the workspace, for routing the document to its governing root
 # es:      editor session holding the buffer
@@ -57,7 +62,7 @@ val MAX_DIAGNOSTICS: usize = 200;
 # uri:     document URI to report on
 # fid:     editor FileId of the document's buffer
 pub fun publish(w: *project.Workspace, es: *editor.EditorSession, sources: *src.SourceMap, alloc: *Allocator, uri: str, fid: src.FileId) {
-    val root: *project.Root = project.root_for(w, uri);
+    val root: *project.Root = project.root_for_loaded(w, uri);
     var dr: Result[*diag.DiagList, str];
     if (root != nil) { dr = project.diagnose_doc(w, root, fid); }
     or              { dr = editor.diagnostics(es, fid); }

--- a/src/diagnostics.mach
+++ b/src/diagnostics.mach
@@ -31,6 +31,7 @@ use editor: mach.lang.editor;
 use transport: mls.transport;
 use json:      mls.json;
 use positions: mls.positions;
+use project:   mls.project;
 
 # LSP diagnostic severities (1 = Error … 4 = Hint).
 val LSP_ERROR:   i64 = 1;
@@ -41,15 +42,25 @@ val LSP_HINT:    i64 = 4;
 # MAX_DIAGNOSTICS: cap on diagnostics published per document, to bound message size.
 val MAX_DIAGNOSTICS: usize = 200;
 
-# publish: analyze `uri`'s buffer and send its current diagnostics.
+# publish: analyze `uri`'s buffer and send its current diagnostics. a document
+# governed by a project root is analyzed dep-aware (`project.diagnose_doc`) so
+# its name-resolution diagnostics — including an import of a module outside the
+# project's dep closure — are surfaced, keeping the published diagnostics
+# consistent with what go-to-definition can resolve (#78). a document under no
+# project resolves single-file (`editor.diagnostics`, parse-only), so its
+# cross-module `use`s are not flagged against an empty dep set.
 # ---
+# w:       the workspace, for routing the document to its governing root
 # es:      editor session holding the buffer
 # sources: source map whose SourceFiles resolve spans to positions
 # alloc:   allocator for the message buffers
 # uri:     document URI to report on
 # fid:     editor FileId of the document's buffer
-pub fun publish(es: *editor.EditorSession, sources: *src.SourceMap, alloc: *Allocator, uri: str, fid: src.FileId) {
-    val dr: Result[*diag.DiagList, str] = editor.diagnostics(es, fid);
+pub fun publish(w: *project.Workspace, es: *editor.EditorSession, sources: *src.SourceMap, alloc: *Allocator, uri: str, fid: src.FileId) {
+    val root: *project.Root = project.root_for(w, uri);
+    var dr: Result[*diag.DiagList, str];
+    if (root != nil) { dr = project.diagnose_doc(w, root, fid); }
+    or              { dr = editor.diagnostics(es, fid); }
     if (is_err[*diag.DiagList, str](dr)) {
         clear(alloc, uri);
         ret;

--- a/src/documents.mach
+++ b/src/documents.mach
@@ -148,6 +148,28 @@ pub fun close(st: *Store, uri: str) {
     d.in_use = false;
 }
 
+# slot_count: the number of Document slots in the store. paired with `at` to
+# walk every live document — the re-publish-after-load sweep iterates
+# [0, slot_count) and skips slots whose `in_use` is false.
+# ---
+# st:  the store
+# ret: the slot-array length
+pub fun slot_count(st: *Store) usize {
+    ret st.len;
+}
+
+# at: the Document in slot `idx`, or nil when out of range. the slot may be
+# retired (`in_use` false) — callers check that. for the open-document sweep
+# that re-publishes diagnostics once a project finishes loading.
+# ---
+# st:  the store
+# idx: slot index in [0, slot_count)
+# ret: the slot's Document, or nil
+pub fun at(st: *Store, idx: usize) *Document {
+    if (st.docs == nil || idx >= st.len) { ret nil; }
+    ret ?st.docs[idx];
+}
+
 # find: the tracked Document for `uri`, or nil when not open.
 # ---
 # st:  the store

--- a/src/project.mach
+++ b/src/project.mach
@@ -195,6 +195,9 @@ pub rec Root {
 # cache_len:    number of slots in `cache`
 # gen_seq:      next generation stamp to hand out; each successful root build
 #               claims one, pinning a cache entry's gen to an exact build
+# load_epoch:   monotonic counter bumped on every successful root build, so the
+#               server can tell a feature request triggered a lazy load and
+#               re-publish diagnostics for the now-loaded buffers (#96)
 pub rec Workspace {
     s:            *sess.Session;
     es:           *editor.EditorSession;
@@ -206,6 +209,7 @@ pub rec Workspace {
     cache:        *Cached;
     cache_len:    u32;
     gen_seq:      u32;
+    load_epoch:   u32;
 }
 
 # init: construct an empty workspace over the server's sessions.
@@ -227,6 +231,7 @@ pub fun init(s: *sess.Session, es: *editor.EditorSession, alloc: *Allocator) Wor
     w.cache         = nil;
     w.cache_len     = 0;
     w.gen_seq       = 1;
+    w.load_epoch    = 0;
     ret w;
 }
 
@@ -264,6 +269,18 @@ pub fun sources(w: *Workspace) *src.SourceMap {
 # on: whether file watching is active
 pub fun set_watch_active(w: *Workspace, on: bool) {
     w.watch_active = on;
+}
+
+# load_epoch: the workspace's current load epoch — a counter bumped on every
+# successful root build. the server snapshots it around a feature request; a
+# change means a lazy project load completed, so the open buffers it now governs
+# can have their diagnostics re-published with semantic (dep-aware) results
+# without waiting for an edit (#96).
+# ---
+# w:   the workspace
+# ret: the current load epoch
+pub fun load_epoch(w: *Workspace) u32 {
+    ret w.load_epoch;
 }
 
 # dnit: release the resolve cache and every loaded root.
@@ -457,6 +474,36 @@ pub fun root_for(w: *Workspace, uri: str) *Root {
     ret load_root(w, doc_root);
 }
 
+# root_for_loaded: the root governing the document at `uri` ONLY when it is
+# already loaded — never triggering a build. unlike `root_for`, this neither
+# loads a fresh root nor speculatively loads a vendoring ancestor nor reloads a
+# stale one; it returns nil when no loaded root holds the document. the
+# diagnostics publish path uses this so opening or editing a buffer publishes
+# instantly (parse-only) instead of blocking on a ~tens-of-seconds project build
+# (#96); the project still loads lazily on the first feature request, where
+# `root_for` runs. a document already governed by a loaded root resolves
+# dep-aware as before (#78). matches `root_for`'s routing: a loaded twin rooted
+# elsewhere wins, else the document's own root when it is loaded.
+# ---
+# w:   the workspace
+# uri: the document's URI
+# ret: a borrowed pointer to the governing loaded Root, or nil
+pub fun root_for_loaded(w: *Workspace, uri: str) *Root {
+    if (uri == nil) { ret nil; }
+
+    # a loaded root rooted elsewhere holding the document governs it read-only,
+    # exactly as in root_for — checked without reloading.
+    val twin: *Root = containing_root_loaded(w, uri);
+    if (twin != nil) { ret twin; }
+
+    val doc_root: str = document_root(w, uri);
+    if (doc_root == nil) { ret nil; }
+    val existing: *Root = find_root(w, doc_root);
+    strutil.str_free(w.alloc, doc_root);
+    if (existing != nil && existing.loaded) { ret existing; }
+    ret nil;
+}
+
 # ancestor_root: load-and-prefer the outermost project that vendors the document
 # at `uri` (whose own fresh root is `doc_root`) and whose loaded graph holds it.
 # walks the chain of ancestor manifest dirs strictly above `dir` (`doc_root` on
@@ -602,6 +649,32 @@ fun containing_root(w: *Workspace, uri: str, doc_root: str) *Root {
     ret found;
 }
 
+# containing_root_loaded: the load-free counterpart of `containing_root` for the
+# diagnostics publish path — the outermost already-loaded root whose graph holds
+# the document at `uri`, without the per-candidate `maybe_reload` (which would
+# rebuild a stale root). selection is identical otherwise: the shortest holding
+# root path wins, so a vendored module routes to the project that vendors it. nil
+# when no loaded root holds the document. staleness is reconciled on the feature
+# path's `root_for`, never on publish.
+fun containing_root_loaded(w: *Workspace, uri: str) *Root {
+    if (w.roots == nil) { ret nil; }
+    val norm: str = uri_to_norm(w.alloc, uri);
+    if (norm == nil) { ret nil; }
+    var found: *Root = nil;
+    var i: u32 = 0;
+    for (i < w.root_cap) {
+        val r: *Root = ?w.roots[i];
+        if (r.path != nil && r.loaded
+            && is_some[sess.ModuleId](module_for_norm(r, norm))
+            && (found == nil || str_len(r.path) < str_len(found.path))) {
+            found = r;
+        }
+        i = i + 1;
+    }
+    strutil.str_free(w.alloc, norm);
+    ret found;
+}
+
 # load_root: claim a slot for `root_path` (taking ownership of the string) and
 # build its graph. the vendored flag is stamped once here — intrinsic to the
 # path, so every root-creating path (root_for's fresh-root load, ancestor_root's
@@ -724,6 +797,7 @@ fun try_load(w: *Workspace, r: *Root) bool {
     r.loaded   = true;
     r.own_base = r.p.module_len;
     r.gen      = next_gen(w);
+    w.load_epoch = w.load_epoch + 1;
     build_mod_paths(w, r);
     build_deps(w, r);
     ret true;

--- a/src/project.mach
+++ b/src/project.mach
@@ -89,6 +89,7 @@ use src:      mach.lang.source;
 use editor:   mach.lang.editor;
 use intern:   mach.lang.intern;
 use ast:      mach.lang.fe.ast;
+use diag:     mach.lang.diagnostic;
 use res:      mach.lang.fe.resolve;
 use comptime: mach.lang.fe.comptime;
 use driver:   mach.lang.driver;
@@ -307,7 +308,22 @@ pub fun resolve_doc(w: *Workspace, root: *Root, fid: src.FileId) Result[*res.Res
         if (is_err[*ast.Ast, str](pr)) { ret err[*res.ResolveResult, str](unwrap_err[*ast.Ast, str](pr)); }
         a = unwrap_ok[*ast.Ast, str](pr);
     }
+    ret resolve_fresh(w, root, fid, a);
+}
 
+# resolve_fresh: re-resolve buffer `a` (FileId `fid`) against `root`'s dep set
+# unconditionally — the cache-miss core shared by `resolve_doc` (after its cache
+# check) and `diagnose_doc` (which forces a fresh parse to repopulate the session
+# DiagList). drops any prior cached result for `fid`, resolves with `res.resolve`,
+# and caches the new result. the resolve's diagnostics land on the session
+# DiagList, which `diagnose_doc` then publishes.
+# ---
+# w:    the workspace
+# root: the root governing the document, or nil for a single-file document
+# fid:  FileId of the open buffer
+# a:    the buffer's current parsed Ast
+# ret:  a borrowed pointer to the cached ResolveResult, or an error
+fun resolve_fresh(w: *Workspace, root: *Root, fid: src.FileId, a: *ast.Ast) Result[*res.ResolveResult, str] {
     free_cached(w, fid);
 
     # resolve under the same comptime environment the project's own modules
@@ -345,6 +361,35 @@ pub fun resolve_doc(w: *Workspace, root: *Root, fid: src.FileId) Result[*res.Res
         ret err[*res.ResolveResult, str]("project: resolve cache allocation failed");
     }
     ret ok[*res.ResolveResult, str](slot);
+}
+
+# diagnose_doc: parse and dep-aware-resolve the buffer governed by `root`,
+# returning the session DiagList populated with both its syntactic and its
+# name-resolution diagnostics. resolving against `root.deps` — the same dep set
+# go-to-definition uses — is what makes an import of a module outside the
+# project's dep closure surface its `imported module is not in the dep set`
+# diagnostic instead of binding silently to SYMBOL_NIL, so the published
+# diagnostics and what the features can resolve no longer disagree (#78). the
+# dep-aware ResolveResult is cached as a side effect, so a feature request on the
+# same unedited buffer reuses it. the fresh parse resets the session DiagList and
+# emits this buffer's lex / parse diagnostics; the resolve appends its own.
+# `root` must be non-nil: a single-file document keeps the editor's parse-only
+# diagnostics so its cross-module `use`s are not flagged against an empty dep set.
+# ---
+# w:    the workspace
+# root: the root governing the document (non-nil)
+# fid:  FileId of the open buffer
+# ret:  a borrowed pointer to the session DiagList, or an error
+pub fun diagnose_doc(w: *Workspace, root: *Root, fid: src.FileId) Result[*diag.DiagList, str] {
+    val pr: Result[*ast.Ast, str] = editor.parse(w.es, fid);
+    if (is_err[*ast.Ast, str](pr)) { ret err[*diag.DiagList, str](unwrap_err[*ast.Ast, str](pr)); }
+    val a: *ast.Ast = unwrap_ok[*ast.Ast, str](pr);
+
+    val rr: Result[*res.ResolveResult, str] = resolve_fresh(w, root, fid, a);
+    if (is_err[*res.ResolveResult, str](rr)) {
+        ret err[*diag.DiagList, str](unwrap_err[*res.ResolveResult, str](rr));
+    }
+    ret ok[*diag.DiagList, str](?w.s.diags);
 }
 
 # own_module: the synthetic module id a buffer resolves under for `root`. offset

--- a/src/server.mach
+++ b/src/server.mach
@@ -351,6 +351,11 @@ fun handle_did_close(srv: *Server, body: str) {
 fun handle_feature(srv: *Server, body: str, which: i64) {
     val uri: str = json.extract_after(body, "\"textDocument\"", "\"uri\"", srv.alloc);
 
+    # a feature request resolves dep-aware via project.root_for, which loads the
+    # governing project lazily on first use. snapshot the load epoch so a load
+    # triggered here re-publishes the now-loaded buffers' diagnostics (#96).
+    val epoch_before: u32 = project.load_epoch(?srv.ws);
+
     if (which == 0) { language.hover(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, body, uri); }
     or (which == 1) { language.definition(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, body, uri); }
     or (which == 2) { language.references(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, body, uri); }
@@ -360,6 +365,27 @@ fun handle_feature(srv: *Server, body: str, which: i64) {
     or (which == 6) { language.completion(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, body, uri); }
 
     if (uri != nil) { json.free_str(uri, srv.alloc); }
+
+    if (project.load_epoch(?srv.ws) != epoch_before) { republish_loaded(srv); }
+}
+
+# republish_loaded: re-publish diagnostics for every open document now governed
+# by a loaded project root. run after a feature request triggers a lazy load
+# (#96): the buffers under the freshly-loaded root were published parse-only on
+# open, so this upgrades them to dep-aware semantic diagnostics — including any
+# out-of-closure import the load now flags — without the user touching the file.
+# the publish path is load-free, so a buffer under no loaded root simply
+# re-publishes its parse-only diagnostics (unchanged), and nothing new is built.
+fun republish_loaded(srv: *Server) {
+    val n: usize = documents.slot_count(?srv.docs);
+    var i: usize = 0;
+    for (i < n) {
+        val d: *documents.Document = documents.at(?srv.docs, i);
+        if (d != nil && d.in_use && d.uri != nil) {
+            diagnostics.publish(?srv.ws, ?srv.es, project.sources(?srv.ws), srv.alloc, d.uri, d.file_id);
+        }
+        i = i + 1;
+    }
 }
 
 # publish_for: register/update `uri`'s buffer and publish its diagnostics.

--- a/src/server.mach
+++ b/src/server.mach
@@ -376,7 +376,7 @@ fun publish_for(srv: *Server, uri: str, text: str, is_open: bool) {
         ret;
     }
     val doc: *documents.Document = unwrap_ok[*documents.Document, str](dr);
-    diagnostics.publish(?srv.es, project.sources(?srv.ws), srv.alloc, uri, doc.file_id);
+    diagnostics.publish(?srv.ws, ?srv.es, project.sources(?srv.ws), srv.alloc, uri, doc.file_id);
 }
 
 # reply_error: send a JSON-RPC error response for a request that carries an id;

--- a/test/fixture-multibinary/mach.toml
+++ b/test/fixture-multibinary/mach.toml
@@ -1,0 +1,24 @@
+# multi-artifact fixture for build_project_union (#84): `toolonly` is reachable
+# only through the secondary `tool` binary's entry, outside the primary `app`
+# artifact's closure. a single-artifact load (the union's resolution ctx) omits
+# it; the union over every declared artifact's closure includes it, so workspace
+# references on `core.shared` reach its use-site in toolonly.
+[project]
+id      = "mbfix"
+version = "0.0.0"
+src     = "src"
+target  = "native"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.app]
+entry = "app.mach"
+
+[lib.core]
+entry = "core.mach"
+
+[bin.tool]
+entry = "tool.mach"

--- a/test/fixture-multibinary/src/app.mach
+++ b/test/fixture-multibinary/src/app.mach
@@ -1,0 +1,8 @@
+# app: the primary binary artifact (first declared, so the union's resolution
+# ctx). reaches core.shared directly but never toolonly, so toolonly sits outside
+# the primary artifact's closure.
+use mbfix.core.shared;
+
+fun main() i64 {
+    ret shared();
+}

--- a/test/fixture-multibinary/src/core.mach
+++ b/test/fixture-multibinary/src/core.mach
@@ -1,0 +1,7 @@
+# core: the library artifact's entry; declares the symbol shared across the app
+# and tool artifacts, so references on it must reach use-sites in both closures.
+
+# shared: a value imported and used across the primary and non-primary closures.
+pub fun shared() i64 {
+    ret 42;
+}

--- a/test/fixture-multibinary/src/tool.mach
+++ b/test/fixture-multibinary/src/tool.mach
@@ -1,0 +1,8 @@
+# tool: a secondary binary artifact's entry, the sole path to toolonly. the union
+# over every declared artifact's closure must load toolonly so workspace features
+# see its use-sites.
+use mbfix.toolonly.toolmain;
+
+fun main() i64 {
+    ret toolmain();
+}

--- a/test/fixture-multibinary/src/toolonly.mach
+++ b/test/fixture-multibinary/src/toolonly.mach
@@ -1,0 +1,8 @@
+# toolonly: reachable only through the non-primary `tool` binary's entry. its use
+# of core.shared is in the union graph only when the union covers every artifact's
+# closure, not just the primary's.
+use mbfix.core.shared;
+
+pub fun toolmain() i64 {
+    ret shared();
+}

--- a/test/fixture-multitarget-realloc/mach.toml
+++ b/test/fixture-multitarget-realloc/mach.toml
@@ -1,0 +1,29 @@
+# realloc-mid-walk regression fixture (#91 / mach#1540): three targets diverging
+# on both OS and arch. main's `$if` chain takes the windows branch (importing 24
+# leaf modules — enough to cross the compiler's INITIAL_MODULE_CAP of 16 and force
+# a `p.modules` realloc mid-walk) and the linux branch (one more leaf). under the
+# union build the load-walk visits both taken branches; pre-fix mach the realloc
+# in the first dangled the cached module entry the second deref'd -> SIGSEGV.
+[project]
+id      = "rtfix"
+version = "0.0.0"
+src     = "src"
+target  = "native"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.windows]
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[bin.rtfix]
+entry = "main.mach"

--- a/test/fixture-multitarget-realloc/src/lx.mach
+++ b/test/fixture-multitarget-realloc/src/lx.mach
@@ -1,0 +1,4 @@
+# lx: the linux-branch leaf, loaded after the windows branch's realloc. the
+# test resolves a request onto `lxval` to prove the union loaded it and the
+# server survived the post-realloc walk.
+pub fun lxval() i32 { ret 99; }

--- a/test/fixture-multitarget-realloc/src/main.mach
+++ b/test/fixture-multitarget-realloc/src/main.mach
@@ -1,0 +1,40 @@
+# main: a 2-branch target-gated $if. the windows branch imports 24 leaf modules
+# (w00..w23) — crossing the compiler's INITIAL_MODULE_CAP (16) so loading it grows
+# `p.modules` mid-walk; the linux branch imports one more leaf (lx). under the
+# union build both branches are taken (windows and the two linux targets), so the
+# load-walk visits the linux branch after the windows realloc — the use-after-
+# realloc that crashed pre-fix (#91 / mach#1540). lx.mach is loaded only via the
+# linux branch, so a cross-module request reaching it proves the union loaded and
+# the server survived the walk.
+$if ($mach.build.os == $mach.os.windows) {
+    use rtfix.w00;
+    use rtfix.w01;
+    use rtfix.w02;
+    use rtfix.w03;
+    use rtfix.w04;
+    use rtfix.w05;
+    use rtfix.w06;
+    use rtfix.w07;
+    use rtfix.w08;
+    use rtfix.w09;
+    use rtfix.w10;
+    use rtfix.w11;
+    use rtfix.w12;
+    use rtfix.w13;
+    use rtfix.w14;
+    use rtfix.w15;
+    use rtfix.w16;
+    use rtfix.w17;
+    use rtfix.w18;
+    use rtfix.w19;
+    use rtfix.w20;
+    use rtfix.w21;
+    use rtfix.w22;
+    use rtfix.w23;
+} $or ($mach.build.os == $mach.os.linux) {
+    use rtfix.lx;
+}
+
+fun main() i32 {
+    ret 0;
+}

--- a/test/fixture-multitarget-realloc/src/w00.mach
+++ b/test/fixture-multitarget-realloc/src/w00.mach
@@ -1,0 +1,3 @@
+# w00: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f00() i32 { ret 0; }

--- a/test/fixture-multitarget-realloc/src/w01.mach
+++ b/test/fixture-multitarget-realloc/src/w01.mach
@@ -1,0 +1,3 @@
+# w01: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f01() i32 { ret 1; }

--- a/test/fixture-multitarget-realloc/src/w02.mach
+++ b/test/fixture-multitarget-realloc/src/w02.mach
@@ -1,0 +1,3 @@
+# w02: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f02() i32 { ret 2; }

--- a/test/fixture-multitarget-realloc/src/w03.mach
+++ b/test/fixture-multitarget-realloc/src/w03.mach
@@ -1,0 +1,3 @@
+# w03: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f03() i32 { ret 3; }

--- a/test/fixture-multitarget-realloc/src/w04.mach
+++ b/test/fixture-multitarget-realloc/src/w04.mach
@@ -1,0 +1,3 @@
+# w04: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f04() i32 { ret 4; }

--- a/test/fixture-multitarget-realloc/src/w05.mach
+++ b/test/fixture-multitarget-realloc/src/w05.mach
@@ -1,0 +1,3 @@
+# w05: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f05() i32 { ret 5; }

--- a/test/fixture-multitarget-realloc/src/w06.mach
+++ b/test/fixture-multitarget-realloc/src/w06.mach
@@ -1,0 +1,3 @@
+# w06: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f06() i32 { ret 6; }

--- a/test/fixture-multitarget-realloc/src/w07.mach
+++ b/test/fixture-multitarget-realloc/src/w07.mach
@@ -1,0 +1,3 @@
+# w07: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f07() i32 { ret 7; }

--- a/test/fixture-multitarget-realloc/src/w08.mach
+++ b/test/fixture-multitarget-realloc/src/w08.mach
@@ -1,0 +1,3 @@
+# w08: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f08() i32 { ret 8; }

--- a/test/fixture-multitarget-realloc/src/w09.mach
+++ b/test/fixture-multitarget-realloc/src/w09.mach
@@ -1,0 +1,3 @@
+# w09: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f09() i32 { ret 9; }

--- a/test/fixture-multitarget-realloc/src/w10.mach
+++ b/test/fixture-multitarget-realloc/src/w10.mach
@@ -1,0 +1,3 @@
+# w10: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f10() i32 { ret 10; }

--- a/test/fixture-multitarget-realloc/src/w11.mach
+++ b/test/fixture-multitarget-realloc/src/w11.mach
@@ -1,0 +1,3 @@
+# w11: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f11() i32 { ret 11; }

--- a/test/fixture-multitarget-realloc/src/w12.mach
+++ b/test/fixture-multitarget-realloc/src/w12.mach
@@ -1,0 +1,3 @@
+# w12: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f12() i32 { ret 12; }

--- a/test/fixture-multitarget-realloc/src/w13.mach
+++ b/test/fixture-multitarget-realloc/src/w13.mach
@@ -1,0 +1,3 @@
+# w13: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f13() i32 { ret 13; }

--- a/test/fixture-multitarget-realloc/src/w14.mach
+++ b/test/fixture-multitarget-realloc/src/w14.mach
@@ -1,0 +1,3 @@
+# w14: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f14() i32 { ret 14; }

--- a/test/fixture-multitarget-realloc/src/w15.mach
+++ b/test/fixture-multitarget-realloc/src/w15.mach
@@ -1,0 +1,3 @@
+# w15: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f15() i32 { ret 15; }

--- a/test/fixture-multitarget-realloc/src/w16.mach
+++ b/test/fixture-multitarget-realloc/src/w16.mach
@@ -1,0 +1,3 @@
+# w16: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f16() i32 { ret 16; }

--- a/test/fixture-multitarget-realloc/src/w17.mach
+++ b/test/fixture-multitarget-realloc/src/w17.mach
@@ -1,0 +1,3 @@
+# w17: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f17() i32 { ret 17; }

--- a/test/fixture-multitarget-realloc/src/w18.mach
+++ b/test/fixture-multitarget-realloc/src/w18.mach
@@ -1,0 +1,3 @@
+# w18: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f18() i32 { ret 18; }

--- a/test/fixture-multitarget-realloc/src/w19.mach
+++ b/test/fixture-multitarget-realloc/src/w19.mach
@@ -1,0 +1,3 @@
+# w19: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f19() i32 { ret 19; }

--- a/test/fixture-multitarget-realloc/src/w20.mach
+++ b/test/fixture-multitarget-realloc/src/w20.mach
@@ -1,0 +1,3 @@
+# w20: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f20() i32 { ret 20; }

--- a/test/fixture-multitarget-realloc/src/w21.mach
+++ b/test/fixture-multitarget-realloc/src/w21.mach
@@ -1,0 +1,3 @@
+# w21: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f21() i32 { ret 21; }

--- a/test/fixture-multitarget-realloc/src/w22.mach
+++ b/test/fixture-multitarget-realloc/src/w22.mach
@@ -1,0 +1,3 @@
+# w22: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f22() i32 { ret 22; }

--- a/test/fixture-multitarget-realloc/src/w23.mach
+++ b/test/fixture-multitarget-realloc/src/w23.mach
@@ -1,0 +1,3 @@
+# w23: a windows-branch leaf in the realloc fixture. trivial body; its only
+# job is to be one of the 24 modules whose load crosses INITIAL_MODULE_CAP.
+pub fun f23() i32 { ret 23; }

--- a/test/fixture-outofclosure/mach.toml
+++ b/test/fixture-outofclosure/mach.toml
@@ -1,0 +1,28 @@
+# out-of-closure import fixture (#78). the only declared artifact's entry
+# (app.mach) imports just std.types.size, so the project's dep closure — the
+# union of every declared target's transitive imports, snapshotted into
+# root.deps — never loads std.types.option. opening the orphan buffer
+# outofclosure.mach (in src/ but reachable from no artifact entry) lets the
+# test assert that its `use std.types.option` import is surfaced as a published
+# diagnostic instead of resolving silently.
+#
+# depends on the repo's vendored mach-std (reached via `dep = "../../dep"`), the
+# same layout as test/fixture, so the server's own build_project_union loads it.
+[project]
+id      = "outofclosure"
+version = "0.0.0"
+src     = "src"
+dep     = "../../dep"
+target  = "native"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[bin.outofclosure]
+entry = "app.mach"
+
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "v0.6.0"

--- a/test/fixture-outofclosure/src/app.mach
+++ b/test/fixture-outofclosure/src/app.mach
@@ -1,0 +1,11 @@
+# the project entry. it imports only std.types.size, so the dep closure loads
+# std.types.size but never std.types.option — the precondition the #78 test
+# relies on. no artifact reaches outofclosure.mach, so that buffer's
+# std.types.option import stays outside the snapshot.
+
+use std.types.size.usize;
+
+# main: the binary entry, referencing only the in-closure usize.
+fun main() usize {
+    ret 0;
+}

--- a/test/fixture-outofclosure/src/outofclosure.mach
+++ b/test/fixture-outofclosure/src/outofclosure.mach
@@ -1,0 +1,15 @@
+# an orphan buffer: no artifact entry reaches it, so std.types.option is never
+# loaded into the project's dep closure. every reference through `opt` is
+# out-of-closure. before #78 these resolved silently to nothing with no
+# diagnostic; now the import surfaces "imported module is not in the dep set".
+# std.types.size is in the closure, so usize binds — keeping the diagnostics
+# focused on the out-of-closure `opt`.
+
+use std.types.size.usize;
+use opt: std.types.option;
+
+# f: references the out-of-closure alias as a type, both in a parameter and the
+# return position.
+fun f(o: opt.Option[usize]) opt.Option[usize] {
+    ret o;
+}

--- a/test/run.py
+++ b/test/run.py
@@ -16,6 +16,7 @@ import test_multiroot
 import test_invalidation
 import test_encoding
 import test_multitarget
+import test_multitarget_realloc
 
 SUITES = [
     ("diagnostics", test_diagnostics.run),
@@ -27,6 +28,7 @@ SUITES = [
     ("invalidation", test_invalidation.run),
     ("encoding", test_encoding.run),
     ("multitarget", test_multitarget.run),
+    ("multitarget-realloc", test_multitarget_realloc.run),
 ]
 
 

--- a/test/run.py
+++ b/test/run.py
@@ -19,6 +19,7 @@ import test_multitarget
 import test_multitarget_realloc
 import test_multibinary
 import test_outofclosure
+import test_hotpath
 
 SUITES = [
     ("diagnostics", test_diagnostics.run),
@@ -33,6 +34,7 @@ SUITES = [
     ("multitarget-realloc", test_multitarget_realloc.run),
     ("multibinary", test_multibinary.run),
     ("outofclosure", test_outofclosure.run),
+    ("hotpath", test_hotpath.run),
 ]
 
 

--- a/test/run.py
+++ b/test/run.py
@@ -17,6 +17,7 @@ import test_invalidation
 import test_encoding
 import test_multitarget
 import test_multitarget_realloc
+import test_multibinary
 
 SUITES = [
     ("diagnostics", test_diagnostics.run),
@@ -29,6 +30,7 @@ SUITES = [
     ("encoding", test_encoding.run),
     ("multitarget", test_multitarget.run),
     ("multitarget-realloc", test_multitarget_realloc.run),
+    ("multibinary", test_multibinary.run),
 ]
 
 

--- a/test/run.py
+++ b/test/run.py
@@ -18,6 +18,7 @@ import test_encoding
 import test_multitarget
 import test_multitarget_realloc
 import test_multibinary
+import test_outofclosure
 
 SUITES = [
     ("diagnostics", test_diagnostics.run),
@@ -31,6 +32,7 @@ SUITES = [
     ("multitarget", test_multitarget.run),
     ("multitarget-realloc", test_multitarget_realloc.run),
     ("multibinary", test_multibinary.run),
+    ("outofclosure", test_outofclosure.run),
 ]
 
 

--- a/test/test_hotpath.py
+++ b/test/test_hotpath.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""diagnostics publish never triggers a project load (#96).
+
+#78 routed publish through project.root_for, which loads the project on first
+use — putting the full ~tens-of-seconds build on the didOpen/didChange hot path
+and freezing the single-threaded server. the fix decouples them: publish uses a
+load-free lookup, so an open buffer publishes parse-only until a feature request
+loads the project, after which the server re-publishes dep-aware.
+
+this asserts the decoupling by behavior, not timing: the out-of-closure import
+diagnostic (a dep-aware, name-resolution result that only exists once the
+project's dep closure is known) must be ABSENT from the buffer's publish on
+didOpen — proving publish did not load the project — and must APPEAR only after
+a definition request triggers the load and the re-publish."""
+import os
+
+from harness import drive, req, notify, did_open, pos, by_id, file_uri, standalone, REPO
+
+FIXTURE = os.path.join(REPO, "test", "fixture-outofclosure")
+OOC = os.path.join(FIXTURE, "src", "outofclosure.mach")
+APP = os.path.join(FIXTURE, "src", "app.mach")
+OOC_URI = file_uri(OOC)
+APP_URI = file_uri(APP)
+
+
+def _pubs_for(msgs, uri):
+    """every publishDiagnostics diagnostics-array for `uri`, in order."""
+    return [m["params"]["diagnostics"] for m in msgs
+            if m.get("method") == "textDocument/publishDiagnostics"
+            and m["params"]["uri"] == uri]
+
+
+def _has_depset(diags):
+    """whether any diagnostic names the missing dep set (the dep-aware signal)."""
+    return any("dep set" in d.get("message", "") for d in diags)
+
+
+def run():
+    """drive open-then-load and assert publish stays off the load path."""
+    if not os.path.exists(OOC) or not os.path.exists(APP):
+        return [f"fixture not found under {FIXTURE}"]
+
+    ooc_text = open(OOC).read()
+    app_text = open(APP).read()
+
+    # open both buffers, then issue a definition that triggers the lazy load.
+    # the definition's id (2) lets us split publishes into pre-load (on open)
+    # and post-load (re-published by the server after the load).
+    frames = [
+        req(1, "initialize", {"capabilities": {}}),
+        notify("initialized"),
+        did_open(OOC_URI, ooc_text),
+        did_open(APP_URI, app_text),
+        req(2, "textDocument/definition",
+            {"textDocument": {"uri": APP_URI}, "position": pos(8, 11)}),
+        req(3, "shutdown", None),
+        notify("exit"),
+    ]
+    code, msgs = drive(frames)
+
+    failures = []
+
+    # the out-of-closure buffer must publish on open (the editor sees diagnostics
+    # immediately) and that first publish must be parse-only — no dep-set
+    # diagnostic, proving publish did not load the project's dep closure.
+    ooc_pubs = _pubs_for(msgs, OOC_URI)
+    if not ooc_pubs:
+        failures.append("no publishDiagnostics for the out-of-closure buffer on open")
+    else:
+        if _has_depset(ooc_pubs[0]):
+            failures.append(
+                "first publish carried a dep-aware diagnostic — publish loaded the "
+                "project on the hot path (the #96 regression)")
+        # after the definition loads the project, the server must re-publish the
+        # buffer with the dep-aware out-of-closure diagnostic.
+        if not _has_depset(ooc_pubs[-1]):
+            failures.append(
+                "out-of-closure diagnostic never appeared after the load — "
+                "re-publish-after-load did not fire")
+
+    # the definition request must still be answered (the load happened on the
+    # feature path, as before #78), so the server stayed responsive.
+    if by_id(msgs, 2) is None:
+        failures.append("no response to the definition request")
+
+    sh = by_id(msgs, 3)
+    if not sh or "result" not in sh:
+        failures.append("missing shutdown result")
+    if code != 0:
+        failures.append("non-zero exit code after clean shutdown")
+
+    return failures
+
+
+if __name__ == "__main__":
+    standalone("hotpath", run)

--- a/test/test_multibinary.py
+++ b/test/test_multibinary.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""multi-artifact union coverage (#84): a project declaring more than one artifact
+(here [bin.app], [lib.core], [bin.tool]) loads cleanly — no "multiple artifacts"
+load failure — and the union covers every artifact's closure, not just the
+primary's. fixture-multibinary's `toolonly` is reachable only from the secondary
+`tool` binary's entry; `app` (the primary artifact) never reaches it. with
+`build_project_union` the server still sees toolonly's use of `core.shared`, so
+references on `shared` reach a use-site a single-artifact load would omit."""
+import os
+
+from harness import LiveServer, req, notify, did_open, pos, file_uri, standalone, REPO
+
+MB = os.path.join(REPO, "test", "fixture-multibinary")
+CORE = os.path.join(MB, "src", "core.mach")
+
+# core.mach line 5 (0-based 4): `pub fun shared() i64 {` — decl `shared` at col 8.
+DECL = pos(4, 8)
+
+
+def run():
+    """drive the multi-artifact union scenario; return a list of failure strings."""
+    if not os.path.exists(CORE):
+        return [f"fixture-multibinary not found at {MB}"]
+    core_uri = file_uri(CORE)
+    failures = []
+    srv = LiveServer()
+    try:
+        srv.send(req(1, "initialize", {"capabilities": {}}))
+        srv.recv_id(1)
+        srv.send(notify("initialized"))
+        srv.send(did_open(core_uri, open(CORE).read()))
+
+        srv.send(req(20, "textDocument/references",
+                     {"textDocument": {"uri": core_uri}, "position": DECL,
+                      "context": {"includeDeclaration": True}}))
+        res = (srv.recv_id(20) or {}).get("result")
+        if not isinstance(res, list):
+            failures.append("references(shared) result is not an array — the "
+                            "multi-artifact project failed to load")
+        else:
+            uris = {r.get("uri", "") for r in res}
+            if not any(u.endswith("toolonly.mach") for u in uris):
+                failures.append(
+                    "references(shared) missing the non-primary-artifact-only "
+                    f"use-site (toolonly.mach); got {sorted(uris)} — the union "
+                    "did not cover the secondary `tool` artifact's closure")
+            if not any(u.endswith("app.mach") for u in uris):
+                failures.append(
+                    f"references(shared) missing the primary app.mach use-site; "
+                    f"got {sorted(uris)}")
+
+        srv.send(req(2, "shutdown", None))
+        srv.send(notify("exit"))
+    finally:
+        srv.close()
+    return failures
+
+
+if __name__ == "__main__":
+    standalone("multibinary", run)

--- a/test/test_multitarget_realloc.py
+++ b/test/test_multitarget_realloc.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""multi-target union realloc regression (#91 / mach#1540): loading a real
+multi-target project drove the compiler's `walk_comptime_if_union` through a
+use-after-realloc and segfaulted the server. the crash needed all three: union
+mode (multiple `[target.*]`), 2+ taken `$if` branches diverging on OS *and* arch,
+and an earlier taken branch importing enough modules to cross the compiler's
+INITIAL_MODULE_CAP (16) and realloc `p.modules` mid-walk.
+
+fixture-multitarget-realloc reproduces it: three targets (linux x86_64, windows
+x86_64, linux aarch64), a windows branch importing 24 leaf modules (the realloc)
+and a linux branch importing one more (`lx`, deref'd post-realloc). opening
+main.mach triggers the union build; pre-fix mach this segfaults the server. the
+test asserts the server survives the load and that a cross-module request reaches
+`lx`, which the union loads only via the linux branch."""
+import os
+
+from harness import LiveServer, req, notify, did_open, pos, file_uri, standalone, REPO
+
+RT = os.path.join(REPO, "test", "fixture-multitarget-realloc")
+MAIN = os.path.join(RT, "src", "main.mach")
+LX = os.path.join(RT, "src", "lx.mach")
+
+# lx.mach: `pub fun lxval()` is the 4th line (3 comment lines above it), so the
+# 0-based decl `lxval` is at line 3, col 8.
+LXVAL = pos(3, 8)
+
+
+def run():
+    """drive the realloc union scenario; return a list of failure strings."""
+    if not os.path.exists(MAIN):
+        return [f"fixture-multitarget-realloc not found at {RT}"]
+    main_uri = file_uri(MAIN)
+    lx_uri = file_uri(LX)
+    root_uri = file_uri(RT)
+    failures = []
+    srv = LiveServer()
+    try:
+        srv.send(req(1, "initialize",
+                     {"rootUri": root_uri,
+                      "workspaceFolders": [{"uri": root_uri, "name": "rtfix"}],
+                      "capabilities": {}}))
+        if srv.recv_id(1) is None:
+            return ["server did not answer initialize (crashed during startup?)"]
+        srv.send(notify("initialized"))
+
+        # opening both documents; the union build is lazy, so the realloc walk
+        # fires on the first feature request below, not on didOpen.
+        srv.send(did_open(main_uri, open(MAIN).read()))
+        srv.send(did_open(lx_uri, open(LX).read()))
+
+        # references on lx's decl drives the union load (lx is reachable only via
+        # the linux branch). pre-fix the walk segfaults here mid-request, so no
+        # response arrives; a sane array proves the union loaded lx and survived.
+        srv.send(req(20, "textDocument/references",
+                     {"textDocument": {"uri": lx_uri}, "position": LXVAL,
+                      "context": {"includeDeclaration": True}}))
+        res = srv.recv_id(20)
+        if res is None:
+            # the server died during the union load — don't send into the dead
+            # pipe; close() below surfaces the signal.
+            failures.append(
+                "no response to references(lxval) — the server died during the "
+                "multi-target union load (the #91/mach#1540 realloc crash)")
+            return failures
+        result = res.get("result")
+        if not isinstance(result, list):
+            failures.append("references(lxval) result is not an array")
+        elif not any(r.get("uri", "").endswith("lx.mach") for r in result):
+            failures.append(
+                "references(lxval) missing lx.mach's own decl — the union did "
+                f"not load the linux-branch leaf; got {sorted(r.get('uri','') for r in result)}")
+
+        # a second request the server can only answer if it is still alive after
+        # the load — the liveness assertion the bare didOpen cannot make.
+        srv.send(req(21, "textDocument/hover",
+                     {"textDocument": {"uri": lx_uri}, "position": LXVAL}))
+        if srv.recv_id(21) is None:
+            failures.append(
+                "no response to a follow-up request — the server is not alive "
+                "after the multi-target union load")
+            return failures
+
+        srv.send(req(2, "shutdown", None))
+        srv.send(notify("exit"))
+    finally:
+        code = srv.close()
+        # a clean shutdown exits 0; a signal kill (SIGSEGV) surfaces as a negative
+        # return code, so flag it even if a response slipped through.
+        if code is not None and code < 0:
+            failures.append(f"server exited on signal {-code} (SIGSEGV=11 is the #91 crash)")
+    return failures
+
+
+if __name__ == "__main__":
+    standalone("multitarget-realloc", run)

--- a/test/test_outofclosure.py
+++ b/test/test_outofclosure.py
@@ -1,16 +1,22 @@
 #!/usr/bin/env python3
-"""out-of-closure import diagnostics (#78).
+"""out-of-closure import diagnostics (#78), re-published after a lazy load (#96).
 
 a project whose entry imports only std.types.size never loads std.types.option
 into its dep closure. opening a buffer under that root which imports
-std.types.option must now PUBLISH a diagnostic ("imported module is not in the
-dep set") instead of resolving silently to nothing — keeping the published
+std.types.option must PUBLISH a diagnostic ("imported module is not in the dep
+set") instead of resolving silently to nothing — keeping the published
 diagnostics consistent with go-to-definition's inability to bind the symbol. a
 control buffer importing only the in-closure std.types.size must stay clean (no
-false positives from the dep-aware diagnostics pass)."""
+false positives from the dep-aware diagnostics pass).
+
+since #96 the project no longer loads on didOpen (that put the full build on the
+hot path and froze the server); the open buffers publish parse-only until a
+feature request loads the project, after which the server re-publishes their
+diagnostics dep-aware. so this drives a `definition` (which triggers the load)
+between the opens and shutdown, then asserts the re-published diagnostic."""
 import os
 
-from harness import drive, req, notify, did_open, by_id, file_uri, standalone, REPO
+from harness import drive, req, notify, did_open, pos, by_id, file_uri, standalone, REPO
 
 FIXTURE = os.path.join(REPO, "test", "fixture-outofclosure")
 OOC = os.path.join(FIXTURE, "src", "outofclosure.mach")
@@ -36,12 +42,18 @@ def run():
 
     ooc_text = open(OOC).read()
     app_text = open(APP).read()
+    # a definition request on the entry buffer's `usize` triggers the lazy
+    # project load (#96 moved the load off the didOpen hot path); the server
+    # then re-publishes the open buffers' diagnostics dep-aware, surfacing the
+    # out-of-closure import without an edit.
     frames = [
         req(1, "initialize", {"capabilities": {}}),
         notify("initialized"),
         did_open(OOC_URI, ooc_text),
         did_open(APP_URI, app_text),
-        req(2, "shutdown", None),
+        req(2, "textDocument/definition",
+            {"textDocument": {"uri": APP_URI}, "position": pos(8, 11)}),
+        req(3, "shutdown", None),
         notify("exit"),
     ]
     code, msgs = drive(frames)
@@ -76,7 +88,7 @@ def run():
     elif app:
         failures.append(f"in-closure control buffer produced diagnostics: {app!r}")
 
-    sh = by_id(msgs, 2)
+    sh = by_id(msgs, 3)
     if not sh or "result" not in sh:
         failures.append("missing shutdown result")
     if code != 0:

--- a/test/test_outofclosure.py
+++ b/test/test_outofclosure.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""out-of-closure import diagnostics (#78).
+
+a project whose entry imports only std.types.size never loads std.types.option
+into its dep closure. opening a buffer under that root which imports
+std.types.option must now PUBLISH a diagnostic ("imported module is not in the
+dep set") instead of resolving silently to nothing — keeping the published
+diagnostics consistent with go-to-definition's inability to bind the symbol. a
+control buffer importing only the in-closure std.types.size must stay clean (no
+false positives from the dep-aware diagnostics pass)."""
+import os
+
+from harness import drive, req, notify, did_open, by_id, file_uri, standalone, REPO
+
+FIXTURE = os.path.join(REPO, "test", "fixture-outofclosure")
+OOC = os.path.join(FIXTURE, "src", "outofclosure.mach")
+APP = os.path.join(FIXTURE, "src", "app.mach")
+OOC_URI = file_uri(OOC)
+APP_URI = file_uri(APP)
+
+
+def _diags_for(msgs, uri):
+    """the diagnostics array of the last publishDiagnostics for `uri`, or None."""
+    pubs = [m for m in msgs
+            if m.get("method") == "textDocument/publishDiagnostics"
+            and m["params"]["uri"] == uri]
+    if not pubs:
+        return None
+    return pubs[-1]["params"]["diagnostics"]
+
+
+def run():
+    """drive the out-of-closure diagnostics scenario; return failure strings."""
+    if not os.path.exists(OOC) or not os.path.exists(APP):
+        return [f"fixture not found under {FIXTURE}"]
+
+    ooc_text = open(OOC).read()
+    app_text = open(APP).read()
+    frames = [
+        req(1, "initialize", {"capabilities": {}}),
+        notify("initialized"),
+        did_open(OOC_URI, ooc_text),
+        did_open(APP_URI, app_text),
+        req(2, "shutdown", None),
+        notify("exit"),
+    ]
+    code, msgs = drive(frames)
+
+    failures = []
+
+    init = by_id(msgs, 1)
+    if not init or "result" not in init or "capabilities" not in init["result"]:
+        failures.append("missing/invalid initialize result")
+
+    # the out-of-closure import must surface a diagnostic, not resolve silently.
+    ooc = _diags_for(msgs, OOC_URI)
+    if ooc is None:
+        failures.append("no publishDiagnostics for the out-of-closure buffer")
+    elif not ooc:
+        failures.append("out-of-closure import produced 0 diagnostics (the #78 silence)")
+    else:
+        msgs_text = " ".join(d.get("message", "") for d in ooc)
+        if "dep set" not in msgs_text:
+            failures.append(
+                f"out-of-closure diagnostics do not name the missing dep set: {msgs_text!r}")
+        d0 = ooc[0]
+        if "range" not in d0 or "start" not in d0["range"] or "end" not in d0["range"]:
+            failures.append("out-of-closure diagnostic missing range")
+        if "severity" not in d0:
+            failures.append("out-of-closure diagnostic missing severity")
+
+    # the in-closure control must stay clean: no false positives.
+    app = _diags_for(msgs, APP_URI)
+    if app is None:
+        failures.append("no publishDiagnostics for the in-closure control buffer")
+    elif app:
+        failures.append(f"in-closure control buffer produced diagnostics: {app!r}")
+
+    sh = by_id(msgs, 2)
+    if not sh or "result" not in sh:
+        failures.append("missing shutdown result")
+    if code != 0:
+        failures.append("non-zero exit code after clean shutdown")
+
+    return failures
+
+
+if __name__ == "__main__":
+    standalone("outofclosure", run)


### PR DESCRIPTION
## mach-lsp v0.6.0

First release compatible with the post-collapse **mach 2.x** toolchain (vendors mach 2.4.1). Prior releases no longer built against current mach.

### Fixed
- **Build restored against mach 2.x** — vendored deps were stranded pre-collapse; the LSP now builds against mach 2.4.1 (#89).
- **Crash loading multi-target projects** — a use-after-realloc in the compiler's union build SIGSEGV'd the server on any real 3-target project (the restart loop). Fixed upstream (octalide/mach#1540, shipped in mach 2.4.1) and vendored, with an LSP regression fixture (#91).
- **File open froze large projects** — the diagnostics path triggered the full project build on `didOpen`; decoupled so opening/typing is instant again, the build stays on first feature request (#96).

### Added
- **Multi-binary / multi-artifact projects** load correctly — features resolve across modules reachable only from a non-primary artifact's entry (#84).
- **Semantic diagnostics** for project files — name-resolution errors (undefined symbols, type errors, out-of-closure imports) are now published, not just syntax errors; they appear once the project loads (#78).

### Known limitation
- Large projects are slow on the first feature request (~tens of seconds, single-threaded whole-closure build) and rebuild on save. Tracked in #95 (blocked by octalide/mach#1547) for a later incremental-reload pass.