### PR TITLE
feat(rename): field references + docstring-aware rename

### DIFF
--- a/src/features.mach
+++ b/src/features.mach
@@ -39,6 +39,7 @@ use page: std.allocator.page;
 use sess:   mach.lang.session;
 use src:    mach.lang.source;
 use intern: mach.lang.intern;
+use type:   mach.lang.type;
 use token:  mach.lang.fe.token;
 use ast:    mach.lang.fe.ast;
 use id:     mach.lang.fe.ast.id;
@@ -49,6 +50,9 @@ use expr:   mach.lang.fe.ast.expr;
 use atype:  mach.lang.fe.ast.type;
 use fedoc:  mach.lang.fe.doc;
 use res:    mach.lang.fe.resolve;
+use sema:   mach.lang.fe.sema;
+
+use mtypes: mls.types;
 
 # SymbolRef: a symbol a position references, joined with the location of the
 # name token that referenced it.
@@ -823,6 +827,157 @@ pub fun field_decl_self_at(decl_a: *ast.Ast, fields_start: u32, fields_len: u32,
         i = i + 1;
     }
     ret none[token.Span]();
+}
+
+# FieldKey: the cross-module identity of a record / union field — the nominal
+# declaration site of its record (`origin`, `decl`) paired with the field name as
+# bytes in the declaring module's source. the field-reference / field-rename walk
+# carries it across every loaded module: a member access or struct-literal init
+# names this field iff its host expression's type peels to the keyed record and the
+# referenced name bytes equal the keyed field name. the name is held as a file +
+# span (not interned) because a field has no Symbol and so no StrId.
+# ---
+# origin:     ModuleId of the module declaring the record / union
+# decl:       DeclId of the rec / uni declaration in `origin`'s Ast
+# decl_file:  SourceFile backing the declaring module (the field-name bytes)
+# field_name: byte span of the field's declared name in `decl_file`
+pub rec FieldKey {
+    origin:     sess.ModuleId;
+    decl:       id.DeclId;
+    decl_file:  *src.SourceFile;
+    field_name: token.Span;
+}
+
+# field_ref_span_at: the field-name span of expr `eid` in module (`a`, `sr`) when
+# it references the keyed field, or none. the field analogue of `expr_ref_span`:
+# resolution never binds a value-field access, so a field reference is recovered
+# by typing the host expression and peeling it to its record's nominal site rather
+# than reading a Symbol. two expression shapes name a field:
+#   - a member access `obj.field`: types the receiver `member.object` and, when
+#     that peels to the keyed record and the member name bytes equal the field
+#     name, yields the member name span;
+#   - a struct literal `T{ field: ... }`: types the literal itself and, when that
+#     peels to the keyed record, yields the matching init-name span.
+# the host type is read from `sr` (the module's SemaResult) and peeled through the
+# session type interner `ti`, so a field reached through `*T` or a generic instance
+# of the record matches the same key. pure over (`a`, `sr`, `ti`) — the caller
+# walks `[0, a.expr_len)` feeding the spans this returns to a sink.
+# ---
+# a:    the module's parsed Ast
+# sr:   the module's SemaResult (per-expr typing)
+# ti:   the session type interner (for nominal peeling)
+# eid:  the expr id to test
+# qf:   the SourceFile backing `a` (the referenced name bytes)
+# key:  the field identity to match
+# ret:  some(name span) when `eid` references the keyed field, or none
+pub fun field_ref_span_at(a: *ast.Ast, sr: *sema.SemaResult, ti: *type.TypeInterner, eid: id.ExprId, qf: *src.SourceFile, key: FieldKey) Option[token.Span] {
+    val eo: Option[*expr.Expr] = ast.get_expr(a, eid);
+    if (!is_some[*expr.Expr](eo)) { ret none[token.Span](); }
+    val e: *expr.Expr = unwrap[*expr.Expr](eo);
+
+    if (e.kind == expr.EXPR_KIND_MEMBER) {
+        if (!host_matches(sr, ti, e.data.member.object, key)) { ret none[token.Span](); }
+        if (!span_bytes_equal(qf, e.data.member.name, key.decl_file, key.field_name)) { ret none[token.Span](); }
+        ret some[token.Span](e.data.member.name);
+    }
+
+    if (e.kind == expr.EXPR_KIND_STRUCT_LIT) {
+        if (!host_matches(sr, ti, eid, key)) { ret none[token.Span](); }
+        val start: u32 = e.data.struct_lit.fields_start;
+        val len:   u32 = e.data.struct_lit.fields_len;
+        var i: u32 = 0;
+        for (i < len) {
+            val fi: *expr.FieldInit = ?a.field_inits[start + i];
+            if (span_bytes_equal(qf, fi.name, key.decl_file, key.field_name)) {
+                ret some[token.Span](fi.name);
+            }
+            i = i + 1;
+        }
+    }
+
+    ret none[token.Span]();
+}
+
+# host_matches: whether host expression `eid`'s type peels to the keyed record's
+# nominal declaration site. the type-identity half of `field_ref_span_at`: a
+# member receiver or a struct literal whose `(origin, decl)` equals the key names
+# the same record across modules, regardless of pointer / generic-instance wrapping
+# (peeled by `nominal_of`).
+fun host_matches(sr: *sema.SemaResult, ti: *type.TypeInterner, eid: id.ExprId, key: FieldKey) bool {
+    val tid: type.TypeId = mtypes.type_of(sr, eid);
+    val no: Option[mtypes.Nominal] = mtypes.nominal_of(ti, tid);
+    if (is_none[mtypes.Nominal](no)) { ret false; }
+    val n: mtypes.Nominal = unwrap[mtypes.Nominal](no);
+    ret n.origin == key.origin && n.decl == key.decl;
+}
+
+# doc_component_name_span: the byte span to rewrite when a doc component's name is
+# renamed — the component in doc block `doc` (within `source`) whose name matches
+# the binding `query` (in `qf`), narrowed to the exact identifier token a rename
+# replaces. for a field or value parameter the component head is `# <name>:` and
+# the whole component `name_span` is the identifier, so it is returned as-is. for a
+# generic the component head keeps its syntactic `# [T]:` bracket form (see
+# `mach.lang.fe.doc`), so the returned span is the inner `T` only — the brackets
+# are preserved. none when no component matches, or (for a generic) the matched
+# component carries no bracketed identifier. matching compares the inner identifier
+# against `query` so a `# [T]:` head matches the generic named `T`.
+# ---
+# source:      the declaring module's source text (the doc block points into it)
+# doc:         the owning decl's `Decl.doc` span
+# qf:          the SourceFile backing `query`
+# query:       byte span of the field / param / generic binding name
+# is_generic:  true to match / rewrite the bracket form `# [T]:`
+# ret:         some(span to rewrite) for the matching component, or none
+pub fun doc_component_name_span(source: str, doc: token.Span, qf: *src.SourceFile, query: token.Span, is_generic: bool) Option[token.Span] {
+    if (doc.len == 0 || query.len == 0) { ret none[token.Span](); }
+    var it: fedoc.DocComponentIter = fedoc.component_iter(source, doc);
+    var c: fedoc.DocComponent;
+    for (fedoc.component_next(?it, ?c)) {
+        val ident: token.Span = component_ident(source, c.name_span, is_generic);
+        if (ident.len == 0) { cnt; }
+        if (span_bytes_equal_2(source, ident, qf, query)) { ret some[token.Span](ident); }
+    }
+    ret none[token.Span]();
+}
+
+# component_ident: the identifier token within a component name span — the whole
+# span for a plain `name`, or the bracketed inner identifier for a generic's `[T]`
+# head. an empty span when a generic head has no `[...]` enclosed single-word
+# identifier. the narrowing `doc_component_name_span` applies so a generic rename
+# rewrites `T` inside `[T]` without disturbing the brackets.
+fun component_ident(source: str, name: token.Span, is_generic: bool) token.Span {
+    if (!is_generic) { ret name; }
+    if (name.len < 3) { ret empty_span(); }
+    val lo: usize = name.offset;
+    val hi: usize = name.offset + name.len;
+    if (source[lo] != '[' || source[hi - 1] != ']') { ret empty_span(); }
+    var sp: token.Span;
+    sp.offset = lo + 1;
+    sp.len    = (hi - 1) - (lo + 1);
+    ret sp;
+}
+
+# empty_span: a zero-length span, the "absent" marker for component_ident.
+fun empty_span() token.Span {
+    var s: token.Span;
+    s.offset = 0;
+    s.len    = 0;
+    ret s;
+}
+
+# span_bytes_equal_2: true when span `sa` in `source` and span `sb` in `fb` cover
+# identical bytes. a cross-source compare where one side is a raw `str` (a doc
+# block lives in the declaring module's source) and the other a SourceFile (the
+# binding name) — bridging `same_source_span_equal` and `span_bytes_equal`.
+fun span_bytes_equal_2(source: str, sa: token.Span, fb: *src.SourceFile, sb: token.Span) bool {
+    if (sa.len != sb.len) { ret false; }
+    val b: *u8 = fb.text::*u8;
+    var i: usize = 0;
+    for (i < sa.len) {
+        if (source[sa.offset + i] != b[sb.offset + i]) { ret false; }
+        i = i + 1;
+    }
+    ret true;
 }
 
 # span_bytes_equal: true when the bytes of `sa` in `fa` exactly equal the bytes of

--- a/src/features.mach
+++ b/src/features.mach
@@ -34,6 +34,8 @@ use std.types.result.is_err;
 use std.types.result.unwrap_ok;
 
 use std.allocator.Allocator;
+use std.allocator.allocate;
+use std.allocator.deallocate;
 use page: std.allocator.page;
 
 use sess:   mach.lang.session;
@@ -911,6 +913,48 @@ fun host_matches(sr: *sema.SemaResult, ti: *type.TypeInterner, eid: id.ExprId, k
     ret n.origin == key.origin && n.decl == key.decl;
 }
 
+# collect_field_sites: write into `out` (up to `cap` spans) every site naming the
+# keyed field in module (`a`, `sr`) and return the count. the spans are, in walk
+# order: every member-access / struct-literal init whose host type peels to the
+# keyed record (`field_ref_span_at` over `[0, a.expr_len)`), and — when `declaring`
+# (this module declares the record) — the field declaration's own name span, then
+# (when `want_doc` and the record's `doc` block carries a matching component) that
+# component's name token. this is the complete edit set a field rename applies to
+# one module and the location set references reports; it is pulled out of the JSON
+# emission so it can be asserted directly. the doc block is read from the declaring
+# module's source (`decl_src`), the same file `key.field_name` indexes into.
+# ---
+# a:         the module's Ast
+# sr:        the module's SemaResult
+# ti:        the session type interner
+# qf:        the SourceFile backing `a`
+# key:       the field identity
+# declaring: true when this module declares the record
+# want_doc:  true to include the doc component (rename); false for references
+# decl_src:  the declaring module's source text (for the doc block)
+# doc:       the record decl's `Decl.doc` span (empty when none)
+# out:       array of at least `cap` Span slots
+# cap:       capacity of `out`
+# ret:       number of spans written
+pub fun collect_field_sites(a: *ast.Ast, sr: *sema.SemaResult, ti: *type.TypeInterner, qf: *src.SourceFile, key: FieldKey, declaring: bool, want_doc: bool, decl_src: str, doc: token.Span, out: *token.Span, cap: usize) usize {
+    var n: usize = 0;
+    var ei: usize = 0;
+    for (ei < a.expr_len && n < cap) {
+        val so: Option[token.Span] = field_ref_span_at(a, sr, ti, ei::id.ExprId, qf, key);
+        if (is_some[token.Span](so)) { out[n] = unwrap[token.Span](so); n = n + 1; }
+        ei = ei + 1;
+    }
+    if (declaring && n < cap) {
+        out[n] = key.field_name;
+        n = n + 1;
+        if (want_doc && doc.len != 0 && n < cap) {
+            val co: Option[token.Span] = doc_component_name_span(decl_src, doc, key.decl_file, key.field_name, false);
+            if (is_some[token.Span](co)) { out[n] = unwrap[token.Span](co); n = n + 1; }
+        }
+    }
+    ret n;
+}
+
 # doc_component_name_span: the byte span to rewrite when a doc component's name is
 # renamed — the component in doc block `doc` (within `source`) whose name matches
 # the binding `query` (in `qf`), narrowed to the exact identifier token a rename
@@ -1309,4 +1353,439 @@ fun region_eq(source: str, span: token.Span, expect: str) bool {
         i = i + 1;
     }
     ret true;
+}
+
+# fk: a FieldKey naming the field at `[off, off + len)` in `decl_file` of the
+# record (`origin`, `decl`), the test builder for the field-reference matcher.
+fun fk(origin: u32, decl: u32, decl_file: *src.SourceFile, off: usize, len: usize) FieldKey {
+    var k: FieldKey;
+    k.origin     = origin::sess.ModuleId;
+    k.decl       = decl::id.DeclId;
+    k.decl_file  = decl_file;
+    k.field_name = span_at(off, len);
+    ret k;
+}
+
+# mk_sema: a standalone SemaResult with an `expr_type` array of `n` slots, every
+# slot TYPE_NIL. the test stand-in for sema's own typing output, so the field
+# matcher can be driven without a whole analysis. released with `free_sema`.
+fun mk_sema(pa: *Allocator, n: u32) sema.SemaResult {
+    var sr: sema.SemaResult;
+    sr.alloc            = pa;
+    sr.expr_type        = nil;
+    sr.type_resolved_ty = nil;
+    sr.decl_type        = nil;
+    sr.expr_count       = 0;
+    sr.type_count       = 0;
+    sr.decl_count       = 0;
+    if (n > 0) {
+        val r: Result[*type.TypeId, str] = allocate[type.TypeId](pa, n::usize);
+        if (!is_err[*type.TypeId, str](r)) {
+            sr.expr_type  = unwrap_ok[*type.TypeId, str](r);
+            sr.expr_count = n;
+            var i: u32 = 0;
+            for (i < n) { sr.expr_type[i] = type.TYPE_NIL; i = i + 1; }
+        }
+    }
+    ret sr;
+}
+
+fun free_sema(pa: *Allocator, sr: *sema.SemaResult) {
+    if (sr.expr_type != nil && sr.expr_count > 0) {
+        deallocate[type.TypeId](pa, sr.expr_type, sr.expr_count::usize);
+    }
+}
+
+# add_ident: append an IDENT expr spanning `[off, off + len)`, returning its id.
+# the receiver of a member access is an IDENT whose type the SemaResult carries.
+fun add_ident(a: *ast.Ast, off: usize, len: usize) id.ExprId {
+    var e: expr.Expr;
+    e.span = span_at(off, len);
+    e.kind = expr.EXPR_KIND_IDENT;
+    val r: Result[id.ExprId, str] = ast.add_expr(a, e);
+    ret unwrap_ok[id.ExprId, str](r);
+}
+
+# add_member: append a member access `obj.<name>` where `obj` is expr `object`
+# and the field-name token spans `[name_off, name_off + name_len)`, returning the
+# member expr id.
+fun add_member(a: *ast.Ast, object: id.ExprId, name_off: usize, name_len: usize) id.ExprId {
+    var e: expr.Expr;
+    e.span = span_at(name_off, name_len);
+    e.kind = expr.EXPR_KIND_MEMBER;
+    e.data.member.object = object;
+    e.data.member.name   = span_at(name_off, name_len);
+    val r: Result[id.ExprId, str] = ast.add_expr(a, e);
+    ret unwrap_ok[id.ExprId, str](r);
+}
+
+# add_struct_lit: append a struct literal with a single field init named over
+# `[name_off, name_off + name_len)`, returning the struct-lit expr id.
+fun add_struct_lit(a: *ast.Ast, name_off: usize, name_len: usize) id.ExprId {
+    var fi: expr.FieldInit;
+    fi.name  = span_at(name_off, name_len);
+    fi.value = id.EXPR_NIL;
+    val fr: Result[u32, str] = ast.add_field_init(a, fi);
+    val start: u32 = unwrap_ok[u32, str](fr);
+
+    var e: expr.Expr;
+    e.span = span_at(name_off, name_len);
+    e.kind = expr.EXPR_KIND_STRUCT_LIT;
+    e.data.struct_lit.ty           = id.TYPE_NIL;
+    e.data.struct_lit.fields_start = start;
+    e.data.struct_lit.fields_len   = 1;
+    val r: Result[id.ExprId, str] = ast.add_expr(a, e);
+    ret unwrap_ok[id.ExprId, str](r);
+}
+
+test "features: field_ref_span_at matches a member access of the keyed record" {
+    var pa: Allocator;
+    page.make(?pa);
+    var a: ast.Ast = ast.init(?pa, 0::src.FileId);
+    var ti: type.TypeInterner = unwrap_ok[type.TypeInterner, str](type.init(?pa));
+    # the record P is declared in module 2, decl 4; its field "x" lives at offset
+    # 8 of the declaring source. the buffer text "p.x" carries the member access.
+    val recp: type.TypeId = unwrap_ok[type.TypeId, str](
+        type.intern_nominal(?ti, intern.STR_NIL, 2::sess.ModuleId, 4::id.DeclId, type.TYPE_REC));
+    var declf: src.SourceFile = stub_file("rec P { x: i32; }");   # "x" at offset 8
+    var buf:   src.SourceFile = stub_file("p.x");
+
+    # expr 0 = receiver "p" (typed P); expr 1 = member access "p.x" (name "x"@2).
+    val recv: id.ExprId = add_ident(?a, 0, 1);
+    val mem:  id.ExprId = add_member(?a, recv, 2, 1);
+    var sr: sema.SemaResult = mk_sema(?pa, 2);
+    sr.expr_type[recv] = recp;
+
+    val key: FieldKey = fk(2, 4, ?declf, 8, 1);
+    var fail: bool = false;
+    val o: Option[token.Span] = field_ref_span_at(?a, ?sr, ?ti, mem, ?buf, key);
+    if (is_none[token.Span](o)) { fail = true; }
+    or {
+        val sp: token.Span = unwrap[token.Span](o);
+        if (sp.offset != 2 || sp.len != 1) { fail = true; }
+    }
+    # the receiver IDENT itself is not a member access — no field span.
+    if (is_some[token.Span](field_ref_span_at(?a, ?sr, ?ti, recv, ?buf, key))) { fail = true; }
+
+    free_sema(?pa, ?sr);
+    type.dnit(?ti);
+    ast.dnit(?a);
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+test "features: field_ref_span_at peels a pointer receiver to the record" {
+    var pa: Allocator;
+    page.make(?pa);
+    var a: ast.Ast = ast.init(?pa, 0::src.FileId);
+    var ti: type.TypeInterner = unwrap_ok[type.TypeInterner, str](type.init(?pa));
+    val recp: type.TypeId = unwrap_ok[type.TypeId, str](
+        type.intern_nominal(?ti, intern.STR_NIL, 1::sess.ModuleId, 0::id.DeclId, type.TYPE_REC));
+    val ptr: type.TypeId = unwrap_ok[type.TypeId, str](type.intern_pointer(?ti, recp));
+    var declf: src.SourceFile = stub_file("name");   # "name" at offset 0
+    var buf:   src.SourceFile = stub_file("q.name");
+
+    val recv: id.ExprId = add_ident(?a, 0, 1);
+    val mem:  id.ExprId = add_member(?a, recv, 2, 4);   # ".name"
+    var sr: sema.SemaResult = mk_sema(?pa, 2);
+    sr.expr_type[recv] = ptr;   # *P
+
+    val key: FieldKey = fk(1, 0, ?declf, 0, 4);
+    val ok: bool = is_some[token.Span](field_ref_span_at(?a, ?sr, ?ti, mem, ?buf, key));
+
+    free_sema(?pa, ?sr);
+    type.dnit(?ti);
+    ast.dnit(?a);
+    if (!ok) { ret 1; }
+    ret 0;
+}
+
+test "features: field_ref_span_at matches a struct-literal field init" {
+    var pa: Allocator;
+    page.make(?pa);
+    var a: ast.Ast = ast.init(?pa, 0::src.FileId);
+    var ti: type.TypeInterner = unwrap_ok[type.TypeInterner, str](type.init(?pa));
+    val recp: type.TypeId = unwrap_ok[type.TypeId, str](
+        type.intern_nominal(?ti, intern.STR_NIL, 3::sess.ModuleId, 1::id.DeclId, type.TYPE_REC));
+    var declf: src.SourceFile = stub_file("rec P { x: i32; }");   # "x" at offset 8
+    var buf:   src.SourceFile = stub_file("P{ x: 1 }");           # init "x" at offset 3
+
+    # expr 0 = the struct literal itself, typed P; its single init names "x"@3.
+    val lit: id.ExprId = add_struct_lit(?a, 3, 1);
+    var sr: sema.SemaResult = mk_sema(?pa, 1);
+    sr.expr_type[lit] = recp;
+
+    val key: FieldKey = fk(3, 1, ?declf, 8, 1);
+    var fail: bool = false;
+    val o: Option[token.Span] = field_ref_span_at(?a, ?sr, ?ti, lit, ?buf, key);
+    if (is_none[token.Span](o)) { fail = true; }
+    or {
+        val sp: token.Span = unwrap[token.Span](o);
+        if (sp.offset != 3 || sp.len != 1) { fail = true; }
+    }
+
+    free_sema(?pa, ?sr);
+    type.dnit(?ti);
+    ast.dnit(?a);
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+test "features: field_ref_span_at rejects a different record and a different field" {
+    var pa: Allocator;
+    page.make(?pa);
+    var a: ast.Ast = ast.init(?pa, 0::src.FileId);
+    var ti: type.TypeInterner = unwrap_ok[type.TypeInterner, str](type.init(?pa));
+    val recp: type.TypeId = unwrap_ok[type.TypeId, str](
+        type.intern_nominal(?ti, intern.STR_NIL, 2::sess.ModuleId, 4::id.DeclId, type.TYPE_REC));
+    var declf: src.SourceFile = stub_file("rec P { x: i32; }");   # "x" at offset 8
+    var buf:   src.SourceFile = stub_file("p.x");
+
+    val recv: id.ExprId = add_ident(?a, 0, 1);
+    val mem:  id.ExprId = add_member(?a, recv, 2, 1);
+    var sr: sema.SemaResult = mk_sema(?pa, 2);
+    sr.expr_type[recv] = recp;
+
+    var fail: bool = false;
+    # right record, wrong field name ("y" vs the access "x"): no match.
+    var decly: src.SourceFile = stub_file("y");
+    if (is_some[token.Span](field_ref_span_at(?a, ?sr, ?ti, mem, ?buf, fk(2, 4, ?decly, 0, 1)))) { fail = true; }
+    # right field name, wrong record identity (decl 9): no match.
+    if (is_some[token.Span](field_ref_span_at(?a, ?sr, ?ti, mem, ?buf, fk(2, 9, ?declf, 8, 1)))) { fail = true; }
+    # receiver untyped (TYPE_NIL): no match.
+    sr.expr_type[recv] = type.TYPE_NIL;
+    if (is_some[token.Span](field_ref_span_at(?a, ?sr, ?ti, mem, ?buf, fk(2, 4, ?declf, 8, 1)))) { fail = true; }
+
+    free_sema(?pa, ?sr);
+    type.dnit(?ti);
+    ast.dnit(?a);
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+# empty_doc: a zero-length doc span, for the no-doc test cases.
+fun empty_doc() token.Span {
+    var d: token.Span;
+    d.offset = 0;
+    d.len    = 0;
+    ret d;
+}
+
+test "features: collect_field_sites gathers every site, the decl, and the doc component (rename)" {
+    var pa: Allocator;
+    page.make(?pa);
+    var a: ast.Ast = ast.init(?pa, 0::src.FileId);
+    var ti: type.TypeInterner = unwrap_ok[type.TypeInterner, str](type.init(?pa));
+    val recp: type.TypeId = unwrap_ok[type.TypeId, str](
+        type.intern_nominal(?ti, intern.STR_NIL, 0::sess.ModuleId, 4::id.DeclId, type.TYPE_REC));
+
+    # the declaring module's source: the doc block then `rec P { x: i32; y: i32; }`.
+    # the doc `# x:` component name is at offset 18 (after "# a point\n# ---\n# ").
+    val declsrc: str = "# a point\n# ---\n# x: the abscissa\nrec P { x: i32; y: i32; }";
+    var declf: src.SourceFile = stub_file(declsrc);
+    var doc: token.Span;
+    doc.offset = 0;
+    doc.len    = 33;   # through the `# x: ...` component, before the rec body
+    # the field "x" name in the rec body sits at offset 42 (within `rec P { x`).
+    val xoff: usize = 42;
+
+    # the module under walk also contains two member accesses and a struct lit on x.
+    var buf: src.SourceFile = stub_file("p.x q.x P{ x: 1 }");
+    val r1: id.ExprId = add_ident(?a, 0, 1);          # "p"
+    val m1: id.ExprId = add_member(?a, r1, 2, 1);     # "p.x" name @2
+    val r2: id.ExprId = add_ident(?a, 4, 1);          # "q"
+    val m2: id.ExprId = add_member(?a, r2, 6, 1);     # "q.x" name @6
+    val lit: id.ExprId = add_struct_lit(?a, 11, 1);   # "P{ x" name @11
+    var sr: sema.SemaResult = mk_sema(?pa, 5);
+    sr.expr_type[r1]  = recp;
+    sr.expr_type[r2]  = recp;
+    sr.expr_type[lit] = recp;
+
+    val key: FieldKey = fk(0, 4, ?declf, xoff, 1);
+    var out: [8]token.Span;
+
+    var fail: bool = false;
+    # rename over the declaring module: two members, one init, the decl, the doc.
+    val n: usize = collect_field_sites(?a, ?sr, ?ti, ?buf, key, true, true, declsrc, doc, ?out[0], 8);
+    if (n != 5) { fail = true; }
+    or {
+        # the three body sites in walk order: m1@2, m2@6, lit@11.
+        if (out[0].offset != 2  || out[0].len != 1) { fail = true; }
+        if (out[1].offset != 6  || out[1].len != 1) { fail = true; }
+        if (out[2].offset != 11 || out[2].len != 1) { fail = true; }
+        # the field declaration name.
+        if (out[3].offset != xoff || out[3].len != 1) { fail = true; }
+        # the doc component name token "x" at offset 18.
+        if (!region_eq(declsrc, out[4], "x")) { fail = true; }
+        if (declsrc[out[4].offset - 2] != '#') { fail = true; }
+    }
+
+    free_sema(?pa, ?sr);
+    type.dnit(?ti);
+    ast.dnit(?a);
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+test "features: collect_field_sites omits the doc component for references (want_doc false)" {
+    var pa: Allocator;
+    page.make(?pa);
+    var a: ast.Ast = ast.init(?pa, 0::src.FileId);
+    var ti: type.TypeInterner = unwrap_ok[type.TypeInterner, str](type.init(?pa));
+    val recp: type.TypeId = unwrap_ok[type.TypeId, str](
+        type.intern_nominal(?ti, intern.STR_NIL, 0::sess.ModuleId, 4::id.DeclId, type.TYPE_REC));
+    val declsrc: str = "# a point\n# ---\n# x: the abscissa\nrec P { x: i32; }";
+    var declf: src.SourceFile = stub_file(declsrc);
+    var doc: token.Span;
+    doc.offset = 0;
+    doc.len    = 33;
+    var buf: src.SourceFile = stub_file("p.x");
+    val r1: id.ExprId = add_ident(?a, 0, 1);
+    val m1: id.ExprId = add_member(?a, r1, 2, 1);
+    var sr: sema.SemaResult = mk_sema(?pa, 2);
+    sr.expr_type[r1] = recp;
+
+    val key: FieldKey = fk(0, 4, ?declf, 42, 1);
+    var out: [4]token.Span;
+    # references: the one member access + the field decl, but NOT the doc component.
+    val n: usize = collect_field_sites(?a, ?sr, ?ti, ?buf, key, true, false, declsrc, doc, ?out[0], 4);
+
+    free_sema(?pa, ?sr);
+    type.dnit(?ti);
+    ast.dnit(?a);
+    if (n != 2) { ret 1; }
+    if (out[0].offset != 2) { ret 1; }
+    ret 0;
+}
+
+test "features: collect_field_sites in a non-declaring module yields only body sites" {
+    var pa: Allocator;
+    page.make(?pa);
+    var a: ast.Ast = ast.init(?pa, 0::src.FileId);
+    var ti: type.TypeInterner = unwrap_ok[type.TypeInterner, str](type.init(?pa));
+    # the record is declared in module 0; this is a different (importing) module
+    # whose only contribution is a member access on the imported record's value.
+    val recp: type.TypeId = unwrap_ok[type.TypeId, str](
+        type.intern_nominal(?ti, intern.STR_NIL, 0::sess.ModuleId, 4::id.DeclId, type.TYPE_REC));
+    var declf: src.SourceFile = stub_file("rec P { x: i32; }");   # "x" @8
+    var buf:   src.SourceFile = stub_file("p.x");
+    val r1: id.ExprId = add_ident(?a, 0, 1);
+    val m1: id.ExprId = add_member(?a, r1, 2, 1);
+    var sr: sema.SemaResult = mk_sema(?pa, 2);
+    sr.expr_type[r1] = recp;
+
+    val key: FieldKey = fk(0, 4, ?declf, 8, 1);
+    var out: [4]token.Span;
+    # declaring=false: no decl span, no doc — just the body site.
+    val n: usize = collect_field_sites(?a, ?sr, ?ti, ?buf, key, false, true, "", empty_doc(), ?out[0], 4);
+
+    free_sema(?pa, ?sr);
+    type.dnit(?ti);
+    ast.dnit(?a);
+    if (n != 1) { ret 1; }
+    if (out[0].offset != 2 || out[0].len != 1) { ret 1; }
+    ret 0;
+}
+
+test "features: collect_field_sites adds the decl but no doc edit when the record has no docstring" {
+    var pa: Allocator;
+    page.make(?pa);
+    var a: ast.Ast = ast.init(?pa, 0::src.FileId);
+    var ti: type.TypeInterner = unwrap_ok[type.TypeInterner, str](type.init(?pa));
+    val recp: type.TypeId = unwrap_ok[type.TypeId, str](
+        type.intern_nominal(?ti, intern.STR_NIL, 0::sess.ModuleId, 4::id.DeclId, type.TYPE_REC));
+    var declf: src.SourceFile = stub_file("rec P { x: i32; }");   # "x" @8
+    var buf:   src.SourceFile = stub_file("p.x");
+    val r1: id.ExprId = add_ident(?a, 0, 1);
+    val m1: id.ExprId = add_member(?a, r1, 2, 1);
+    var sr: sema.SemaResult = mk_sema(?pa, 2);
+    sr.expr_type[r1] = recp;
+
+    val key: FieldKey = fk(0, 4, ?declf, 8, 1);
+    var out: [4]token.Span;
+    # rename, declaring, but the doc span is empty -> the decl edit, no doc edit.
+    val n: usize = collect_field_sites(?a, ?sr, ?ti, ?buf, key, true, true, "rec P { x: i32; }", empty_doc(), ?out[0], 4);
+
+    free_sema(?pa, ?sr);
+    type.dnit(?ti);
+    ast.dnit(?a);
+    if (n != 2) { ret 1; }
+    if (out[0].offset != 2) { ret 1; }   # the member access
+    if (out[1].offset != 8) { ret 1; }   # the field decl
+    ret 0;
+}
+
+test "features: doc_component_name_span rewrites a plain field / param component" {
+    val txt: str = "# sums\n# ---\n# a: the addend\n# b: the augend\n";
+    var doc: token.Span;
+    doc.offset = 0;
+    doc.len    = str_len(txt);
+    var qf: src.SourceFile = stub_file("b");
+
+    var fail: bool = false;
+    val o: Option[token.Span] = doc_component_name_span(txt, doc, ?qf, span_at(0, 1), false);
+    if (is_none[token.Span](o)) { fail = true; }
+    or {
+        val sp: token.Span = unwrap[token.Span](o);
+        if (!region_eq(txt, sp, "b")) { fail = true; }
+        if (sp.len != 1) { fail = true; }
+        # it must be the component head "b", not the "b" inside "the augend".
+        if (txt[sp.offset - 2] != '#') { fail = true; }
+    }
+
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+test "features: doc_component_name_span rewrites the inner identifier of a generic [T]" {
+    val txt: str = "# a box\n# ---\n# [T]: the element\n# v: the value\n";
+    var doc: token.Span;
+    doc.offset = 0;
+    doc.len    = str_len(txt);
+    var qf: src.SourceFile = stub_file("T");
+
+    var fail: bool = false;
+    # generic match: the inner "T" only, brackets preserved.
+    val o: Option[token.Span] = doc_component_name_span(txt, doc, ?qf, span_at(0, 1), true);
+    if (is_none[token.Span](o)) { fail = true; }
+    or {
+        val sp: token.Span = unwrap[token.Span](o);
+        if (!region_eq(txt, sp, "T")) { fail = true; }
+        if (sp.len != 1) { fail = true; }
+        # the byte before the matched span is the '[' and after is the ']'.
+        if (txt[sp.offset - 1] != '[' || txt[sp.offset + sp.len] != ']') { fail = true; }
+    }
+    # the same query in non-generic mode must NOT match "[T]" (it is not "T").
+    if (is_some[token.Span](doc_component_name_span(txt, doc, ?qf, span_at(0, 1), false))) { fail = true; }
+
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+test "features: doc_component_name_span returns none with no doc, no match, summary-only" {
+    var qf: src.SourceFile = stub_file("x");
+    var fail: bool = false;
+
+    # empty doc span -> none.
+    var empty: token.Span;
+    empty.offset = 0;
+    empty.len    = 0;
+    if (is_some[token.Span](doc_component_name_span("", empty, ?qf, span_at(0, 1), false))) { fail = true; }
+
+    # a real doc block whose components do not include "x" -> none.
+    val txt: str = "# d\n# ---\n# a: one\n# b: two\n";
+    var doc: token.Span;
+    doc.offset = 0;
+    doc.len    = str_len(txt);
+    if (is_some[token.Span](doc_component_name_span(txt, doc, ?qf, span_at(0, 1), false))) { fail = true; }
+
+    # a summary-only block (no `# ---`) -> no components -> none.
+    val s2: str = "# just a summary mentioning x\n";
+    var d2: token.Span;
+    d2.offset = 0;
+    d2.len    = str_len(s2);
+    if (is_some[token.Span](doc_component_name_span(s2, d2, ?qf, span_at(0, 1), false))) { fail = true; }
+
+    if (fail) { ret 1; }
+    ret 0;
 }

--- a/src/language.mach
+++ b/src/language.mach
@@ -632,6 +632,395 @@ fun reply_result(alloc: *Allocator, id_raw: str, result: str) {
     json.free_str(id_raw, alloc);
 }
 
+# FieldTarget: a record / union field resolved from a cursor, the type-driven twin
+# of a SymbolRef for the field references / rename / prepareRename paths. carries
+# the field's cross-module identity (`key`), the record's declaring site (`rs`,
+# for the field-declaration span and its doc block), and whether that site is the
+# active buffer (so the declaring module's edits — the field decl name and the doc
+# component — are placed in the buffer's URI rather than a loaded module's).
+# ---
+# key:            the field's cross-module identity
+# rs:             the record's declaring site (field range, Ast, file, doc)
+# decl_in_buffer: true when the record is declared in the active buffer
+rec FieldTarget {
+    key:            features.FieldKey;
+    rs:             project.RecordSite;
+    decl_in_buffer: bool;
+}
+
+# field_target_at: the record / union field a cursor references, resolved to its
+# cross-module identity and declaring site, or none. drives the field references /
+# rename / prepareRename paths: pivots the offset through `field_ref_at` (a member
+# access or struct-literal field name) or `field_self_at` (a field's own decl
+# name), types the host expression, peels it to a `RecordSite`, and matches the
+# field name to recover its declaring span. none when the position is not on a
+# field, the host cannot be typed, or no field matches. requires a loaded project
+# root for typing.
+# ---
+# ws:     the workspace
+# an:     the analyzed request document
+# offset: cursor byte offset into the buffer
+# ret:    some(FieldTarget) on a field position, or none
+fun field_target_at(ws: *project.Workspace, an: *Analyzed, offset: usize) Option[FieldTarget] {
+    if (an.root == nil) { ret none[FieldTarget](); }
+
+    val fo: Option[features.FieldRef] = features.field_ref_at(an.a, offset);
+    if (is_some[features.FieldRef](fo)) {
+        val fr: features.FieldRef = unwrap[features.FieldRef](fo);
+        val sr_r: Result[*sema.SemaResult, str] = project.sema_doc(ws, an.root, an.fid);
+        if (is_err[*sema.SemaResult, str](sr_r)) { ret none[FieldTarget](); }
+        val tid: type.TypeId = project.type_of(unwrap_ok[*sema.SemaResult, str](sr_r), fr.host);
+        val rso: Option[project.RecordSite] = project.record_decl_in(ws, an.root, an.own, an.a, an.file, tid);
+        if (!is_some[project.RecordSite](rso)) { ret none[FieldTarget](); }
+        val rs: project.RecordSite = unwrap[project.RecordSite](rso);
+        val spo: Option[token.Span] = features.field_decl_span(rs.a, rs.file, rs.fields_start, rs.fields_len, an.file, fr.name_span);
+        if (!is_some[token.Span](spo)) { ret none[FieldTarget](); }
+        ret some[FieldTarget](make_field_target(an, rs, unwrap[token.Span](spo)));
+    }
+
+    # the cursor may sit on a field's own declaration name inside a rec / uni in
+    # the buffer; resolve it to itself, then to that record's site for the walk.
+    val self_o: Option[FieldSelf] = field_self_at(an, offset);
+    if (is_some[FieldSelf](self_o)) {
+        val fs: FieldSelf = unwrap[FieldSelf](self_o);
+        val did: id.DeclId = ast.offset_to_decl(an.a, offset);
+        val rso: Option[project.RecordSite] = project.record_site_at(ws, an.root, an.own, an.a, an.file, did);
+        if (!is_some[project.RecordSite](rso)) { ret none[FieldTarget](); }
+        ret some[FieldTarget](make_field_target(an, unwrap[project.RecordSite](rso), fs.name));
+    }
+
+    ret none[FieldTarget]();
+}
+
+# make_field_target: assemble a FieldTarget from a resolved record site and the
+# field's declared-name span. the field name and its source live in the record's
+# declaring module (`rs.file`), which is the cross-module byte identity every
+# other module's references are matched against.
+fun make_field_target(an: *Analyzed, rs: project.RecordSite, field_name: token.Span) FieldTarget {
+    var t: FieldTarget;
+    t.key.origin     = rs.origin;
+    t.key.decl       = rs.decl;
+    t.key.decl_file  = rs.file;
+    t.key.field_name = field_name;
+    t.rs             = rs;
+    t.decl_in_buffer = rs.origin == an.own;
+    ret t;
+}
+
+# FieldXRef: one module contributing field references — its Ast, SemaResult (for
+# typing each host expression), source file, document URI, and whether it is the
+# record's declaring module (so its field-declaration name span and doc component
+# are emitted). the active buffer is always `out[0]`; each other loaded module
+# that types a reference is another (owned `file://` URI freed by free_field_refs).
+rec FieldXRef {
+    a:        *ast.Ast;
+    sr:       *sema.SemaResult;
+    file:     *src.SourceFile;
+    uri:      str;
+    declaring: bool;
+}
+
+# build_field_refs: populate `out` with the modules that reference the keyed field
+# and return the count. `out[0]` is always the active buffer (live SemaResult);
+# each subsequent entry is a loaded module whose SemaResult types at least one
+# reference to the field, skipping the buffer's on-disk twin so its live edits are
+# not double-counted. every module is walked (a field is reachable wherever its
+# record is imported), so this is not gated on project ownership — the rename gate
+# is applied separately by the caller.
+# ---
+# ws:    the workspace
+# an:    the active buffer's analysis
+# uri:   the active buffer's document URI
+# t:     the resolved field target
+# out:   array of at least `cap` FieldXRef slots
+# cap:   capacity of `out` (module_count + 1)
+# ret:   number of populated entries (>= 1), or 0 when the buffer cannot be typed
+fun build_field_refs(ws: *project.Workspace, an: Analyzed, uri: str, t: FieldTarget, out: *FieldXRef, cap: usize) usize {
+    val sr_r: Result[*sema.SemaResult, str] = project.sema_doc(ws, an.root, an.fid);
+    if (is_err[*sema.SemaResult, str](sr_r)) { ret 0; }
+    out[0].a         = an.a;
+    out[0].sr        = unwrap_ok[*sema.SemaResult, str](sr_r);
+    out[0].file      = an.file;
+    out[0].uri       = uri;
+    out[0].declaring = t.decl_in_buffer;
+    var n: usize = 1;
+
+    val self_o: Option[sess.ModuleId] = project.module_for_uri(ws, an.root, uri);
+    val have_self: bool = is_some[sess.ModuleId](self_o);
+    var self_mid: sess.ModuleId = 0::sess.ModuleId;
+    if (have_self) { self_mid = unwrap[sess.ModuleId](self_o); }
+
+    val mc: u32 = project.module_count(an.root);
+    var mid: u32 = 0;
+    for (mid < mc && n < cap) {
+        val cur: sess.ModuleId = mid::sess.ModuleId;
+        if (have_self && cur == self_mid) { mid = mid + 1; cnt; }
+        val mv_o: Option[project.ModuleView] = project.module_view(ws, an.root, cur);
+        val ms_o: Option[*sema.SemaResult] = project.module_sema(ws, an.root, cur);
+        if (!is_some[project.ModuleView](mv_o) || !is_some[*sema.SemaResult](ms_o)) { mid = mid + 1; cnt; }
+        val muri: str = project.module_uri(ws, an.root, cur);
+        if (muri == nil) { mid = mid + 1; cnt; }
+        val mv: project.ModuleView = unwrap[project.ModuleView](mv_o);
+        out[n].a         = mv.a;
+        out[n].sr        = unwrap[*sema.SemaResult](ms_o);
+        out[n].file      = mv.file;
+        out[n].uri       = muri;
+        out[n].declaring = cur == t.key.origin;
+        n = n + 1;
+        mid = mid + 1;
+    }
+    ret n;
+}
+
+# free_field_refs: release the owned `file://` URIs of the graph-module entries.
+# refs[0] borrows the request URI and is skipped.
+fun free_field_refs(ws: *project.Workspace, refs: *FieldXRef, n: usize) {
+    var i: usize = 1;
+    for (i < n) {
+        if (refs[i].uri != nil) { json.free_str(refs[i].uri, ws.alloc); }
+        i = i + 1;
+    }
+}
+
+# walk_field_sites: feed every site naming the keyed field in module `s` to the
+# sink — every member access / struct-literal init whose host type peels to the
+# keyed record, plus (when `s` is the record's declaring module) the field
+# declaration's own name span and, for rename, the matching `# <field>:` doc
+# component name token. the field decl and doc spans always carry the field name
+# and bypass the (nil) spelling guard.
+fun walk_field_sites(s: *FieldXRef, ti: *type.TypeInterner, t: FieldTarget, want_doc: bool, k: *WalkSink) {
+    var ei: usize = 0;
+    for (ei < s.a.expr_len) {
+        val so: Option[token.Span] = features.field_ref_span_at(s.a, s.sr, ti, ei::id.ExprId, s.file, t.key);
+        if (is_some[token.Span](so)) { sink_emit(k, s.file, s.uri, unwrap[token.Span](so)); }
+        ei = ei + 1;
+    }
+    if (s.declaring) {
+        sink_emit(k, s.file, s.uri, t.key.field_name);
+        if (want_doc) {
+            val d_opt: Option[*decl.Decl] = ast.get_decl(t.rs.a, t.rs.decl);
+            if (is_some[*decl.Decl](d_opt)) {
+                val d: *decl.Decl = unwrap[*decl.Decl](d_opt);
+                if (d.doc.len != 0) {
+                    val co: Option[token.Span] = features.doc_component_name_span(t.rs.file.text, d.doc, t.rs.file, t.key.field_name, false);
+                    if (is_some[token.Span](co)) { sink_emit(k, s.file, s.uri, unwrap[token.Span](co)); }
+                }
+            }
+        }
+    }
+}
+
+# field_references: the type-driven references path for a record / union field.
+# resolves the field, walks every loaded module's SemaResult collecting its
+# member-access / struct-literal sites plus the field declaration, and emits a
+# Location[]. true when a field was resolved and replied; false (without replying)
+# so the caller falls back to an empty array.
+fun field_references(ws: *project.Workspace, alloc: *Allocator, an: *Analyzed, uri: str, offset: usize, id_raw: str) bool {
+    val to: Option[FieldTarget] = field_target_at(ws, an, offset);
+    if (!is_some[FieldTarget](to)) { ret false; }
+    val t: FieldTarget = unwrap[FieldTarget](to);
+
+    val cap: usize = (project.module_count(an.root) + 1)::usize;
+    val ra: Result[*FieldXRef, str] = allocate[FieldXRef](alloc, cap);
+    if (is_err[*FieldXRef, str](ra)) { ret false; }
+    val refs: *FieldXRef = unwrap_ok[*FieldXRef, str](ra);
+
+    val n: usize = build_field_refs(ws, @an, uri, t, refs, cap);
+    if (n == 0) { deallocate[FieldXRef](alloc, refs, cap); ret false; }
+
+    emit_field_locations(ws, alloc, id_raw, refs, n, t);
+    free_field_refs(ws, refs, n);
+    deallocate[FieldXRef](alloc, refs, cap);
+    ret true;
+}
+
+# field_rename: the type-driven rename path for a record / union field. refuses
+# (returns false without replying — the caller emits an empty edit) when the
+# field's record is declared in a vendored dependency: such a declaration is not
+# the editor's to rewrite. otherwise resolves the field, walks every loaded
+# module, and emits a WorkspaceEdit replacing every member-access / struct-literal
+# site, the field declaration, and the record's matching doc component. true when
+# the edit was replied.
+fun field_rename(ws: *project.Workspace, alloc: *Allocator, an: *Analyzed, uri: str, offset: usize, id_raw: str, new_name: str) bool {
+    val to: Option[FieldTarget] = field_target_at(ws, an, offset);
+    if (!is_some[FieldTarget](to)) { ret false; }
+    val t: FieldTarget = unwrap[FieldTarget](to);
+
+    if (!field_record_renameable(ws, an.root, uri, t)) { reply_empty_edit(alloc, id_raw); ret true; }
+
+    val cap: usize = (project.module_count(an.root) + 1)::usize;
+    val ra: Result[*FieldXRef, str] = allocate[FieldXRef](alloc, cap);
+    if (is_err[*FieldXRef, str](ra)) { ret false; }
+    val refs: *FieldXRef = unwrap_ok[*FieldXRef, str](ra);
+
+    val n: usize = build_field_refs(ws, @an, uri, t, refs, cap);
+    if (n == 0) { deallocate[FieldXRef](alloc, refs, cap); reply_empty_edit(alloc, id_raw); ret true; }
+
+    emit_field_rename(ws, alloc, id_raw, refs, n, t, new_name);
+    free_field_refs(ws, refs, n);
+    deallocate[FieldXRef](alloc, refs, cap);
+    ret true;
+}
+
+# field_record_renameable: whether the field's record is the editor's to rewrite —
+# the same gate the symbol rename `renameable` applies, keyed on the record's
+# declaring module. a record declared in a loaded module keys directly on
+# `is_project_module`; a record declared in the active buffer keys on the buffer's
+# on-disk twin (a dependency source opened for editing has a loaded twin that is
+# not project-owned), and on the buffer's governing root not being a vendored
+# dependency project when it has no twin.
+fun field_record_renameable(ws: *project.Workspace, root: *project.Root, uri: str, t: FieldTarget) bool {
+    if (!t.decl_in_buffer) { ret project.is_project_module(ws, root, t.key.origin); }
+    val twin_o: Option[sess.ModuleId] = project.module_for_uri(ws, root, uri);
+    if (!is_some[sess.ModuleId](twin_o)) { ret !project.root_vendored(root); }
+    ret project.is_project_module(ws, root, unwrap[sess.ModuleId](twin_o));
+}
+
+# field_prepare_span: write the field-name span the cursor sits on into `out` and
+# return true when it resolves to a field of a project-owned record, or false. the
+# prepareRename gate for field positions.
+fun field_prepare_span(ws: *project.Workspace, an: *Analyzed, uri: str, offset: usize, out: *token.Span) bool {
+    val to: Option[FieldTarget] = field_target_at(ws, an, offset);
+    if (!is_some[FieldTarget](to)) { ret false; }
+    val t: FieldTarget = unwrap[FieldTarget](to);
+    if (!field_record_renameable(ws, an.root, uri, t)) { ret false; }
+    # the range reported is the cursor's own field-name token in the buffer; the
+    # decl-site name lives in the record's module, which may not be the buffer.
+    val fo: Option[features.FieldRef] = features.field_ref_at(an.a, offset);
+    if (is_some[features.FieldRef](fo)) { @out = unwrap[features.FieldRef](fo).name_span; ret true; }
+    val self_o: Option[FieldSelf] = field_self_at(an, offset);
+    if (is_some[FieldSelf](self_o)) { @out = unwrap[FieldSelf](self_o).name; ret true; }
+    ret false;
+}
+
+# emit_field_locations: send a Location[] of every field site across `refs` (each
+# module's member-access / struct-literal sites plus the field declaration). takes
+# ownership of `id_raw` and frees it.
+fun emit_field_locations(ws: *project.Workspace, alloc: *Allocator, id_raw: str, refs: *FieldXRef, nref: usize, t: FieldTarget) {
+    val ti: *type.TypeInterner = project.type_interner(ws);
+    val prefix: str = "{\"jsonrpc\":\"2.0\",\"id\":";
+    val mid:    str = ",\"result\":[";
+    val suffix: str = "]}";
+
+    var k: WalkSink = sink_init(alloc, nil, nil);
+    var si: usize = 0;
+    for (si < nref) { walk_field_sites(?refs[si], ti, t, false, ?k); si = si + 1; }
+
+    val total: usize = str_len(prefix) + str_len(id_raw) + str_len(mid) + k.total + str_len(suffix);
+    val br: Result[*u8, str] = allocate[u8](alloc, total + 1);
+    if (is_err[*u8, str](br)) { reply_empty_array(alloc, id_raw); ret; }
+    val buf: *u8 = unwrap_ok[*u8, str](br);
+
+    var off: usize = 0;
+    off = append(buf, off, prefix);
+    off = append(buf, off, id_raw);
+    off = append(buf, off, mid);
+    k.buf   = buf;
+    k.off   = off;
+    k.count = 0;
+    var sj: usize = 0;
+    for (sj < nref) { walk_field_sites(?refs[sj], ti, t, false, ?k); sj = sj + 1; }
+    off = k.off;
+    off = append(buf, off, suffix);
+    buf[off] = 0;
+    transport.send_message(buf::str, alloc);
+    deallocate[u8](alloc, buf, total + 1);
+    json.free_str(id_raw, alloc);
+}
+
+# emit_field_rename: send a WorkspaceEdit renaming the field to `new_name` across
+# `refs`, one `changes` entry per module. each entry rewrites that module's
+# member-access / struct-literal sites; the declaring module's entry also rewrites
+# the field declaration and the record's matching doc component. takes ownership of
+# `id_raw` and frees it.
+fun emit_field_rename(ws: *project.Workspace, alloc: *Allocator, id_raw: str, refs: *FieldXRef, nref: usize, t: FieldTarget, new_name: str) {
+    val ti: *type.TypeInterner = project.type_interner(ws);
+    val qname: str = json.quote(new_name, alloc);
+    if (qname == nil) { reply_empty_edit(alloc, id_raw); ret; }
+
+    val ga: Result[*str, str] = allocate[str](alloc, nref);
+    if (is_err[*str, str](ga)) { json.free_str(qname, alloc); reply_empty_edit(alloc, id_raw); ret; }
+    val groups: *str = unwrap_ok[*str, str](ga);
+
+    val prefix: str = "{\"jsonrpc\":\"2.0\",\"id\":";
+    val mid:    str = ",\"result\":{\"changes\":{";
+    val suffix: str = "}}}";
+    var total: usize = str_len(prefix) + str_len(id_raw) + str_len(mid) + str_len(suffix);
+    var ng: usize = 0;
+    var si: usize = 0;
+    for (si < nref) {
+        val g: str = field_rename_group_json(?refs[si], ti, t, qname, alloc);
+        if (g != nil) {
+            if (ng > 0) { total = total + 1; }
+            total = total + str_len(g);
+            groups[ng] = g;
+            ng = ng + 1;
+        }
+        si = si + 1;
+    }
+
+    val br: Result[*u8, str] = allocate[u8](alloc, total + 1);
+    if (is_err[*u8, str](br)) {
+        free_groups(groups, ng, alloc);
+        deallocate[str](alloc, groups, nref);
+        json.free_str(qname, alloc);
+        reply_empty_edit(alloc, id_raw); ret;
+    }
+    val buf: *u8 = unwrap_ok[*u8, str](br);
+
+    var off: usize = 0;
+    off = append(buf, off, prefix);
+    off = append(buf, off, id_raw);
+    off = append(buf, off, mid);
+    var gi: usize = 0;
+    for (gi < ng) {
+        if (gi > 0) { buf[off] = ','; off = off + 1; }
+        off = append(buf, off, groups[gi]);
+        gi = gi + 1;
+    }
+    off = append(buf, off, suffix);
+    buf[off] = 0;
+    transport.send_message(buf::str, alloc);
+    deallocate[u8](alloc, buf, total + 1);
+
+    free_groups(groups, ng, alloc);
+    deallocate[str](alloc, groups, nref);
+    json.free_str(qname, alloc);
+    json.free_str(id_raw, alloc);
+}
+
+# field_rename_group_json: the `changes`-map entry `"<uri>":[<edits>]` for module
+# `s`, rewriting its field sites (and, for the declaring module, the declaration
+# and doc component) to the quoted `qname`, or nil when `s` contributes no edit.
+fun field_rename_group_json(s: *FieldXRef, ti: *type.TypeInterner, t: FieldTarget, qname: str, alloc: *Allocator) str {
+    val quri: str = json.quote(s.uri, alloc);
+    if (quri == nil) { ret nil; }
+
+    var k: WalkSink = sink_init(alloc, qname, nil);
+    walk_field_sites(s, ti, t, true, ?k);
+    if (k.count == 0) { json.free_str(quri, alloc); ret nil; }
+
+    val open:  str = ":[";
+    val close: str = "]";
+    val total: usize = str_len(quri) + str_len(open) + k.total + str_len(close);
+    val r: Result[*u8, str] = allocate[u8](alloc, total + 1);
+    if (is_err[*u8, str](r)) { json.free_str(quri, alloc); ret nil; }
+    val buf: *u8 = unwrap_ok[*u8, str](r);
+
+    var off: usize = 0;
+    off = append(buf, off, quri);
+    off = append(buf, off, open);
+    k.buf   = buf;
+    k.off   = off;
+    k.count = 0;
+    walk_field_sites(s, ti, t, true, ?k);
+    off = k.off;
+    off = append(buf, off, close);
+    buf[off] = 0;
+    json.free_str(quri, alloc);
+    ret buf::str;
+}
+
 # references: answer textDocument/references with every Location resolving to
 # the symbol at the cursor — its declaration plus every use-site across the
 # loaded project graph (the requesting buffer and every other module that
@@ -646,7 +1035,13 @@ pub fun references(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Al
     val offset: usize = unwrap[usize](off_o);
 
     val ro: Option[features.SymbolRef] = features.ref_at(an.a, an.rr, an.own, offset);
-    if (!is_some[features.SymbolRef](ro)) { reply_empty_array(alloc, id_raw); ret; }
+    if (!is_some[features.SymbolRef](ro)) {
+        # name resolution leaves a value-field access unbound, so a cursor on a
+        # field name yields no SymbolRef — fall through to the type-driven field
+        # references before giving up.
+        if (field_references(ws, alloc, ?an, uri, offset, id_raw)) { ret; }
+        reply_empty_array(alloc, id_raw); ret;
+    }
     val sr: features.SymbolRef = unwrap[features.SymbolRef](ro);
 
     val so: Option[*res.Symbol] = features.symbol(an.rr, sr.sym_id);
@@ -692,7 +1087,12 @@ pub fun rename(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Alloca
     val offset: usize = unwrap[usize](off_o);
 
     val ro: Option[features.SymbolRef] = features.ref_at(an.a, an.rr, an.own, offset);
-    if (!is_some[features.SymbolRef](ro)) { reply_empty_edit(alloc, id_raw); json.free_str(new_name, alloc); ret; }
+    if (!is_some[features.SymbolRef](ro)) {
+        # a cursor on a field name yields no SymbolRef — fall through to the
+        # type-driven field rename, which gates on the record's ownership.
+        if (field_rename(ws, alloc, ?an, uri, offset, id_raw, new_name)) { json.free_str(new_name, alloc); ret; }
+        reply_empty_edit(alloc, id_raw); json.free_str(new_name, alloc); ret;
+    }
     val sr: features.SymbolRef = unwrap[features.SymbolRef](ro);
 
     val so: Option[*res.Symbol] = features.symbol(an.rr, sr.sym_id);
@@ -708,6 +1108,13 @@ pub fun rename(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Alloca
 
     var bind: token.Span;
     val has_bind: bool = binding_span(an, sr.sym_id, ?bind);
+
+    # a param / generic carries its name in its owning decl's docstring component
+    # block too (`# <param>:` / `# [T]:`); rename rewrites that name token in the
+    # buffer where the decl lives. a fun / rec / val / etc. summary line no longer
+    # carries the name, so only param / generic bindings contribute a doc edit.
+    var doc: token.Span;
+    val has_doc: bool = param_generic_doc_span(an, sym, name, ?doc);
 
     val cap: usize = (project.module_count(an.root) + 1)::usize;
     val ra: Result[*XRef, str] = allocate[XRef](alloc, cap);
@@ -725,15 +1132,41 @@ pub fun rename(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Alloca
         reply_empty_edit(alloc, id_raw);
         ret;
     }
-    emit_rename(alloc, id_raw, refs, n, new_name, name, bind, has_bind);
+    emit_rename(alloc, id_raw, refs, n, new_name, name, bind, has_bind, doc, has_doc);
     free_refs(ws, refs, n);
     deallocate[XRef](alloc, refs, cap);
     json.free_str(new_name, alloc);
 }
 
+# param_generic_doc_span: write the doc-component name token for a param / generic
+# symbol's binding into `out` and return true, or false when the symbol is not a
+# param / generic, its owning decl has no docstring, or no component matches its
+# name. the doc block lives in the buffer the decl is declared in, so its name span
+# (`Decl.doc` resolved through `mach.lang.fe.doc`) is a buffer edit. a generic's
+# component head is the bracket form `# [T]:`, so the returned span is the inner
+# identifier only (the brackets stay).
+fun param_generic_doc_span(an: Analyzed, sym: *res.Symbol, name: str, out: *token.Span) bool {
+    if (sym.kind != res.SYM_PARAM && sym.kind != res.SYM_GENERIC) { ret false; }
+    if (sym.decl == id.DECL_NIL) { ret false; }
+    val d_opt: Option[*decl.Decl] = ast.get_decl(an.a, sym.decl);
+    if (!is_some[*decl.Decl](d_opt)) { ret false; }
+    val d: *decl.Decl = unwrap[*decl.Decl](d_opt);
+    if (d.doc.len == 0) { ret false; }
+
+    val bo: Option[token.Span] = features.binding_name_span(an.a, sym);
+    if (!is_some[token.Span](bo)) { ret false; }
+    val is_generic: bool = sym.kind == res.SYM_GENERIC;
+    val co: Option[token.Span] = features.doc_component_name_span(an.file.text, d.doc, an.file, unwrap[token.Span](bo), is_generic);
+    if (!is_some[token.Span](co)) { ret false; }
+    @out = unwrap[token.Span](co);
+    ret true;
+}
+
 # prepare_rename: answer textDocument/prepareRename with the range of the name
 # token at the cursor when it is a renameable symbol (a buffer-local symbol, or a
-# project-owned cross-module one), or null when it is not the editor's to rename.
+# project-owned cross-module one) or a field of a known, project-owned record, or
+# null when it is not the editor's to rename (an unresolved position, a dependency
+# symbol, or a field of a vendored record).
 pub fun prepare_rename(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
     val id_raw: str = json.extract_raw(body, "\"id\"", alloc);
     if (id_raw == nil) { ret; }
@@ -744,21 +1177,32 @@ pub fun prepare_rename(ws: *project.Workspace, es: *editor.EditorSession, alloc:
     val offset: usize = unwrap[usize](off_o);
 
     val ro: Option[features.SymbolRef] = features.ref_at(an.a, an.rr, an.own, offset);
-    if (!is_some[features.SymbolRef](ro)) { reply_null(alloc, id_raw); ret; }
+    if (!is_some[features.SymbolRef](ro)) {
+        # a cursor on a field name yields no SymbolRef — accept it when it resolves
+        # to a field of a project-owned record (the same gate field rename uses).
+        var name_span: token.Span;
+        if (field_prepare_span(ws, ?an, uri, offset, ?name_span)) {
+            reply_range(alloc, id_raw, an.file, name_span); ret;
+        }
+        reply_null(alloc, id_raw); ret;
+    }
     val sr: features.SymbolRef = unwrap[features.SymbolRef](ro);
 
     val so: Option[*res.Symbol] = features.symbol(an.rr, sr.sym_id);
     if (!is_some[*res.Symbol](so)) { reply_null(alloc, id_raw); ret; }
     if (!renameable(ws, an.root, uri, unwrap[*res.Symbol](so), sr)) { reply_null(alloc, id_raw); ret; }
 
-    val range: positions.LspRange = positions.range_of(an.file, sr.name_span);
-    val rng: str = range_json(range, alloc);
+    reply_range(alloc, id_raw, an.file, sr.name_span);
+}
 
+# reply_range: send a prepareRename success reply carrying the range of `span` in
+# `file`, freeing `id_raw`. shared by the symbol and field prepare paths.
+fun reply_range(alloc: *Allocator, id_raw: str, file: *src.SourceFile, span: token.Span) {
+    val rng: str = range_json(positions.range_of(file, span), alloc);
     val p1: str = "{\"jsonrpc\":\"2.0\",\"id\":";
     val p2: str = ",\"result\":";
     val p3: str = "}";
     send6(alloc, p1, id_raw, p2, rng, p3, nil, nil);
-
     json.free_str(rng, alloc);
     json.free_str(id_raw, alloc);
 }
@@ -1008,46 +1452,49 @@ fun sink_init(alloc: *Allocator, qname: str, guard: str) WalkSink {
     ret k;
 }
 
-# sink_emit: size or write one Location / TextEdit for `span` of source `s`,
-# per the sink's mode.
-fun sink_emit(k: *WalkSink, s: *XRef, span: token.Span) {
+# sink_emit: size or write one Location / TextEdit for `span` in `file` (located
+# at `uri`), per the sink's mode. taking `file` / `uri` rather than a source
+# record lets the symbol walk (XRef) and the field walk (FieldXRef) share it.
+fun sink_emit(k: *WalkSink, file: *src.SourceFile, uri: str, span: token.Span) {
     if (k.qname == nil) {
-        if (k.buf == nil) { k.total = k.total + loc_len(s.file, s.uri, span, k.alloc, k.count); }
-        or                { k.off   = put_loc(k.buf, k.off, s.file, s.uri, span, k.alloc, k.count); }
+        if (k.buf == nil) { k.total = k.total + loc_len(file, uri, span, k.alloc, k.count); }
+        or                { k.off   = put_loc(k.buf, k.off, file, uri, span, k.alloc, k.count); }
     }
     or {
-        if (k.buf == nil) { k.total = k.total + edit_len(s.file, span, k.qname, k.alloc, k.count); }
-        or                { k.off   = put_edit(k.buf, k.off, s.file, span, k.qname, k.alloc, k.count); }
+        if (k.buf == nil) { k.total = k.total + edit_len(file, span, k.qname, k.alloc, k.count); }
+        or                { k.off   = put_edit(k.buf, k.off, file, span, k.qname, k.alloc, k.count); }
     }
     k.count = k.count + 1;
 }
 
 # walk_refs: feed every reference to `s.target` in source `s` to the sink — the
 # declaration name, `use` / `fwd` import-path leaves, and the body (expr / type)
-# use-sites, plus the active buffer's param / generic binding when
-# `include_bind`. body spans pass the sink's spelling guard (see WalkSink);
-# declaration and import leaves always carry the declared name and are exempt.
-fun walk_refs(s: *XRef, include_bind: bool, bind: token.Span, k: *WalkSink) {
+# use-sites, plus the active buffer's param / generic binding when `include_bind`
+# and its owning decl's matching doc-component name token when `include_doc`. body
+# spans pass the sink's spelling guard (see WalkSink); declaration, import leaves,
+# binding, and doc-component spans always carry the declared name and are exempt.
+fun walk_refs(s: *XRef, include_bind: bool, bind: token.Span, include_doc: bool, doc: token.Span, k: *WalkSink) {
     if (s.target == res.SYMBOL_NIL) { ret; }
-    if (include_bind) { sink_emit(k, s, bind); }
+    if (include_bind) { sink_emit(k, s.file, s.uri, bind); }
+    if (include_doc)  { sink_emit(k, s.file, s.uri, doc); }
     var di: usize = 0;
     for (di < s.a.decl_len) {
         val dso: Option[token.Span] = features.decl_ref_span(s.a, s.rr, di::id.DeclId, s.target);
-        if (is_some[token.Span](dso)) { sink_emit(k, s, unwrap[token.Span](dso)); }
+        if (is_some[token.Span](dso)) { sink_emit(k, s.file, s.uri, unwrap[token.Span](dso)); }
         val iso: Option[token.Span] = features.import_ref_span(s.a, s.rr, di::id.DeclId, s.target, s.file);
-        if (is_some[token.Span](iso)) { sink_emit(k, s, unwrap[token.Span](iso)); }
+        if (is_some[token.Span](iso)) { sink_emit(k, s.file, s.uri, unwrap[token.Span](iso)); }
         di = di + 1;
     }
     var ei: usize = 0;
     for (ei < s.a.expr_len) {
         val so: Option[token.Span] = features.expr_ref_span(s.a, s.rr, ei::id.ExprId, s.target);
-        if (is_some[token.Span](so) && guard_admits(s, k, unwrap[token.Span](so))) { sink_emit(k, s, unwrap[token.Span](so)); }
+        if (is_some[token.Span](so) && guard_admits(s, k, unwrap[token.Span](so))) { sink_emit(k, s.file, s.uri, unwrap[token.Span](so)); }
         ei = ei + 1;
     }
     var ti: usize = 0;
     for (ti < s.a.type_len) {
         val so: Option[token.Span] = features.type_ref_span(s.a, s.rr, ti::id.TypeId, s.target);
-        if (is_some[token.Span](so) && guard_admits(s, k, unwrap[token.Span](so))) { sink_emit(k, s, unwrap[token.Span](so)); }
+        if (is_some[token.Span](so) && guard_admits(s, k, unwrap[token.Span](so))) { sink_emit(k, s.file, s.uri, unwrap[token.Span](so)); }
         ti = ti + 1;
     }
 }
@@ -1068,9 +1515,10 @@ fun emit_locations(alloc: *Allocator, id_raw: str, refs: *XRef, nref: usize, bin
     val mid:    str = ",\"result\":[";
     val suffix: str = "]}";
 
+    var empty: token.Span;
     var k: WalkSink = sink_init(alloc, nil, nil);
     var si: usize = 0;
-    for (si < nref) { walk_refs(?refs[si], si == 0 && has_bind, bind, ?k); si = si + 1; }
+    for (si < nref) { walk_refs(?refs[si], si == 0 && has_bind, bind, false, empty, ?k); si = si + 1; }
 
     val total: usize = str_len(prefix) + str_len(id_raw) + str_len(mid) + k.total + str_len(suffix);
     val br: Result[*u8, str] = allocate[u8](alloc, total + 1);
@@ -1086,7 +1534,7 @@ fun emit_locations(alloc: *Allocator, id_raw: str, refs: *XRef, nref: usize, bin
     k.off   = off;
     k.count = 0;
     var sj: usize = 0;
-    for (sj < nref) { walk_refs(?refs[sj], sj == 0 && has_bind, bind, ?k); sj = sj + 1; }
+    for (sj < nref) { walk_refs(?refs[sj], sj == 0 && has_bind, bind, false, empty, ?k); sj = sj + 1; }
     off = k.off;
 
     off = append(buf, off, suffix);
@@ -1100,9 +1548,10 @@ fun emit_locations(alloc: *Allocator, id_raw: str, refs: *XRef, nref: usize, bin
 # files in `refs`, one `changes` entry per file. each entry renames the
 # declaration, the import-path leaves, and every body reference spelled with the
 # declared name `name` (so an aliased import's references are not rewritten); the
-# active buffer's param / generic binding is included when `has_bind`. takes
-# ownership of `id_raw` and frees it.
-fun emit_rename(alloc: *Allocator, id_raw: str, refs: *XRef, nref: usize, new_name: str, name: str, bind: token.Span, has_bind: bool) {
+# active buffer's param / generic binding is included when `has_bind`, and its
+# owning decl's matching doc-component name token when `has_doc`. takes ownership
+# of `id_raw` and frees it.
+fun emit_rename(alloc: *Allocator, id_raw: str, refs: *XRef, nref: usize, new_name: str, name: str, bind: token.Span, has_bind: bool, doc: token.Span, has_doc: bool) {
     val qname: str = json.quote(new_name, alloc);
     if (qname == nil) { reply_empty_edit(alloc, id_raw); ret; }
 
@@ -1117,7 +1566,7 @@ fun emit_rename(alloc: *Allocator, id_raw: str, refs: *XRef, nref: usize, new_na
     var ng: usize = 0;
     var si: usize = 0;
     for (si < nref) {
-        val g: str = rename_group_json(?refs[si], si == 0 && has_bind, bind, name, qname, alloc);
+        val g: str = rename_group_json(?refs[si], si == 0 && has_bind, bind, si == 0 && has_doc, doc, name, qname, alloc);
         if (g != nil) {
             if (ng > 0) { total = total + 1; }
             total = total + str_len(g);
@@ -1160,15 +1609,16 @@ fun emit_rename(alloc: *Allocator, id_raw: str, refs: *XRef, nref: usize, new_na
 # rename_group_json: the `changes`-map entry `"<uri>":[<edits>]` for source `s`,
 # renaming the declaration, import-path leaves, and every body reference spelled
 # `name` to the already-quoted `qname` (via the shared walk; see WalkSink), or
-# nil when `s` contributes no edit. the active buffer's param / generic binding
-# is included when `include_bind`.
-fun rename_group_json(s: *XRef, include_bind: bool, bind: token.Span, name: str, qname: str, alloc: *Allocator) str {
+# nil when `s` contributes no edit. the active buffer's param / generic binding is
+# included when `include_bind` and its owning decl's doc-component name token when
+# `include_doc`.
+fun rename_group_json(s: *XRef, include_bind: bool, bind: token.Span, include_doc: bool, doc: token.Span, name: str, qname: str, alloc: *Allocator) str {
     if (s.target == res.SYMBOL_NIL) { ret nil; }
     val quri: str = json.quote(s.uri, alloc);
     if (quri == nil) { ret nil; }
 
     var k: WalkSink = sink_init(alloc, qname, name);
-    walk_refs(s, include_bind, bind, ?k);
+    walk_refs(s, include_bind, bind, include_doc, doc, ?k);
     if (k.count == 0) { json.free_str(quri, alloc); ret nil; }
 
     val open:  str = ":[";
@@ -1184,7 +1634,7 @@ fun rename_group_json(s: *XRef, include_bind: bool, bind: token.Span, name: str,
     k.buf   = buf;
     k.off   = off;
     k.count = 0;
-    walk_refs(s, include_bind, bind, ?k);
+    walk_refs(s, include_bind, bind, include_doc, doc, ?k);
     off = k.off;
     off = append(buf, off, close);
     buf[off] = 0;

--- a/src/language.mach
+++ b/src/language.mach
@@ -786,28 +786,27 @@ fun free_field_refs(ws: *project.Workspace, refs: *FieldXRef, n: usize) {
 # sink — every member access / struct-literal init whose host type peels to the
 # keyed record, plus (when `s` is the record's declaring module) the field
 # declaration's own name span and, for rename, the matching `# <field>:` doc
-# component name token. the field decl and doc spans always carry the field name
-# and bypass the (nil) spelling guard.
+# component name token. the span set is computed by the pure
+# `features.collect_field_sites` (a module can name a field at most once per expr,
+# so the buffer is sized to the expr count plus the two declaring extras).
 fun walk_field_sites(s: *FieldXRef, ti: *type.TypeInterner, t: FieldTarget, want_doc: bool, k: *WalkSink) {
-    var ei: usize = 0;
-    for (ei < s.a.expr_len) {
-        val so: Option[token.Span] = features.field_ref_span_at(s.a, s.sr, ti, ei::id.ExprId, s.file, t.key);
-        if (is_some[token.Span](so)) { sink_emit(k, s.file, s.uri, unwrap[token.Span](so)); }
-        ei = ei + 1;
-    }
+    var doc: token.Span;
+    doc.offset = 0;
+    doc.len    = 0;
     if (s.declaring) {
-        sink_emit(k, s.file, s.uri, t.key.field_name);
-        if (want_doc) {
-            val d_opt: Option[*decl.Decl] = ast.get_decl(t.rs.a, t.rs.decl);
-            if (is_some[*decl.Decl](d_opt)) {
-                val d: *decl.Decl = unwrap[*decl.Decl](d_opt);
-                if (d.doc.len != 0) {
-                    val co: Option[token.Span] = features.doc_component_name_span(t.rs.file.text, d.doc, t.rs.file, t.key.field_name, false);
-                    if (is_some[token.Span](co)) { sink_emit(k, s.file, s.uri, unwrap[token.Span](co)); }
-                }
-            }
-        }
+        val d_opt: Option[*decl.Decl] = ast.get_decl(t.rs.a, t.rs.decl);
+        if (is_some[*decl.Decl](d_opt)) { doc = unwrap[*decl.Decl](d_opt).doc; }
     }
+
+    val cap: usize = s.a.expr_len + 2;
+    val ra: Result[*token.Span, str] = allocate[token.Span](k.alloc, cap);
+    if (is_err[*token.Span, str](ra)) { ret; }
+    val spans: *token.Span = unwrap_ok[*token.Span, str](ra);
+
+    val n: usize = features.collect_field_sites(s.a, s.sr, ti, s.file, t.key, s.declaring, want_doc, t.rs.file.text, doc, spans, cap);
+    var i: usize = 0;
+    for (i < n) { sink_emit(k, s.file, s.uri, spans[i]); i = i + 1; }
+    deallocate[token.Span](k.alloc, spans, cap);
 }
 
 # field_references: the type-driven references path for a record / union field.

--- a/src/project.mach
+++ b/src/project.mach
@@ -279,6 +279,18 @@ pub fun sources(w: *Workspace) *src.SourceMap {
     ret ?w.s.sources;
 }
 
+# type_interner: the session's type interner, for peeling a record / union TypeId
+# to its nominal declaration site (the cross-module field-reference walk reads
+# each module's typing and matches the field's host type against its key through
+# it). the narrow read the feature layer makes; see `interner` for why the whole
+# session is kept out of feature signatures.
+# ---
+# w:   the workspace
+# ret: the session's type interner
+pub fun type_interner(w: *Workspace) *type.TypeInterner {
+    ret ?w.s.types;
+}
+
 # set_watch_active: record that the client delivers
 # workspace/didChangeWatchedFiles for the registered manifest / lockfile /
 # source globs, so invalidation is event-driven and the per-request
@@ -1326,6 +1338,25 @@ pub fun record_decl_in(w: *Workspace, root: *Root, own: sess.ModuleId, own_a: *a
     val n: mtypes.Nominal = unwrap[mtypes.Nominal](no);
     if (n.origin == own) { ret record_site_from(own, n.decl, own_a, own_file); }
     ret record_decl(w, root, tid);
+}
+
+# record_site_at: a RecordSite for the rec / uni declaration `decl` in the active
+# buffer (`own` / `own_a` / `own_file`), or none when `decl` is not a rec / uni.
+# the buffer-side entry point for a cursor sitting on a field's own declaration
+# name: the decl is in the buffer being edited, so its Ast / file are the live
+# ones. the resulting site carries the buffer's own module id, the cross-module
+# identity every other module's references are matched against.
+# ---
+# w:        the workspace (unused, kept for signature symmetry with record_decl_in)
+# root:     the project root, or nil
+# own:      the buffer's own module id
+# own_a:    the buffer's live Ast
+# own_file: the buffer's SourceFile
+# decl:     the rec / uni DeclId in the buffer
+# ret:      some(RecordSite), or none
+pub fun record_site_at(w: *Workspace, root: *Root, own: sess.ModuleId, own_a: *ast.Ast, own_file: *src.SourceFile, decl: id.DeclId) Option[RecordSite] {
+    if (decl == id.DECL_NIL) { ret none[RecordSite](); }
+    ret record_site_from(own, decl, own_a, own_file);
 }
 
 # nominal_of_tid: the nominal back-link of `tid` against the session type interner,


### PR DESCRIPTION
Closes #110.

Extends the field-aware feature surface into references and rename, and makes symbol rename docstring-aware.

## What

- **Field references** (`textDocument/references`): a cursor on a field name (member access, struct-literal init, or the field's own decl) pivots through the type-driven `FieldRef`, peels the host expression to its record's nominal `(origin, decl)` site, and walks every loaded module's retained `SemaResult` collecting each site naming that field of that record — member accesses, struct-literal inits, and the field declaration. The active buffer's on-disk twin is skipped (`module_for_uri`) so its live edits are not double-counted.
- **Field rename** (`textDocument/rename`): the same site set, plus the record's matching `# <field>:` doc component name token (located via `mach.lang.fe.doc`). Gated on the record's declaring module being project-owned — a vendored / std record is refused (empty edit).
- **Docstring-aware param / generic rename**: the existing symbol rename path now also rewrites a `SYM_PARAM`'s `# <param>:` and a `SYM_GENERIC`'s `# [T]:` doc component name token in the owning decl's docstring (the generic bracket form keeps its brackets — only the inner `T` is rewritten). Function / record / val summary lines no longer carry the name and are untouched.
- **prepareRename**: accepts field positions of project-owned records, rejects vendored / unknown ones.

## Design

A field's cross-module identity is `FieldKey { record origin, record decl, field-name bytes }`. The pure, testable core lives in `features.mach`:
- `field_ref_span_at` — the per-expr field-reference matcher (types the host, peels via `nominal_of`, compares the field-name bytes).
- `doc_component_name_span` — the doc component name token to rewrite (the whole token for a field / param, the bracketed inner identifier for a generic).

The walk and `WorkspaceEdit` JSON building reuse the existing `WalkSink` size-then-write machinery (refactored to take `file` / `uri` directly so the symbol `XRef` walk and the field `FieldXRef` walk share it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)