### PR TITLE
feat(hover): first-class docs from Decl.doc; field hover/docs

### DIFF
--- a/src/features.mach
+++ b/src/features.mach
@@ -47,6 +47,7 @@ use decl:   mach.lang.fe.ast.decl;
 use stmt:   mach.lang.fe.ast.stmt;
 use expr:   mach.lang.fe.ast.expr;
 use atype:  mach.lang.fe.ast.type;
+use fedoc:  mach.lang.fe.doc;
 use res:    mach.lang.fe.resolve;
 
 # SymbolRef: a symbol a position references, joined with the location of the
@@ -433,54 +434,64 @@ fun param_signature_span(a: *ast.Ast, sym: *res.Symbol) Option[token.Span] {
     ret some[token.Span](sp);
 }
 
-# doc_comment_span: the byte span of the contiguous run of `#` comment lines
-# immediately above a local symbol's declaration — its doc comment. the lexer
-# discards comment tokens, so this back-scans the file's line index the way
-# `mach doc` scans raw text: from the decl's line it walks backward over
-# comment lines (tolerating leading whitespace before the `#`), stopping at
-# the first non-comment line. none for a param / generic, a decl with no
-# comment run flush above it, or a decl on the first line.
+# doc_span_of: the first-class doc-block span the parser attached to a local
+# symbol's declaration (`Decl.doc`) — the `#`-comment run directly above the
+# decl with its `#[...]` attribute lines excluded, or none. the attribute-aware
+# replacement for the old source line-scan: it carries no `#[attr]` bytes, so the
+# rendered doc never folds in attribute syntax. none for a param / generic (which
+# carry no Decl node), a decl with no docstring (empty `doc` span), or an absent /
+# out-of-range decl.
 # ---
-# a:    the Ast owning the decl
-# sym:  the symbol whose doc comment is wanted
-# file: the source file owning the decl
-# ret:  some(span) covering the comment run (its line endings included), or none
-pub fun doc_comment_span(a: *ast.Ast, sym: *res.Symbol, file: *src.SourceFile) Option[token.Span] {
+# a:   the Ast owning the decl
+# sym: the symbol whose doc block is wanted
+# ret: some(span) covering the doc block within the file text, or none
+pub fun doc_span_of(a: *ast.Ast, sym: *res.Symbol) Option[token.Span] {
     if (sym.kind == res.SYM_PARAM || sym.kind == res.SYM_GENERIC) { ret none[token.Span](); }
-    val dso: Option[token.Span] = decl_span_of(a, sym);
-    if (!is_some[token.Span](dso)) { ret none[token.Span](); }
-    val decl_line: usize = src.position(file, unwrap[token.Span](dso).offset).line;
-
-    var first: usize = decl_line;
-    for (first > 1 && comment_line(file, first - 1)) { first = first - 1; }
-    if (first == decl_line) { ret none[token.Span](); }
-
-    val so: Option[usize] = src.line_start(file, first);
-    val eo: Option[usize] = src.line_start(file, decl_line);
-    if (!is_some[usize](so) || !is_some[usize](eo)) { ret none[token.Span](); }
-
-    var sp: token.Span;
-    sp.offset = unwrap[usize](so);
-    sp.len    = unwrap[usize](eo) - sp.offset;
-    ret some[token.Span](sp);
+    if (sym.decl == id.DECL_NIL) { ret none[token.Span](); }
+    val d_opt: Option[*decl.Decl] = ast.get_decl(a, sym.decl);
+    if (!is_some[*decl.Decl](d_opt)) { ret none[token.Span](); }
+    val d: *decl.Decl = unwrap[*decl.Decl](d_opt);
+    if (d.doc.len == 0) { ret none[token.Span](); }
+    ret some[token.Span](d.doc);
 }
 
-# first_nonspace: index of the first non-space, non-tab byte in `s` at or after
-# `pos`, clamped to `end`. shared by the doc-comment scan and its renderer.
-pub fun first_nonspace(s: *u8, pos: usize, end: usize) usize {
-    var i: usize = pos;
-    for (i < end && (s[i] == ' ' || s[i] == '\t')) { i = i + 1; }
-    ret i;
+# field_doc_desc: the description span of the component in the record / union doc
+# block `doc` whose component name matches the field name `field_name` — scanned
+# through `fe/doc.mach`'s component cursor, comparing each component's `name_span`
+# bytes against the field-name bytes. both spans index into the declaring module's
+# `source`, since the doc block and the field declaration share that file. none
+# when the doc block has no matching component, no component block at all, or an
+# empty matching description.
+# ---
+# source:     the declaring module's source text (both spans point into it)
+# doc:        the record / union declaration's `Decl.doc` span
+# field_name: the field's declared-name span in `source`
+# ret:        some(description span) for the matching component, or none
+pub fun field_doc_desc(source: str, doc: token.Span, field_name: token.Span) Option[token.Span] {
+    if (doc.len == 0 || field_name.len == 0) { ret none[token.Span](); }
+    var it: fedoc.DocComponentIter = fedoc.component_iter(source, doc);
+    var c: fedoc.DocComponent;
+    for (fedoc.component_next(?it, ?c)) {
+        if (same_source_span_equal(source, c.name_span, field_name)) {
+            if (c.desc_span.len == 0) { ret none[token.Span](); }
+            ret some[token.Span](c.desc_span);
+        }
+    }
+    ret none[token.Span]();
 }
 
-# comment_line: true when the 1-based `line`'s first significant byte is `#`.
-fun comment_line(file: *src.SourceFile, line: usize) bool {
-    val bo: Option[src.LineSpan] = src.line_bounds(file, line);
-    if (!is_some[src.LineSpan](bo)) { ret false; }
-    val lb: src.LineSpan = unwrap[src.LineSpan](bo);
-    val s: *u8 = file.text::*u8;
-    val i: usize = first_nonspace(s, lb.start, lb.end);
-    ret i < lb.end && s[i] == '#';
+# same_source_span_equal: true when spans `a` and `b` cover identical bytes within
+# the single source text `source`. the same-file analogue of `span_bytes_equal`,
+# used to match a doc component's name against a field name (both spans into the
+# declaring module's source).
+fun same_source_span_equal(source: str, a: token.Span, b: token.Span) bool {
+    if (a.len != b.len) { ret false; }
+    var i: usize = 0;
+    for (i < a.len) {
+        if (source[a.offset + i] != source[b.offset + i]) { ret false; }
+        i = i + 1;
+    }
+    ret true;
 }
 
 # kind_label: a human-readable label for a symbol kind, for hover rendering.

--- a/src/features.mach
+++ b/src/features.mach
@@ -999,3 +999,159 @@ test "features: field_decl_self_at hits a field name and misses elsewhere" {
     if (fail) { ret 1; }
     ret 0;
 }
+
+# add_doc_fun: append a function decl carrying the doc-block span `[doc_off,
+# doc_off + doc_len)` to `a`, returning its DeclId. the function payload is left
+# zeroed; only `kind` and `doc` matter for the doc-retrieval tests.
+fun add_doc_fun(a: *ast.Ast, doc_off: usize, doc_len: usize) id.DeclId {
+    var d: decl.Decl;
+    d.kind             = decl.DECL_KIND_FUN;
+    d.flags            = 0;
+    d.doc.offset       = doc_off;
+    d.doc.len          = doc_len;
+    d.decorators_start = 0;
+    d.decorators_len   = 0;
+    d.data.fun_.name.offset   = 0;
+    d.data.fun_.name.len      = 0;
+    d.data.fun_.generics_start = 0;
+    d.data.fun_.generics_len   = 0;
+    d.data.fun_.params_start   = 0;
+    d.data.fun_.params_len     = 0;
+    d.data.fun_.return_type    = id.TYPE_NIL;
+    d.data.fun_.body           = id.STMT_NIL;
+    val r: Result[id.DeclId, str] = ast.add_decl(a, d);
+    ret unwrap_ok[id.DeclId, str](r);
+}
+
+# fun_sym: a SYM_FUN symbol whose decl is `did`, for the doc-retrieval tests.
+fun fun_sym(did: id.DeclId) res.Symbol {
+    var s: res.Symbol;
+    s.kind   = res.SYM_FUN;
+    s.name   = intern.STR_NIL;
+    s.decl   = did;
+    s.slot   = 0;
+    s.origin = 0::sess.ModuleId;
+    ret s;
+}
+
+test "features: doc_span_of returns the decl's first-class doc span" {
+    var pa: Allocator;
+    page.make(?pa);
+    var a: ast.Ast = ast.init(?pa, 0::src.FileId);
+    val did: id.DeclId = add_doc_fun(?a, 4, 9);
+    var sym: res.Symbol = fun_sym(did);
+
+    var fail: bool = false;
+    val o: Option[token.Span] = doc_span_of(?a, ?sym);
+    if (is_none[token.Span](o)) { fail = true; }
+    or {
+        val sp: token.Span = unwrap[token.Span](o);
+        if (sp.offset != 4 || sp.len != 9) { fail = true; }
+    }
+
+    ast.dnit(?a);
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+test "features: doc_span_of returns none for a decl with no docstring" {
+    var pa: Allocator;
+    page.make(?pa);
+    var a: ast.Ast = ast.init(?pa, 0::src.FileId);
+    val did: id.DeclId = add_doc_fun(?a, 0, 0);   # empty doc span = no docstring
+    var sym: res.Symbol = fun_sym(did);
+
+    val ok: bool = is_none[token.Span](doc_span_of(?a, ?sym));
+    ast.dnit(?a);
+    if (!ok) { ret 1; }
+    ret 0;
+}
+
+test "features: doc_span_of returns none for a param symbol" {
+    var pa: Allocator;
+    page.make(?pa);
+    var a: ast.Ast = ast.init(?pa, 0::src.FileId);
+    val did: id.DeclId = add_doc_fun(?a, 4, 9);
+    var sym: res.Symbol = fun_sym(did);
+    sym.kind = res.SYM_PARAM;
+
+    val ok: bool = is_none[token.Span](doc_span_of(?a, ?sym));
+    ast.dnit(?a);
+    if (!ok) { ret 1; }
+    ret 0;
+}
+
+test "features: field_doc_desc finds the matching component's description" {
+    # the doc block and the rec body share one source, so the field-name query
+    # span and the component name span both point into `src` — the same-file
+    # match field_doc_desc performs in `field_hover_markdown`.
+    #             0         1         2         3         4         5         6         7         8         9
+    #             0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456
+    val src: str = "# a point\n# ---\n# x: the horizontal coordinate\n# y: the vertical coordinate\nrec P { x: i32; y: i32; }";
+    var doc: token.Span;
+    doc.offset = 0;
+    doc.len    = 75;   # through the end of the `# y: ...` component, before the rec body
+    # the rec-body field names: "x" at offset 84, "y" at offset 92.
+
+    var fail: bool = false;
+    # "y" field -> the "y" component description.
+    val oy: Option[token.Span] = field_doc_desc(src, doc, name_span_in(92, 1));
+    if (is_none[token.Span](oy)) { fail = true; }
+    or {
+        val sp: token.Span = unwrap[token.Span](oy);
+        if (!region_eq(src, sp, "the vertical coordinate")) { fail = true; }
+    }
+    # "x" field -> the "x" component description.
+    val ox: Option[token.Span] = field_doc_desc(src, doc, name_span_in(84, 1));
+    if (is_none[token.Span](ox)) { fail = true; }
+    or {
+        val sp: token.Span = unwrap[token.Span](ox);
+        if (!region_eq(src, sp, "the horizontal coordinate")) { fail = true; }
+    }
+
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+test "features: field_doc_desc returns none when no component matches" {
+    val src: str = "# a point\n# ---\n# x: the horizontal coordinate\nrec P { z: i32; }";
+    var doc: token.Span;
+    doc.offset = 0;
+    doc.len    = 46;
+    # "z" field name at offset 55 — no matching component.
+    val ok: bool = is_none[token.Span](field_doc_desc(src, doc, name_span_in(55, 1)));
+    if (!ok) { ret 1; }
+    ret 0;
+}
+
+test "features: field_doc_desc returns none for a summary-only doc block" {
+    val src: str = "# just a summary, no components\nrec P { x: i32; }";
+    var doc: token.Span;
+    doc.offset = 0;
+    doc.len    = 31;
+    # "x" field name at offset 40 — the block has no component lines.
+    val ok: bool = is_none[token.Span](field_doc_desc(src, doc, name_span_in(40, 1)));
+    if (!ok) { ret 1; }
+    ret 0;
+}
+
+# name_span_in: a span over `[offset, offset + len)`, the test builder for a
+# field-name query into the shared doc/body source.
+fun name_span_in(offset: usize, len: usize) token.Span {
+    var sp: token.Span;
+    sp.offset = offset;
+    sp.len    = len;
+    ret sp;
+}
+
+# region_eq: true when `span` of `source` equals the byte content of `expect`.
+fun region_eq(source: str, span: token.Span, expect: str) bool {
+    val n: usize = str_len(expect);
+    if (span.len != n) { ret false; }
+    var i: usize = 0;
+    for (i < n) {
+        if (source[span.offset + i] != expect[i]) { ret false; }
+        i = i + 1;
+    }
+    ret true;
+}

--- a/src/language.mach
+++ b/src/language.mach
@@ -27,7 +27,6 @@ use std.types.size.usize;
 use std.types.string.str;
 use std.types.string.str_len;
 use std.types.string.str_equals;
-use std.types.string.str_starts_with;
 use std.types.option.Option;
 use std.types.option.some;
 use std.types.option.none;
@@ -52,6 +51,8 @@ use token:  mach.lang.fe.token;
 use ast:    mach.lang.fe.ast;
 use id:     mach.lang.fe.ast.id;
 use decl:   mach.lang.fe.ast.decl;
+use atype:  mach.lang.fe.ast.type;
+use fedoc:  mach.lang.fe.doc;
 use res:    mach.lang.fe.resolve;
 use sema:   mach.lang.fe.sema;
 
@@ -93,7 +94,13 @@ pub fun hover(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocat
     val offset: usize = unwrap[usize](off_o);
 
     val ro: Option[features.SymbolRef] = features.ref_at(an.a, an.rr, an.own, offset);
-    if (!is_some[features.SymbolRef](ro)) { reply_null(alloc, id_raw); ret; }
+    if (!is_some[features.SymbolRef](ro)) {
+        # name resolution leaves a value-field access unbound, so a cursor on a
+        # field name yields no SymbolRef — fall through to the type-driven field
+        # hover before giving up.
+        if (field_hover(ws, alloc, ?an, offset, id_raw)) { ret; }
+        reply_null(alloc, id_raw); ret;
+    }
     val sr: features.SymbolRef = unwrap[features.SymbolRef](ro);
 
     val so: Option[*res.Symbol] = features.symbol(an.rr, sr.sym_id);
@@ -103,11 +110,18 @@ pub fun hover(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocat
     val md: str = hover_markdown(ws, an, sym, uri, alloc);
     if (md == nil) { reply_null(alloc, id_raw); ret; }
 
+    reply_hover(alloc, id_raw, an.file, sr.name_span, md);
+}
+
+# reply_hover: send a `textDocument/hover` reply rendering Markdown `md` over the
+# name span `name_span` in `file`, freeing `md` and `id_raw`. nil-replies when the
+# Markdown cannot be quoted. shared by the symbol and field hover paths.
+fun reply_hover(alloc: *Allocator, id_raw: str, file: *src.SourceFile, name_span: token.Span, md: str) {
     val qmd: str = json.quote(md, alloc);
     json.free_str(md, alloc);
     if (qmd == nil) { reply_null(alloc, id_raw); ret; }
 
-    val range: positions.LspRange = positions.range_of(an.file, sr.name_span);
+    val range: positions.LspRange = positions.range_of(file, name_span);
     val rng: str = range_json(range, alloc);
 
     val p1: str = "{\"jsonrpc\":\"2.0\",\"id\":";
@@ -119,6 +133,152 @@ pub fun hover(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocat
     json.free_str(rng, alloc);
     json.free_str(qmd, alloc);
     json.free_str(id_raw, alloc);
+}
+
+# field_hover: the type-driven hover path for a record / union field, consulted
+# when the symbol-table pivot finds nothing at `offset`. types the referencing
+# expression (a member access `foo.bar` or a struct-literal field name
+# `T{ bar: ... }`), peels it to its record site, and renders the field's name,
+# its declared type, and — when the record's doc block carries a matching
+# `# <name>: <desc>` component — that description. cross-module aware: the record
+# may be declared in a dependency module, in which case its Ast / file / doc all
+# come from the loaded module. emits the hover over the cursor's field-name span
+# and returns true when a field was rendered; returns false (without replying) so
+# the caller can fall back to a null reply. requires a loaded project root.
+# ---
+# ws:     the workspace
+# alloc:  request allocator
+# an:     the analyzed request document
+# offset: cursor byte offset into the buffer
+# id_raw: the raw JSON request id (for the reply)
+# ret:    true when a field hover was rendered and replied
+fun field_hover(ws: *project.Workspace, alloc: *Allocator, an: *Analyzed, offset: usize, id_raw: str) bool {
+    if (an.root == nil) { ret false; }
+
+    val fo: Option[features.FieldRef] = features.field_ref_at(an.a, offset);
+    if (!is_some[features.FieldRef](fo)) { ret false; }
+    val fr: features.FieldRef = unwrap[features.FieldRef](fo);
+
+    val sr_r: Result[*sema.SemaResult, str] = project.sema_doc(ws, an.root, an.fid);
+    if (is_err[*sema.SemaResult, str](sr_r)) { ret false; }
+    val sr: *sema.SemaResult = unwrap_ok[*sema.SemaResult, str](sr_r);
+
+    val tid: type.TypeId = project.type_of(sr, fr.host);
+    val rso: Option[project.RecordSite] = project.record_decl_in(ws, an.root, an.own, an.a, an.file, tid);
+    if (!is_some[project.RecordSite](rso)) { ret false; }
+    val rs: project.RecordSite = unwrap[project.RecordSite](rso);
+
+    val md: str = field_hover_markdown(rs, an.file, fr.name_span, alloc);
+    if (md == nil) { ret false; }
+
+    reply_hover(alloc, id_raw, an.file, fr.name_span, md);
+    ret true;
+}
+
+# field_hover_markdown: a fenced `mach` code block rendering a field as
+# `<name>: <type>`, with the field's matching doc component description following
+# as prose when present. the field is located by matching the cursor's field-name
+# bytes `query` (in `query_file`, the buffer) against the record site's declared
+# field names; name and type spans are read from the declaring module's source so
+# a cross-module field renders. nil when no field matches, the field name cannot
+# be read, or allocation fails. a field with no matching doc component renders the
+# `name: type` block alone (no description, no error).
+fun field_hover_markdown(rs: project.RecordSite, query_file: *src.SourceFile, query: token.Span, alloc: *Allocator) str {
+    val i: usize = field_index(rs, query_file, query);
+    if (i >= rs.fields_len::usize) { ret nil; }
+    val tn: *decl.TypedName = ?rs.a.typed_names[rs.fields_start + i::u32];
+
+    val name: str = positions.span_text(rs.file, tn.name, alloc);
+    if (name == nil) { ret nil; }
+    val ty: str = field_type_text(rs, tn, alloc);
+
+    var doc: str = nil;
+    val do_opt: Option[*decl.Decl] = ast.get_decl(rs.a, rs.decl);
+    if (is_some[*decl.Decl](do_opt)) {
+        val d: *decl.Decl = unwrap[*decl.Decl](do_opt);
+        val dso: Option[token.Span] = features.field_doc_desc(rs.file.text, d.doc, tn.name);
+        if (is_some[token.Span](dso)) { doc = doc_desc_prose(rs.file, unwrap[token.Span](dso), alloc); }
+    }
+
+    val r: str = compose_field_hover(name, ty, doc, alloc);
+    json.free_str(name, alloc);
+    json.free_str(ty, alloc);
+    json.free_str(doc, alloc);
+    ret r;
+}
+
+# field_index: the index into the record site's field range whose declared name
+# bytes equal `query` (in `query_file`), or fields_len when no field matches. the
+# cross-source byte compare lets the receiver and the declaration live in
+# different modules.
+fun field_index(rs: project.RecordSite, query_file: *src.SourceFile, query: token.Span) usize {
+    if (query.len == 0) { ret rs.fields_len::usize; }
+    var i: u32 = 0;
+    for (i < rs.fields_len) {
+        val tn: *decl.TypedName = ?rs.a.typed_names[rs.fields_start + i];
+        if (features.span_bytes_equal(rs.file, tn.name, query_file, query)) { ret i::usize; }
+        i = i + 1;
+    }
+    ret rs.fields_len::usize;
+}
+
+# field_type_text: the declared-type text of a field, read from the declaring
+# module's source (`TypedName.ty` -> its AST type span), or nil when the field
+# carries no type node. the declaring module's file backs the span, so a
+# cross-module field's type renders.
+fun field_type_text(rs: project.RecordSite, tn: *decl.TypedName, alloc: *Allocator) str {
+    if (tn.ty == id.TYPE_NIL) { ret nil; }
+    val to: Option[*atype.Type] = ast.get_type(rs.a, tn.ty);
+    if (!is_some[*atype.Type](to)) { ret nil; }
+    ret positions.span_text(rs.file, unwrap[*atype.Type](to).span, alloc);
+}
+
+# doc_desc_prose: render a single doc-component description span as prose,
+# folding its embedded comment-line breaks the way `doc_text` does. nil on an
+# empty span or allocation failure.
+fun doc_desc_prose(file: *src.SourceFile, span: token.Span, alloc: *Allocator) str {
+    if (span.len == 0) { ret nil; }
+    val source: str = file.text;
+    val total: usize = doc_text(nil, 0, source, span);
+    if (total == 0) { ret nil; }
+    val r: Result[*u8, str] = allocate[u8](alloc, total + 1);
+    if (is_err[*u8, str](r)) { ret nil; }
+    val buf: *u8 = unwrap_ok[*u8, str](r);
+    doc_text(buf, 0, source, span);
+    buf[total] = 0;
+    ret buf::str;
+}
+
+# compose_field_hover: assemble the field hover Markdown — a fenced `mach` block
+# of `name: type` (or just `name` when the type is unavailable), followed by the
+# description prose as a paragraph when present. nil on allocation failure.
+fun compose_field_hover(name: str, ty: str, doc: str, alloc: *Allocator) str {
+    val pre:  str = "```mach\n";
+    val post: str = "\n```";
+    val sep:  str = "\n\n";
+    val colon: str = ": ";
+
+    var total: usize = str_len(pre) + str_len(name) + str_len(post);
+    if (ty != nil)  { total = total + str_len(colon) + str_len(ty); }
+    if (doc != nil) { total = total + str_len(sep) + str_len(doc); }
+
+    val r: Result[*u8, str] = allocate[u8](alloc, total + 1);
+    if (is_err[*u8, str](r)) { ret nil; }
+    val buf: *u8 = unwrap_ok[*u8, str](r);
+    var off: usize = 0;
+    off = append(buf, off, pre);
+    off = append(buf, off, name);
+    if (ty != nil) {
+        off = append(buf, off, colon);
+        off = append(buf, off, ty);
+    }
+    off = append(buf, off, post);
+    if (doc != nil) {
+        off = append(buf, off, sep);
+        off = append(buf, off, doc);
+    }
+    buf[off] = 0;
+    ret buf::str;
 }
 
 # hover_markdown: a fenced `mach` code block rendering the symbol at hover. it
@@ -138,7 +298,7 @@ fun hover_markdown(ws: *project.Workspace, an: Analyzed, sym: *res.Symbol, uri: 
             if (is_some[token.Span](sso)) {
                 sig = positions.span_text(site.file, unwrap[token.Span](sso), alloc);
             }
-            val dso: Option[token.Span] = features.doc_comment_span(site.a, sym, site.file);
+            val dso: Option[token.Span] = features.doc_span_of(site.a, sym);
             if (is_some[token.Span](dso)) { doc = doc_prose(site.file, unwrap[token.Span](dso), alloc); }
         }
         project.free_site(ws, ?site);
@@ -170,117 +330,79 @@ fun hover_markdown(ws: *project.Workspace, an: Analyzed, sym: *res.Symbol, uri: 
     ret buf::str;
 }
 
-# break kinds threaded through doc_render: the join emitted before the next
-# rendered block — nothing, a soft newline, or a blank-line paragraph break.
-val DOC_BREAK_NONE: usize = 0;
-val DOC_BREAK_LINE: usize = 1;
-val DOC_BREAK_PARA: usize = 2;
-
-# doc_prose: render a doc-comment span (the contiguous `#` run above a decl) as
-# Markdown. prose lines before the first `# ---` separator are joined by single
-# newlines; the separator becomes a thematic break (`---` fenced by blank lines
-# so CommonMark reads a horizontal rule, not a setext heading); and each
-# `ident:` line in the trailing field stanza renders as a `- **ident** — desc`
-# list item, with indented continuation lines folded into the open item. one
+# doc_prose: render a declaration's first-class doc block (`Decl.doc`) as
+# Markdown. the block is read through `fe/doc.mach`: the summary becomes a prose
+# paragraph; when a `# ---` component block follows, a thematic break (`---`
+# fenced by blank lines so CommonMark reads a horizontal rule, not a setext
+# heading) precedes each `# <name>: <desc>` component rendered as a
+# `- **name** — desc` list item. because `Decl.doc` excludes the decl's `#[...]`
+# attribute lines, no attribute syntax can leak into the rendering. one
 # `doc_render` walk both sizes and fills the buffer, so the two passes cannot
-# diverge and the allocation is str_len + 1 as `json.free_str` expects. nil on
-# an empty span, a run carrying no rendered text, or allocation failure.
+# diverge and the allocation is str_len + 1 as `json.free_str` expects. nil on an
+# empty span, a block carrying no rendered text, or allocation failure.
+# ---
+# file:  the source file the doc span points into
+# span:  the declaration's `Decl.doc` span
+# alloc: request allocator
+# ret:   the rendered Markdown, or nil
 fun doc_prose(file: *src.SourceFile, span: token.Span, alloc: *Allocator) str {
     if (span.len == 0) { ret nil; }
-    val first: usize = src.position(file, span.offset).line;
-    val last:  usize = src.position(file, span.offset + span.len - 1).line;
+    val source: str = file.text;
 
     var has_text: bool = false;
-    val total: usize = doc_render(file, first, last, nil, ?has_text);
+    val total: usize = doc_render(source, span, nil, ?has_text);
     if (!has_text) { ret nil; }
 
     val r: Result[*u8, str] = allocate[u8](alloc, total + 1);
     if (is_err[*u8, str](r)) { ret nil; }
     val buf: *u8 = unwrap_ok[*u8, str](r);
 
-    doc_render(file, first, last, buf, ?has_text);
+    doc_render(source, span, buf, ?has_text);
     buf[total] = 0;
     ret buf::str;
 }
 
-# doc_render: walk doc-comment lines `first`..`last` (1-based) once, writing the
-# Markdown rendering into `buf` when it is non-nil and only measuring otherwise.
-# both the measure and fill passes share this walk, so the sized length and the
-# written bytes stay identical. sets `has_text` when any non-separator body byte
-# is rendered. returns the rendered length in bytes.
-fun doc_render(file: *src.SourceFile, first: usize, last: usize, buf: *u8, has_text: *bool) usize {
+# doc_render: walk a doc block once, writing the Markdown rendering into `buf`
+# when it is non-nil and only measuring otherwise. both passes share this walk so
+# the sized length and the written bytes stay identical. sets `has_text` when any
+# summary or component byte is rendered. returns the rendered length in bytes.
+fun doc_render(source: str, span: token.Span, buf: *u8, has_text: *bool) usize {
     @has_text = false;
-    var off:     usize = 0;
-    var stanza:  bool  = false;
-    var open:    bool  = false;
-    var pending: usize = DOC_BREAK_NONE;
+    var off: usize = 0;
 
-    var line: usize = first;
-    for (line <= last) {
-        if (doc_separator(file, line)) {
-            if (off > 0) { off = doc_break(buf, off, DOC_BREAK_PARA); }
+    val sum: token.Span = fedoc.summary_span(source, span);
+    if (sum.len > 0) {
+        off = doc_text(buf, off, source, sum);
+        @has_text = true;
+    }
+
+    var it: fedoc.DocComponentIter = fedoc.component_iter(source, span);
+    var c: fedoc.DocComponent;
+    var first: bool = true;
+    for (fedoc.component_next(?it, ?c)) {
+        if (first) {
+            if (off > 0) { off = doc_lf(buf, off); off = doc_lf(buf, off); }
             off = doc_emit(buf, off, "---");
-            stanza  = true;
-            open    = false;
-            pending = DOC_BREAK_PARA;
-            line = line + 1;
-            cnt;
+            first = false;
         }
-
-        val body: token.Span = doc_line_body(file, line);
-
-        if (stanza) {
-            var name: token.Span;
-            var desc: token.Span;
-            if (doc_field(file, body, ?name, ?desc)) {
-                off = doc_break(buf, off, pending);
-                off = doc_emit(buf, off, "- **");
-                off = doc_copy(buf, off, file, name);
-                off = doc_emit(buf, off, "** \xe2\x80\x94 ");
-                off = doc_copy(buf, off, file, desc);
-                @has_text = true;
-                open    = true;
-                pending = DOC_BREAK_LINE;
-                line = line + 1;
-                cnt;
-            }
-            if (open) {
-                if (body.len > 0) {
-                    off = doc_emit(buf, off, " ");
-                    off = doc_copy(buf, off, file, body);
-                    @has_text = true;
-                }
-                line = line + 1;
-                cnt;
-            }
-            off = doc_break(buf, off, pending);
-            off = doc_copy(buf, off, file, body);
-            if (body.len > 0) { @has_text = true; }
-            pending = DOC_BREAK_LINE;
-            line = line + 1;
-            cnt;
+        off = doc_lf(buf, off);
+        off = doc_emit(buf, off, "- **");
+        off = doc_text(buf, off, source, c.name_span);
+        off = doc_emit(buf, off, "**");
+        if (c.desc_span.len > 0) {
+            off = doc_emit(buf, off, " \xe2\x80\x94 ");
+            off = doc_text(buf, off, source, c.desc_span);
         }
-
-        off = doc_break(buf, off, pending);
-        off = doc_copy(buf, off, file, body);
-        if (body.len > 0) { @has_text = true; }
-        pending = DOC_BREAK_LINE;
-        line = line + 1;
+        @has_text = true;
     }
     ret off;
 }
 
-# doc_break: emit the join for break `kind` (none / soft newline / blank-line
-# paragraph) into `buf` when non-nil, returning the advanced offset.
-fun doc_break(buf: *u8, off: usize, kind: usize) usize {
-    if (kind == DOC_BREAK_NONE) { ret off; }
+# doc_lf: write a single newline into `buf` when non-nil, returning the advanced
+# offset.
+fun doc_lf(buf: *u8, off: usize) usize {
     if (buf != nil) { buf[off] = '\n'; }
-    off = off + 1;
-    if (kind == DOC_BREAK_PARA) {
-        if (buf != nil) { buf[off] = '\n'; }
-        off = off + 1;
-    }
-    ret off;
+    ret off + 1;
 }
 
 # doc_emit: write null-terminated `s` into `buf` at `off` when non-nil, only
@@ -291,80 +413,30 @@ fun doc_emit(buf: *u8, off: usize, s: str) usize {
     ret off + n;
 }
 
-# doc_copy: copy byte span `sp` of the file text into `buf` at `off` when
-# non-nil, only measuring its length otherwise, returning the advanced offset.
-fun doc_copy(buf: *u8, off: usize, file: *src.SourceFile, sp: token.Span) usize {
-    if (buf != nil && sp.len > 0) {
-        mem.raw_copy((buf::usize + off)::ptr, (file.text::usize + sp.offset)::ptr, sp.len);
+# doc_text: copy a summary / description span into `buf`, folding each embedded
+# comment-line break (`\n` then the next line's `#`, whitespace, and an optional
+# single space) into a single rendered space. a span returned by `fe/doc.mach`
+# spans only the first line's leading `#`; continuation lines keep their `#`
+# prefix, so this strips them to leave clean prose. measures when `buf` is nil.
+fun doc_text(buf: *u8, off: usize, source: str, sp: token.Span) usize {
+    val s: *u8 = source::*u8;
+    val end: usize = sp.offset + sp.len;
+    var i: usize = sp.offset;
+    for (i < end) {
+        if (s[i] == '\n') {
+            i = i + 1;
+            for (i < end && (s[i] == ' ' || s[i] == '\t')) { i = i + 1; }
+            if (i < end && s[i] == '#') { i = i + 1; }
+            for (i < end && (s[i] == ' ' || s[i] == '\t')) { i = i + 1; }
+            if (buf != nil) { buf[off] = ' '; }
+            off = off + 1;
+            cnt;
+        }
+        if (buf != nil) { buf[off] = s[i]; }
+        off = off + 1;
+        i = i + 1;
     }
-    ret off + sp.len;
-}
-
-# doc_line_body: the rendered slice of comment line `line` (1-based) as a byte
-# span into the file text — past the leading whitespace, `#`, and a single
-# following space. zero-length for an out-of-range line. unlike doc_separator
-# this does not special-case a `---` row, so callers see its raw text.
-fun doc_line_body(file: *src.SourceFile, line: usize) token.Span {
-    var sp: token.Span;
-    sp.offset = 0;
-    sp.len    = 0;
-    val bo: Option[src.LineSpan] = src.line_bounds(file, line);
-    if (!is_some[src.LineSpan](bo)) { ret sp; }
-    val lb: src.LineSpan = unwrap[src.LineSpan](bo);
-    val s: *u8 = file.text::*u8;
-    var i: usize = features.first_nonspace(s, lb.start, lb.end);
-    if (i < lb.end && s[i] == '#') { i = i + 1; }
-    if (i < lb.end && s[i] == ' ') { i = i + 1; }
-    sp.offset = i;
-    sp.len    = lb.end - i;
-    ret sp;
-}
-
-# doc_separator: true when comment `line`'s rendered body begins with `---`,
-# marking a stanza separator that renders as a horizontal rule.
-fun doc_separator(file: *src.SourceFile, line: usize) bool {
-    val body: token.Span = doc_line_body(file, line);
-    val s: *u8 = file.text::*u8;
-    ret str_starts_with((s::usize + body.offset)::str, "---");
-}
-
-# doc_field: when body span `body` is an `ident:` field row (an identifier, a
-# colon, then whitespace or end of line), write the identifier span into `name`
-# and the description span — past the colon and its alignment padding — into
-# `desc`, and return true. false for any non-field row.
-fun doc_field(file: *src.SourceFile, body: token.Span, name: *token.Span, desc: *token.Span) bool {
-    val s: *u8 = file.text::*u8;
-    val start: usize = body.offset;
-    val end:   usize = body.offset + body.len;
-    if (start >= end || !doc_ident_start(s[start])) { ret false; }
-
-    var i: usize = start + 1;
-    for (i < end && doc_ident_char(s[i])) { i = i + 1; }
-    if (i >= end || s[i] != ':') { ret false; }
-    val name_end: usize = i;
-    i = i + 1;
-    if (i < end && s[i] != ' ' && s[i] != '\t') { ret false; }
-
-    val d: usize = features.first_nonspace(s, i, end);
-    var nm: token.Span;
-    nm.offset = start;
-    nm.len    = name_end - start;
-    @name = nm;
-    var ds: token.Span;
-    ds.offset = d;
-    ds.len    = end - d;
-    @desc = ds;
-    ret true;
-}
-
-# doc_ident_start: true when `c` may begin a field identifier.
-fun doc_ident_start(c: u8) bool {
-    ret (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_';
-}
-
-# doc_ident_char: true when `c` may continue a field identifier.
-fun doc_ident_char(c: u8) bool {
-    ret doc_ident_start(c) || (c >= '0' && c <= '9');
+    ret off;
 }
 
 # compose_kind_name: a `<kind> <name>` rendering for a symbol with no local


### PR DESCRIPTION
Closes #108

## What

- **Hover reads `Decl.doc`.** `features.doc_comment_span` (a source line-scan that mis-folded `#[attr]` lines into the rendered doc) is replaced by `features.doc_span_of`, which returns the parser's attribute-aware `Decl.doc` span. The hover renderer (`doc_prose` / `doc_render`) now drives off `mach.lang.fe.doc` — `summary_span` for the prose paragraph, `component_iter` / `component_next` for `# <name>: <desc>` components rendered as `- **name** — desc` list items. Because `Decl.doc` excludes the decl's `#[...]` lines, attribute syntax can no longer leak into hover.
- **Field hover/docs.** A field reference (member access or struct-literal field name) with no symbol-table binding falls through to `field_hover`: it types the host expression, peels it to its record/union site via `record_decl_in`, and renders the field name, its declared type (from `TypedName.ty`), and the matching component description from the record's `DeclRec.doc` (`features.field_doc_desc`). Cross-module aware; no doc or no matching component renders `name: type` with no description and no error.
- The old line-scan helpers (`doc_comment_span`, `first_nonspace`, `comment_line`, `doc_line_body`, `doc_separator`, `doc_field`, `doc_ident_*`) are removed — the first-class span makes them dead.

## Scope

Hover/docs only. References and rename for fields are the next phase. `mach doc` (the compiler) is unaffected.

## Tests

Native mach unit tests cover doc retrieval from `Decl.doc` (summary-only, with components, no-doc) and the field-doc component lookup (match, no-match, cross-source bytes). `mach build .` + `mach test .` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)