### PR TITLE
feat: go-to-definition on record/union fields

### DIFF
--- a/src/features.mach
+++ b/src/features.mach
@@ -27,7 +27,14 @@ use std.types.option.Option;
 use std.types.option.some;
 use std.types.option.none;
 use std.types.option.is_some;
+use std.types.option.is_none;
 use std.types.option.unwrap;
+use std.types.result.Result;
+use std.types.result.is_err;
+use std.types.result.unwrap_ok;
+
+use std.allocator.Allocator;
+use page: std.allocator.page;
 
 use sess:   mach.lang.session;
 use src:    mach.lang.source;
@@ -827,4 +834,157 @@ pub fun span_bytes_equal(fa: *src.SourceFile, sa: token.Span, fb: *src.SourceFil
         i = i + 1;
     }
     ret true;
+}
+
+# span_at: a Span over `[offset, offset + len)`. the test builder for field-name /
+# query spans into a stub SourceFile.
+fun span_at(offset: usize, len: usize) token.Span {
+    var sp: token.Span;
+    sp.offset = offset;
+    sp.len    = len;
+    ret sp;
+}
+
+# stub_file: a SourceFile carrying just `text`, enough for the byte-level field-name
+# compares the pure locator does (it reads `file.text` only).
+fun stub_file(text: str) src.SourceFile {
+    var f: src.SourceFile;
+    f.path        = nil;
+    f.text        = text;
+    f.line_starts = nil;
+    f.line_len    = 0;
+    ret f;
+}
+
+# add_field: append a field TypedName named over `[offset, offset + len)` to `a`,
+# returning its index into `a.typed_names`.
+fun add_field(a: *ast.Ast, offset: usize, len: usize) u32 {
+    var tn: decl.TypedName;
+    tn.name     = span_at(offset, len);
+    tn.ty       = id.TYPE_NIL;
+    tn.comptime = false;
+    val r: Result[u32, str] = ast.add_typed_name(a, tn);
+    ret unwrap_ok[u32, str](r);
+}
+
+test "features: field_decl_span matches a field in the same source" {
+    var pa: Allocator;
+    page.make(?pa);
+    var a: ast.Ast = ast.init(?pa, 0::src.FileId);
+    # text "xyzz": fields "x"@0, "y"@1, "zz"@2..3
+    val start: u32 = add_field(?a, 0, 1);
+    add_field(?a, 1, 1);
+    add_field(?a, 2, 2);
+    var f: src.SourceFile = stub_file("xyzz");
+
+    var fail: bool = false;
+    # query "y" (the byte at offset 1) resolves to field "y" at offset 1.
+    val o: Option[token.Span] = field_decl_span(?a, ?f, start, 3, ?f, span_at(1, 1));
+    if (is_none[token.Span](o)) { fail = true; }
+    or {
+        val sp: token.Span = unwrap[token.Span](o);
+        if (sp.offset != 1 || sp.len != 1) { fail = true; }
+    }
+
+    ast.dnit(?a);
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+test "features: field_decl_span matches a field across two sources (dependency)" {
+    var pa: Allocator;
+    page.make(?pa);
+    # the declaring "module" file holds the record fields.
+    var da: ast.Ast = ast.init(?pa, 0::src.FileId);
+    val start: u32 = add_field(?da, 0, 4);   # "name"
+    add_field(?da, 5, 3);                     # "age"
+    var df: src.SourceFile = stub_file("name age");
+    # the referencing buffer file holds a member access "p.age".
+    var qf: src.SourceFile = stub_file("p.age");
+
+    var fail: bool = false;
+    val o: Option[token.Span] = field_decl_span(?da, ?df, start, 2, ?qf, span_at(2, 3));
+    if (is_none[token.Span](o)) { fail = true; }
+    or {
+        val sp: token.Span = unwrap[token.Span](o);
+        if (sp.offset != 5 || sp.len != 3) { fail = true; }
+    }
+
+    ast.dnit(?da);
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+test "features: field_decl_span returns none for an unknown field" {
+    var pa: Allocator;
+    page.make(?pa);
+    var a: ast.Ast = ast.init(?pa, 0::src.FileId);
+    val start: u32 = add_field(?a, 0, 1);   # "x"
+    add_field(?a, 2, 1);                     # "y"
+    var f: src.SourceFile = stub_file("xy");
+    var qf: src.SourceFile = stub_file("o.z");
+
+    val ok: bool = is_none[token.Span](field_decl_span(?a, ?f, start, 2, ?qf, span_at(2, 1)));
+    ast.dnit(?a);
+    if (!ok) { ret 1; }
+    ret 0;
+}
+
+test "features: field_decl_span returns none for an empty field range" {
+    var pa: Allocator;
+    page.make(?pa);
+    var a: ast.Ast = ast.init(?pa, 0::src.FileId);
+    var f: src.SourceFile = stub_file("x");
+
+    val ok: bool = is_none[token.Span](field_decl_span(?a, ?f, 0, 0, ?f, span_at(0, 1)));
+    ast.dnit(?a);
+    if (!ok) { ret 1; }
+    ret 0;
+}
+
+test "features: field_decl_span returns none for a zero-length query" {
+    var pa: Allocator;
+    page.make(?pa);
+    var a: ast.Ast = ast.init(?pa, 0::src.FileId);
+    val start: u32 = add_field(?a, 0, 1);   # "x"
+    var f: src.SourceFile = stub_file("x");
+
+    val ok: bool = is_none[token.Span](field_decl_span(?a, ?f, start, 1, ?f, span_at(0, 0)));
+    ast.dnit(?a);
+    if (!ok) { ret 1; }
+    ret 0;
+}
+
+test "features: span_bytes_equal matches identical bytes across files" {
+    var fa: src.SourceFile = stub_file("alpha");
+    var fb: src.SourceFile = stub_file("xalphay");
+    var fail: bool = false;
+    if (!span_bytes_equal(?fa, span_at(0, 5), ?fb, span_at(1, 5))) { fail = true; }
+    if (span_bytes_equal(?fa, span_at(0, 5), ?fb, span_at(1, 4)))  { fail = true; }
+    if (span_bytes_equal(?fa, span_at(0, 3), ?fb, span_at(0, 3)))  { fail = true; }
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+test "features: field_decl_self_at hits a field name and misses elsewhere" {
+    var pa: Allocator;
+    page.make(?pa);
+    var a: ast.Ast = ast.init(?pa, 0::src.FileId);
+    val start: u32 = add_field(?a, 4, 1);   # "x" at offset 4
+    add_field(?a, 10, 3);                    # "foo" at offset 10
+
+    var fail: bool = false;
+    # offset 11 sits inside "foo".
+    val hit: Option[token.Span] = field_decl_self_at(?a, start, 2, 11);
+    if (is_none[token.Span](hit)) { fail = true; }
+    or {
+        val sp: token.Span = unwrap[token.Span](hit);
+        if (sp.offset != 10 || sp.len != 3) { fail = true; }
+    }
+    # offset 7 is between the two field names.
+    if (is_some[token.Span](field_decl_self_at(?a, start, 2, 7))) { fail = true; }
+
+    ast.dnit(?a);
+    if (fail) { ret 1; }
+    ret 0;
 }

--- a/src/features.mach
+++ b/src/features.mach
@@ -695,40 +695,31 @@ fun type_name_span(a: *ast.Ast, tid: id.TypeId) Option[token.Span] {
     ret none[token.Span]();
 }
 
-# FIELD_NONE / FIELD_MEMBER / FIELD_STRUCT_LIT: the shape of a field reference the
-# cursor pivots to. a member access `foo.bar` carries the receiver expression to
-# type; a struct literal `T{ bar: ... }` carries the named type the field belongs
-# to. both also carry the referenced field-name span (the `.bar` / `bar` token).
-pub val FIELD_NONE:        u8 = 0;
-pub val FIELD_MEMBER:      u8 = 1;
-pub val FIELD_STRUCT_LIT:  u8 = 2;
-
 # FieldRef: a record / union field a cursor position references, before the field
 # is typed. name resolution leaves a value-field access unbound (`expr_resolved`
 # is SYMBOL_NIL for a MEMBER node), so this is the type-driven parallel to
-# `SymbolRef`: the feature layer resolves it to a field declaration through the
-# record's TypeId rather than the symbol table. the kind selects which of
-# `object` / `lit_ty` to follow.
+# `SymbolRef`: the feature layer resolves it to a field declaration through a
+# TypeId rather than the symbol table. `host` is the expression whose semantic
+# type names the record / union the field belongs to — the receiver for a member
+# access `foo.bar`, the struct literal itself for `T{ bar: ... }` (whose inferred
+# type is the record). the caller types `host`, peels it to a record site, then
+# matches `name_span` against the site's fields.
 # ---
-# kind:      FIELD_MEMBER (follow `object`) or FIELD_STRUCT_LIT (follow `lit_ty`)
-# object:    receiver expression id for a member access (EXPR_NIL otherwise)
-# lit_ty:    named type id of the struct literal (TYPE_NIL otherwise)
-# name_span: byte span of the referenced field-name token
+# host:      expression id to type (member receiver, or the struct literal itself)
+# name_span: byte span of the referenced field-name token (`.bar` / `bar`)
 pub rec FieldRef {
-    kind:      u8;
-    object:    id.ExprId;
-    lit_ty:    id.TypeId;
+    host:      id.ExprId;
     name_span: token.Span;
 }
 
 # field_ref_at: the record / union field a byte offset references through a member
 # access or a struct-literal field name, or none. the type-driven pivot for
 # go-to-definition on fields: `expr_resolved` never binds a value-field access, so
-# this recovers the field name (and the receiver / literal type the field decl is
-# reached through) directly from the syntax. it is consulted only when the
-# symbol-table pivot (`ref_at`) finds nothing, so an ordinary symbol still wins.
-# pure over the Ast — the actual field-decl lookup needs types and runs in the
-# caller via `field_decl_span`.
+# this recovers the field name and the expression whose type names the field's
+# record directly from the syntax. it is consulted only when the symbol-table
+# pivot (`ref_at`) finds nothing, so an ordinary symbol still wins. pure over the
+# Ast — the actual field-decl lookup needs types and runs in the caller via
+# `field_decl_span`.
 # ---
 # a:      the buffer's parsed Ast
 # offset: byte offset into the buffer
@@ -743,9 +734,7 @@ pub fun field_ref_at(a: *ast.Ast, offset: usize) Option[FieldRef] {
     if (e.kind == expr.EXPR_KIND_MEMBER) {
         if (!ast.span_contains(e.data.member.name, offset)) { ret none[FieldRef](); }
         var fr: FieldRef;
-        fr.kind      = FIELD_MEMBER;
-        fr.object    = e.data.member.object;
-        fr.lit_ty    = id.TYPE_NIL;
+        fr.host      = e.data.member.object;
         fr.name_span = e.data.member.name;
         ret some[FieldRef](fr);
     }
@@ -758,9 +747,7 @@ pub fun field_ref_at(a: *ast.Ast, offset: usize) Option[FieldRef] {
             val fi: *expr.FieldInit = ?a.field_inits[start + i];
             if (ast.span_contains(fi.name, offset)) {
                 var fr: FieldRef;
-                fr.kind      = FIELD_STRUCT_LIT;
-                fr.object    = id.EXPR_NIL;
-                fr.lit_ty    = e.data.struct_lit.ty;
+                fr.host      = eid;
                 fr.name_span = fi.name;
                 ret some[FieldRef](fr);
             }

--- a/src/features.mach
+++ b/src/features.mach
@@ -694,3 +694,150 @@ fun type_name_span(a: *ast.Ast, tid: id.TypeId) Option[token.Span] {
     if (t.kind == atype.TYPE_KIND_NAMED) { ret some[token.Span](t.data.named.name); }
     ret none[token.Span]();
 }
+
+# FIELD_NONE / FIELD_MEMBER / FIELD_STRUCT_LIT: the shape of a field reference the
+# cursor pivots to. a member access `foo.bar` carries the receiver expression to
+# type; a struct literal `T{ bar: ... }` carries the named type the field belongs
+# to. both also carry the referenced field-name span (the `.bar` / `bar` token).
+pub val FIELD_NONE:        u8 = 0;
+pub val FIELD_MEMBER:      u8 = 1;
+pub val FIELD_STRUCT_LIT:  u8 = 2;
+
+# FieldRef: a record / union field a cursor position references, before the field
+# is typed. name resolution leaves a value-field access unbound (`expr_resolved`
+# is SYMBOL_NIL for a MEMBER node), so this is the type-driven parallel to
+# `SymbolRef`: the feature layer resolves it to a field declaration through the
+# record's TypeId rather than the symbol table. the kind selects which of
+# `object` / `lit_ty` to follow.
+# ---
+# kind:      FIELD_MEMBER (follow `object`) or FIELD_STRUCT_LIT (follow `lit_ty`)
+# object:    receiver expression id for a member access (EXPR_NIL otherwise)
+# lit_ty:    named type id of the struct literal (TYPE_NIL otherwise)
+# name_span: byte span of the referenced field-name token
+pub rec FieldRef {
+    kind:      u8;
+    object:    id.ExprId;
+    lit_ty:    id.TypeId;
+    name_span: token.Span;
+}
+
+# field_ref_at: the record / union field a byte offset references through a member
+# access or a struct-literal field name, or none. the type-driven pivot for
+# go-to-definition on fields: `expr_resolved` never binds a value-field access, so
+# this recovers the field name (and the receiver / literal type the field decl is
+# reached through) directly from the syntax. it is consulted only when the
+# symbol-table pivot (`ref_at`) finds nothing, so an ordinary symbol still wins.
+# pure over the Ast — the actual field-decl lookup needs types and runs in the
+# caller via `field_decl_span`.
+# ---
+# a:      the buffer's parsed Ast
+# offset: byte offset into the buffer
+# ret:    some(FieldRef) on a field-name position, or none
+pub fun field_ref_at(a: *ast.Ast, offset: usize) Option[FieldRef] {
+    val eid: id.ExprId = ast.offset_to_expr(a, offset);
+    if (eid == id.EXPR_NIL) { ret none[FieldRef](); }
+    val eo: Option[*expr.Expr] = ast.get_expr(a, eid);
+    if (!is_some[*expr.Expr](eo)) { ret none[FieldRef](); }
+    val e: *expr.Expr = unwrap[*expr.Expr](eo);
+
+    if (e.kind == expr.EXPR_KIND_MEMBER) {
+        if (!ast.span_contains(e.data.member.name, offset)) { ret none[FieldRef](); }
+        var fr: FieldRef;
+        fr.kind      = FIELD_MEMBER;
+        fr.object    = e.data.member.object;
+        fr.lit_ty    = id.TYPE_NIL;
+        fr.name_span = e.data.member.name;
+        ret some[FieldRef](fr);
+    }
+
+    if (e.kind == expr.EXPR_KIND_STRUCT_LIT) {
+        val start: u32 = e.data.struct_lit.fields_start;
+        val len:   u32 = e.data.struct_lit.fields_len;
+        var i: u32 = 0;
+        for (i < len) {
+            val fi: *expr.FieldInit = ?a.field_inits[start + i];
+            if (ast.span_contains(fi.name, offset)) {
+                var fr: FieldRef;
+                fr.kind      = FIELD_STRUCT_LIT;
+                fr.object    = id.EXPR_NIL;
+                fr.lit_ty    = e.data.struct_lit.ty;
+                fr.name_span = fi.name;
+                ret some[FieldRef](fr);
+            }
+            i = i + 1;
+        }
+    }
+
+    ret none[FieldRef]();
+}
+
+# field_decl_span: the name span of the field declared in `decl_a` (its rec / uni
+# field range `[fields_start, fields_start + fields_len)` in `decl_a.typed_names`)
+# whose name bytes equal the referencing token `query` in `query_file`, or none
+# when no field matches. pure and session-free — the field-decl locator the
+# go-to-definition path drives once a value's type has been resolved to its record
+# site. comparing bytes across the two files lets the receiver and the declaration
+# live in different modules.
+# ---
+# decl_a:       the declaring module's Ast (its typed_names hold the fields)
+# decl_file:    the SourceFile backing `decl_a` (field-name bytes)
+# fields_start: start index of the field range in `decl_a.typed_names`
+# fields_len:   number of fields
+# query_file:   the SourceFile backing the referencing token
+# query:        byte span of the referenced field name
+# ret:          some(field name span in `decl_a`), or none
+pub fun field_decl_span(decl_a: *ast.Ast, decl_file: *src.SourceFile, fields_start: u32, fields_len: u32, query_file: *src.SourceFile, query: token.Span) Option[token.Span] {
+    if (query.len == 0) { ret none[token.Span](); }
+    var i: u32 = 0;
+    for (i < fields_len) {
+        val tn: *decl.TypedName = ?decl_a.typed_names[fields_start + i];
+        if (span_bytes_equal(decl_file, tn.name, query_file, query)) {
+            ret some[token.Span](tn.name);
+        }
+        i = i + 1;
+    }
+    ret none[token.Span]();
+}
+
+# field_decl_self_at: the name span of the rec / uni field whose own declaration
+# name covers `offset` in `decl_file`, or none. resolves the field's declaration
+# site to itself (go-to-definition on a field where it is declared). scans the
+# field range `[fields_start, fields_start + fields_len)` in `decl_a.typed_names`.
+# ---
+# decl_a:       the Ast holding the field declarations
+# decl_file:    the SourceFile backing `decl_a`
+# fields_start: start index of the field range in `decl_a.typed_names`
+# fields_len:   number of fields
+# offset:       byte offset into `decl_file`
+# ret:          some(field name span) when the offset is on a field name, or none
+pub fun field_decl_self_at(decl_a: *ast.Ast, fields_start: u32, fields_len: u32, offset: usize) Option[token.Span] {
+    var i: u32 = 0;
+    for (i < fields_len) {
+        val tn: *decl.TypedName = ?decl_a.typed_names[fields_start + i];
+        if (ast.span_contains(tn.name, offset)) { ret some[token.Span](tn.name); }
+        i = i + 1;
+    }
+    ret none[token.Span]();
+}
+
+# span_bytes_equal: true when the bytes of `sa` in `fa` exactly equal the bytes of
+# `sb` in `fb`. the cross-file identifier compare the field-decl locator matches a
+# field name against the referencing token with — the two may sit in different
+# source files (a field declared in a dependency, referenced in the buffer).
+# ---
+# fa: source file backing span `sa`
+# sa: byte span in `fa`
+# fb: source file backing span `sb`
+# sb: byte span in `fb`
+# ret: true on an exact byte-for-byte match
+pub fun span_bytes_equal(fa: *src.SourceFile, sa: token.Span, fb: *src.SourceFile, sb: token.Span) bool {
+    if (sa.len != sb.len) { ret false; }
+    val a: *u8 = fa.text::*u8;
+    val b: *u8 = fb.text::*u8;
+    var i: usize = 0;
+    for (i < sa.len) {
+        if (a[sa.offset + i] != b[sb.offset + i]) { ret false; }
+        i = i + 1;
+    }
+    ret true;
+}

--- a/src/language.mach
+++ b/src/language.mach
@@ -29,6 +29,7 @@ use std.types.string.str_len;
 use std.types.string.str_equals;
 use std.types.string.str_starts_with;
 use std.types.option.Option;
+use std.types.option.some;
 use std.types.option.none;
 use std.types.option.is_some;
 use std.types.option.unwrap;
@@ -46,11 +47,13 @@ use sess:   mach.lang.session;
 use src:    mach.lang.source;
 use intern: mach.lang.intern;
 use editor: mach.lang.editor;
+use type:   mach.lang.type;
 use token:  mach.lang.fe.token;
 use ast:    mach.lang.fe.ast;
 use id:     mach.lang.fe.ast.id;
 use decl:   mach.lang.fe.ast.decl;
 use res:    mach.lang.fe.resolve;
+use sema:   mach.lang.fe.sema;
 
 use transport: mls.transport;
 use json:      mls.json;
@@ -63,6 +66,7 @@ use project:   mls.project;
 # ---
 # interner: the session's string interner, for resolving symbol-name StrIds
 # file:     the document's SourceFile (text + line index for offset/position)
+# fid:      the document's FileId (for the type-aware field path's sema_doc)
 # a:        the buffer's parsed Ast
 # rr:       the buffer's ResolveResult side tables
 # own:      this buffer's module id (Symbol.origin equals it for local symbols)
@@ -70,6 +74,7 @@ use project:   mls.project;
 rec Analyzed {
     interner: *intern.Interner;
     file:     *src.SourceFile;
+    fid:      src.FileId;
     a:        *ast.Ast;
     rr:       *res.ResolveResult;
     own:      sess.ModuleId;
@@ -396,7 +401,13 @@ pub fun definition(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Al
     val offset: usize = unwrap[usize](off_o);
 
     val ro: Option[features.SymbolRef] = features.ref_at(an.a, an.rr, an.own, offset);
-    if (!is_some[features.SymbolRef](ro)) { reply_null(alloc, id_raw); ret; }
+    if (!is_some[features.SymbolRef](ro)) {
+        # name resolution leaves a value-field access unbound, so a cursor on a
+        # field name yields no SymbolRef — fall through to the type-driven field
+        # path before giving up.
+        if (field_definition(ws, alloc, ?an, uri, offset, id_raw)) { ret; }
+        reply_null(alloc, id_raw); ret;
+    }
     val sr: features.SymbolRef = unwrap[features.SymbolRef](ro);
 
     val so: Option[*res.Symbol] = features.symbol(an.rr, sr.sym_id);
@@ -421,6 +432,131 @@ pub fun definition(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Al
     send6(alloc, p1, id_raw, p2, loc, p3, nil, nil);
 
     json.free_str(loc, alloc);
+    json.free_str(id_raw, alloc);
+}
+
+# field_definition: the type-driven go-to-definition path for a record / union
+# field, consulted when the symbol-table pivot finds nothing at `offset`. handles
+# three field positions: a member access `foo.bar`, a struct-literal field name
+# `T{ bar: ... }`, and a field's own declaration site (which resolves to itself).
+# the first two type the referencing expression, peel it to its record site, and
+# match the field name; the third matches the cursor against the rec / uni decl's
+# own field names. emits the field declaration's Location and returns true when a
+# field is found and replied; returns false (without replying) so the caller can
+# fall back to a null reply otherwise. requires a loaded project root for typing.
+# ---
+# ws:     the workspace
+# alloc:  request allocator
+# an:     the analyzed request document
+# uri:    the request document URI
+# offset: cursor byte offset into the buffer
+# id_raw: the raw JSON request id (for the reply)
+# ret:    true when a field declaration was located and emitted
+fun field_definition(ws: *project.Workspace, alloc: *Allocator, an: *Analyzed, uri: str, offset: usize, id_raw: str) bool {
+    if (an.root == nil) { ret false; }
+
+    val fo: Option[features.FieldRef] = features.field_ref_at(an.a, offset);
+    if (is_some[features.FieldRef](fo)) {
+        val fr: features.FieldRef = unwrap[features.FieldRef](fo);
+
+        val sr_r: Result[*sema.SemaResult, str] = project.sema_doc(ws, an.root, an.fid);
+        if (is_err[*sema.SemaResult, str](sr_r)) { ret false; }
+        val sr: *sema.SemaResult = unwrap_ok[*sema.SemaResult, str](sr_r);
+
+        val tid: type.TypeId = project.type_of(sr, fr.host);
+        val rso: Option[project.RecordSite] = project.record_decl_in(ws, an.root, an.own, an.a, an.file, tid);
+        if (!is_some[project.RecordSite](rso)) { ret false; }
+        val rs: project.RecordSite = unwrap[project.RecordSite](rso);
+
+        val spo: Option[token.Span] = features.field_decl_span(rs.a, rs.file, rs.fields_start, rs.fields_len, an.file, fr.name_span);
+        if (!is_some[token.Span](spo)) { ret false; }
+        ret emit_field_location(ws, alloc, an, uri, rs, unwrap[token.Span](spo), id_raw);
+    }
+
+    # the cursor may sit on a field's own declaration name inside a rec / uni;
+    # resolve it to itself by matching the offset against the decl's field names.
+    val self_o: Option[FieldSelf] = field_self_at(an, offset);
+    if (is_some[FieldSelf](self_o)) {
+        val fs: FieldSelf = unwrap[FieldSelf](self_o);
+        val loc: str = location_json(an.file, uri, fs.name, alloc);
+        if (loc == nil) { ret false; }
+        reply_result(alloc, id_raw, loc);
+        json.free_str(loc, alloc);
+        ret true;
+    }
+
+    ret false;
+}
+
+# FieldSelf: a field declaration the cursor sits on at its own definition site —
+# the field name span resolves to itself for go-to-definition.
+# ---
+# name: byte span of the field name in the buffer
+rec FieldSelf {
+    name: token.Span;
+}
+
+# field_self_at: the rec / uni field whose own declaration name covers `offset` in
+# the buffer, or none. enumerates the buffer's record / union declarations and
+# their fields so a cursor on a field's binding name resolves to itself.
+# ---
+# an:     the analyzed request document
+# offset: cursor byte offset into the buffer
+# ret:    some(FieldSelf) on a field declaration name, or none
+fun field_self_at(an: *Analyzed, offset: usize) Option[FieldSelf] {
+    val did: id.DeclId = ast.offset_to_decl(an.a, offset);
+    if (did == id.DECL_NIL) { ret none[FieldSelf](); }
+    val d_opt: Option[*decl.Decl] = ast.get_decl(an.a, did);
+    if (!is_some[*decl.Decl](d_opt)) { ret none[FieldSelf](); }
+    val d: *decl.Decl = unwrap[*decl.Decl](d_opt);
+
+    var start: u32 = 0;
+    var len:   u32 = 0;
+    if (d.kind == decl.DECL_KIND_REC) {
+        start = d.data.rec_.fields_start;
+        len   = d.data.rec_.fields_len;
+    } or (d.kind == decl.DECL_KIND_UNI) {
+        start = d.data.uni_.fields_start;
+        len   = d.data.uni_.fields_len;
+    } or {
+        ret none[FieldSelf]();
+    }
+
+    val nso: Option[token.Span] = features.field_decl_self_at(an.a, start, len, offset);
+    if (!is_some[token.Span](nso)) { ret none[FieldSelf](); }
+    var fs: FieldSelf;
+    fs.name = unwrap[token.Span](nso);
+    ret some[FieldSelf](fs);
+}
+
+# emit_field_location: send the Location of a field declaration at its record
+# site. builds the site's `file://` URI (the buffer's own URI when the record is
+# declared in this module, else the defining module's on-disk file) and emits the
+# field name span. true on success; false on a URI / allocation failure.
+fun emit_field_location(ws: *project.Workspace, alloc: *Allocator, an: *Analyzed, uri: str, rs: project.RecordSite, name: token.Span, id_raw: str) bool {
+    var furi: str = uri;
+    var owned: bool = false;
+    if (rs.origin != an.own) {
+        furi = project.module_uri(ws, an.root, rs.origin);
+        if (furi == nil) { ret false; }
+        owned = true;
+    }
+
+    val loc: str = location_json(rs.file, furi, name, alloc);
+    if (owned) { json.free_str(furi, ws.alloc); }
+    if (loc == nil) { ret false; }
+    reply_result(alloc, id_raw, loc);
+    json.free_str(loc, alloc);
+    ret true;
+}
+
+# reply_result: send a JSON-RPC success reply carrying `result` for request
+# `id_raw`. shared by the field-definition replies.
+fun reply_result(alloc: *Allocator, id_raw: str, result: str) {
+    val p1: str = "{\"jsonrpc\":\"2.0\",\"id\":";
+    val p2: str = ",\"result\":";
+    val p3: str = "}";
+    send6(alloc, p1, id_raw, p2, result, p3, nil, nil);
     json.free_str(id_raw, alloc);
 }
 
@@ -748,6 +884,7 @@ fun analyze(ws: *project.Workspace, es: *editor.EditorSession, docs: *documents.
     if (!is_some[*src.SourceFile](fo)) { ret false; }
     out.interner = project.interner(ws);
     out.file     = unwrap[*src.SourceFile](fo);
+    out.fid      = doc.file_id;
     out.root     = root;
     out.own      = project.own_module(root, doc.file_id);
     ret true;

--- a/src/project.mach
+++ b/src/project.mach
@@ -1259,22 +1259,25 @@ pub fun decl_type_of(sr: *sema.SemaResult, did: id.DeclId) type.TypeId {
 
 # RecordSite: the nominal back-link from a record / union TypeId to its declaring
 # site — what a field go-to-def / rename follows from a value's type to the `rec` /
-# `uni` declaration whose fields it must walk. carries both the declaration payload
-# and the module's Ast / source so field spans can be read directly.
+# `uni` declaration whose fields it must walk. carries the field range (uniform
+# across rec / uni, both being TypedName slices in `a.typed_names`) and the
+# module's Ast / source so field spans can be read directly.
 # ---
-# origin: ModuleId of the declaring module
-# decl:   DeclId of the rec / uni declaration in `origin`'s Ast
-# a:      the declaring module's parsed Ast (field spans index into it)
-# file:   SourceFile backing `a`
-# rec:    the DeclRec payload (field range), valid when kind is TYPE_REC
-# is_rec: true for a record, false for a union (selects the payload)
+# origin:       ModuleId of the declaring module
+# decl:         DeclId of the rec / uni declaration in `origin`'s Ast
+# a:            the declaring module's parsed Ast (field spans index into it)
+# file:         SourceFile backing `a`
+# fields_start: start index into `a.typed_names` of the first field
+# fields_len:   number of fields (record fields / union variants)
+# is_rec:       true for a record, false for a union
 pub rec RecordSite {
-    origin: sess.ModuleId;
-    decl:   id.DeclId;
-    a:      *ast.Ast;
-    file:   *src.SourceFile;
-    rec:    adecl.DeclRec;
-    is_rec: bool;
+    origin:       sess.ModuleId;
+    decl:         id.DeclId;
+    a:            *ast.Ast;
+    file:         *src.SourceFile;
+    fields_start: u32;
+    fields_len:   u32;
+    is_rec:       bool;
 }
 
 # record_decl: the declaring site a record / union TypeId nominally refers to,
@@ -1311,7 +1314,13 @@ pub fun record_decl(w: *Workspace, root: *Root, tid: type.TypeId) Option[RecordS
     rs.a      = ?m.a;
     rs.file   = unwrap[*src.SourceFile](fo);
     rs.is_rec = is_rec;
-    if (is_rec) { rs.rec = d.data.rec_; }
+    if (is_rec) {
+        rs.fields_start = d.data.rec_.fields_start;
+        rs.fields_len   = d.data.rec_.fields_len;
+    } or {
+        rs.fields_start = d.data.uni_.fields_start;
+        rs.fields_len   = d.data.uni_.fields_len;
+    }
     ret some[RecordSite](rs);
 }
 

--- a/src/project.mach
+++ b/src/project.mach
@@ -1281,38 +1281,76 @@ pub rec RecordSite {
 }
 
 # record_decl: the declaring site a record / union TypeId nominally refers to,
-# resolved against the session's type interner and the root's module array — the
-# nominal back-link field features follow. peels a pointer to its pointee and maps
-# a generic instance to its template. none when `tid` is not a nominal type, the
-# declaring module is out of range, or the declaration is not a rec / uni. the
-# returned Ast / file pointers are owned by the loaded project / session.
+# resolved against the session's type interner and the root's loaded module array —
+# the nominal back-link field features follow. peels a pointer to its pointee and
+# maps a generic instance to its template. none when `tid` is not a nominal type,
+# the declaring module is not a loaded project module, or the declaration is not a
+# rec / uni. the returned Ast / file pointers are owned by the loaded project /
+# session. a record declared in the active buffer (whose synthetic module id is not
+# in the loaded array) is not found here — use `record_decl_in`, which falls back to
+# the buffer's live Ast for that case.
 # ---
 # w:    the workspace
 # root: the root the type was resolved under, or nil
 # tid:  a TypeId, typically read from a SemaResult via `type_of`
 # ret:  some(RecordSite), or none
 pub fun record_decl(w: *Workspace, root: *Root, tid: type.TypeId) Option[RecordSite] {
-    if (root == nil || !root.loaded) { ret none[RecordSite](); }
-    val no: Option[mtypes.Nominal] = mtypes.nominal_of(?w.s.types, tid);
+    val no: Option[mtypes.Nominal] = nominal_of_tid(w, root, tid);
     if (is_none[mtypes.Nominal](no)) { ret none[RecordSite](); }
     val n: mtypes.Nominal = unwrap[mtypes.Nominal](no);
 
     val m: *driver.ModuleEntry = module_entry(root, n.origin);
     if (m == nil) { ret none[RecordSite](); }
-    val d_opt: Option[*adecl.Decl] = ast.get_decl(?m.a, n.decl);
+    val fo: Option[*src.SourceFile] = src.get(?w.s.sources, m.file_id);
+    if (!is_some[*src.SourceFile](fo)) { ret none[RecordSite](); }
+    ret record_site_from(n.origin, n.decl, ?m.a, unwrap[*src.SourceFile](fo));
+}
+
+# record_decl_in: `record_decl` extended to resolve a record / union declared in
+# the active buffer. a buffer's own nominal type is interned under its synthetic
+# module id (`own`), which is not in the loaded module array, so `record_decl`
+# alone would miss a field access on a record the edited buffer itself declares.
+# when the nominal's origin is `own`, the declaration is read from the buffer's
+# live Ast / file (`own_a` / `own_file`); otherwise it defers to a loaded module.
+# ---
+# w:        the workspace
+# root:     the root the type was resolved under, or nil
+# own:      the buffer's own module id
+# own_a:    the buffer's live Ast
+# own_file: the buffer's SourceFile
+# tid:      a TypeId, typically read from a SemaResult via `type_of`
+# ret:      some(RecordSite), or none
+pub fun record_decl_in(w: *Workspace, root: *Root, own: sess.ModuleId, own_a: *ast.Ast, own_file: *src.SourceFile, tid: type.TypeId) Option[RecordSite] {
+    val no: Option[mtypes.Nominal] = nominal_of_tid(w, root, tid);
+    if (is_none[mtypes.Nominal](no)) { ret none[RecordSite](); }
+    val n: mtypes.Nominal = unwrap[mtypes.Nominal](no);
+    if (n.origin == own) { ret record_site_from(own, n.decl, own_a, own_file); }
+    ret record_decl(w, root, tid);
+}
+
+# nominal_of_tid: the nominal back-link of `tid` against the session type interner,
+# guarded on a loaded root. none when there is no project or `tid` is not nominal.
+fun nominal_of_tid(w: *Workspace, root: *Root, tid: type.TypeId) Option[mtypes.Nominal] {
+    if (root == nil || !root.loaded) { ret none[mtypes.Nominal](); }
+    ret mtypes.nominal_of(?w.s.types, tid);
+}
+
+# record_site_from: build a RecordSite for the rec / uni decl `decl` in `a` (backed
+# by `file`), or none when the decl is absent or not a rec / uni. the shared core
+# of `record_decl` / `record_decl_in` — both having chosen which Ast / file the
+# declaration lives in.
+fun record_site_from(origin: sess.ModuleId, decl: id.DeclId, a: *ast.Ast, file: *src.SourceFile) Option[RecordSite] {
+    val d_opt: Option[*adecl.Decl] = ast.get_decl(a, decl);
     if (is_none[*adecl.Decl](d_opt)) { ret none[RecordSite](); }
     val d: *adecl.Decl = unwrap[*adecl.Decl](d_opt);
     val is_rec: bool = d.kind == adecl.DECL_KIND_REC;
     if (!is_rec && d.kind != adecl.DECL_KIND_UNI) { ret none[RecordSite](); }
 
-    val fo: Option[*src.SourceFile] = src.get(?w.s.sources, m.file_id);
-    if (!is_some[*src.SourceFile](fo)) { ret none[RecordSite](); }
-
     var rs: RecordSite;
-    rs.origin = n.origin;
-    rs.decl   = n.decl;
-    rs.a      = ?m.a;
-    rs.file   = unwrap[*src.SourceFile](fo);
+    rs.origin = origin;
+    rs.decl   = decl;
+    rs.a      = a;
+    rs.file   = file;
     rs.is_rec = is_rec;
     if (is_rec) {
         rs.fields_start = d.data.rec_.fields_start;


### PR DESCRIPTION
Closes #106

Adds go-to-definition on record/union **fields**, building on the Phase 1 sema/type layer (#105).

## What it does

- Cursor on a member access `foo.bar` (the `.bar` name) jumps to the field's declaration.
- Cursor on a struct-literal field initializer `T{ bar: ... }` (the `bar` name) jumps to the field's declaration.
- Cursor on a field's own declaration site resolves to itself.
- Cross-module aware: the record may be declared in a dependency module; the location points at that module's on-disk file.

## How

- `features.field_ref_at` is the type-driven cursor pivot: name resolution leaves a value-field access unbound (`expr_resolved == SYMBOL_NIL`), so this recovers the field name and the receiver / literal type from the syntax.
- `features.field_decl_span` is the pure, session-free field-decl locator: it scans a record site's `typed_names` for the field whose name bytes match the referencing token (comparing across two source files for the cross-module case).
- `language.definition` consults the field path only when the symbol-table pivot returns nothing, so ordinary-symbol definition is unchanged.

## Scope

Go-to-definition on fields only. Field hover/docs, references, and rename are out of scope (later phases).

## Tests

Native `mach` unit tests for the locator; `mach build .` and `mach test .` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)