### PR TITLE
release: v0.7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,6 @@ jobs:
 
       - name: Build
         run: mach build .
+
+      - name: Test
+        run: mach test .

--- a/mach.lock
+++ b/mach.lock
@@ -8,4 +8,4 @@ commit = "eb940a5b48020c18ac73464377d2ba5471241306"
 [deps.mach]
 url = "https://github.com/octalide/mach"
 ref = "branch/main"
-commit = "10139d987926ded8fa26819b81fe96584c2738c0"
+commit = "2d1ab6fc47aaf1119926704625821babedc73deb"

--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,7 @@
 [project]
 id      = "mls"
 name    = "Mach Language Server"
-version = "0.6.2"
+version = "0.7.0"
 src     = "src"
 dep     = "dep"
 target  = "native"

--- a/src/features.mach
+++ b/src/features.mach
@@ -27,7 +27,14 @@ use std.types.option.Option;
 use std.types.option.some;
 use std.types.option.none;
 use std.types.option.is_some;
+use std.types.option.is_none;
 use std.types.option.unwrap;
+use std.types.result.Result;
+use std.types.result.is_err;
+use std.types.result.unwrap_ok;
+
+use std.allocator.Allocator;
+use page: std.allocator.page;
 
 use sess:   mach.lang.session;
 use src:    mach.lang.source;
@@ -827,4 +834,157 @@ pub fun span_bytes_equal(fa: *src.SourceFile, sa: token.Span, fb: *src.SourceFil
         i = i + 1;
     }
     ret true;
+}
+
+# span_at: a Span over `[offset, offset + len)`. the test builder for field-name /
+# query spans into a stub SourceFile.
+fun span_at(offset: usize, len: usize) token.Span {
+    var sp: token.Span;
+    sp.offset = offset;
+    sp.len    = len;
+    ret sp;
+}
+
+# stub_file: a SourceFile carrying just `text`, enough for the byte-level field-name
+# compares the pure locator does (it reads `file.text` only).
+fun stub_file(text: str) src.SourceFile {
+    var f: src.SourceFile;
+    f.path        = nil;
+    f.text        = text;
+    f.line_starts = nil;
+    f.line_len    = 0;
+    ret f;
+}
+
+# add_field: append a field TypedName named over `[offset, offset + len)` to `a`,
+# returning its index into `a.typed_names`.
+fun add_field(a: *ast.Ast, offset: usize, len: usize) u32 {
+    var tn: decl.TypedName;
+    tn.name     = span_at(offset, len);
+    tn.ty       = id.TYPE_NIL;
+    tn.comptime = false;
+    val r: Result[u32, str] = ast.add_typed_name(a, tn);
+    ret unwrap_ok[u32, str](r);
+}
+
+test "features: field_decl_span matches a field in the same source" {
+    var pa: Allocator;
+    page.make(?pa);
+    var a: ast.Ast = ast.init(?pa, 0::src.FileId);
+    # text "xyzz": fields "x"@0, "y"@1, "zz"@2..3
+    val start: u32 = add_field(?a, 0, 1);
+    add_field(?a, 1, 1);
+    add_field(?a, 2, 2);
+    var f: src.SourceFile = stub_file("xyzz");
+
+    var fail: bool = false;
+    # query "y" (the byte at offset 1) resolves to field "y" at offset 1.
+    val o: Option[token.Span] = field_decl_span(?a, ?f, start, 3, ?f, span_at(1, 1));
+    if (is_none[token.Span](o)) { fail = true; }
+    or {
+        val sp: token.Span = unwrap[token.Span](o);
+        if (sp.offset != 1 || sp.len != 1) { fail = true; }
+    }
+
+    ast.dnit(?a);
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+test "features: field_decl_span matches a field across two sources (dependency)" {
+    var pa: Allocator;
+    page.make(?pa);
+    # the declaring "module" file holds the record fields.
+    var da: ast.Ast = ast.init(?pa, 0::src.FileId);
+    val start: u32 = add_field(?da, 0, 4);   # "name"
+    add_field(?da, 5, 3);                     # "age"
+    var df: src.SourceFile = stub_file("name age");
+    # the referencing buffer file holds a member access "p.age".
+    var qf: src.SourceFile = stub_file("p.age");
+
+    var fail: bool = false;
+    val o: Option[token.Span] = field_decl_span(?da, ?df, start, 2, ?qf, span_at(2, 3));
+    if (is_none[token.Span](o)) { fail = true; }
+    or {
+        val sp: token.Span = unwrap[token.Span](o);
+        if (sp.offset != 5 || sp.len != 3) { fail = true; }
+    }
+
+    ast.dnit(?da);
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+test "features: field_decl_span returns none for an unknown field" {
+    var pa: Allocator;
+    page.make(?pa);
+    var a: ast.Ast = ast.init(?pa, 0::src.FileId);
+    val start: u32 = add_field(?a, 0, 1);   # "x"
+    add_field(?a, 2, 1);                     # "y"
+    var f: src.SourceFile = stub_file("xy");
+    var qf: src.SourceFile = stub_file("o.z");
+
+    val ok: bool = is_none[token.Span](field_decl_span(?a, ?f, start, 2, ?qf, span_at(2, 1)));
+    ast.dnit(?a);
+    if (!ok) { ret 1; }
+    ret 0;
+}
+
+test "features: field_decl_span returns none for an empty field range" {
+    var pa: Allocator;
+    page.make(?pa);
+    var a: ast.Ast = ast.init(?pa, 0::src.FileId);
+    var f: src.SourceFile = stub_file("x");
+
+    val ok: bool = is_none[token.Span](field_decl_span(?a, ?f, 0, 0, ?f, span_at(0, 1)));
+    ast.dnit(?a);
+    if (!ok) { ret 1; }
+    ret 0;
+}
+
+test "features: field_decl_span returns none for a zero-length query" {
+    var pa: Allocator;
+    page.make(?pa);
+    var a: ast.Ast = ast.init(?pa, 0::src.FileId);
+    val start: u32 = add_field(?a, 0, 1);   # "x"
+    var f: src.SourceFile = stub_file("x");
+
+    val ok: bool = is_none[token.Span](field_decl_span(?a, ?f, start, 1, ?f, span_at(0, 0)));
+    ast.dnit(?a);
+    if (!ok) { ret 1; }
+    ret 0;
+}
+
+test "features: span_bytes_equal matches identical bytes across files" {
+    var fa: src.SourceFile = stub_file("alpha");
+    var fb: src.SourceFile = stub_file("xalphay");
+    var fail: bool = false;
+    if (!span_bytes_equal(?fa, span_at(0, 5), ?fb, span_at(1, 5))) { fail = true; }
+    if (span_bytes_equal(?fa, span_at(0, 5), ?fb, span_at(1, 4)))  { fail = true; }
+    if (span_bytes_equal(?fa, span_at(0, 3), ?fb, span_at(0, 3)))  { fail = true; }
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+test "features: field_decl_self_at hits a field name and misses elsewhere" {
+    var pa: Allocator;
+    page.make(?pa);
+    var a: ast.Ast = ast.init(?pa, 0::src.FileId);
+    val start: u32 = add_field(?a, 4, 1);   # "x" at offset 4
+    add_field(?a, 10, 3);                    # "foo" at offset 10
+
+    var fail: bool = false;
+    # offset 11 sits inside "foo".
+    val hit: Option[token.Span] = field_decl_self_at(?a, start, 2, 11);
+    if (is_none[token.Span](hit)) { fail = true; }
+    or {
+        val sp: token.Span = unwrap[token.Span](hit);
+        if (sp.offset != 10 || sp.len != 3) { fail = true; }
+    }
+    # offset 7 is between the two field names.
+    if (is_some[token.Span](field_decl_self_at(?a, start, 2, 7))) { fail = true; }
+
+    ast.dnit(?a);
+    if (fail) { ret 1; }
+    ret 0;
 }

--- a/src/features.mach
+++ b/src/features.mach
@@ -39,6 +39,7 @@ use page: std.allocator.page;
 use sess:   mach.lang.session;
 use src:    mach.lang.source;
 use intern: mach.lang.intern;
+use type:   mach.lang.type;
 use token:  mach.lang.fe.token;
 use ast:    mach.lang.fe.ast;
 use id:     mach.lang.fe.ast.id;
@@ -49,6 +50,9 @@ use expr:   mach.lang.fe.ast.expr;
 use atype:  mach.lang.fe.ast.type;
 use fedoc:  mach.lang.fe.doc;
 use res:    mach.lang.fe.resolve;
+use sema:   mach.lang.fe.sema;
+
+use mtypes: mls.types;
 
 # SymbolRef: a symbol a position references, joined with the location of the
 # name token that referenced it.
@@ -823,6 +827,157 @@ pub fun field_decl_self_at(decl_a: *ast.Ast, fields_start: u32, fields_len: u32,
         i = i + 1;
     }
     ret none[token.Span]();
+}
+
+# FieldKey: the cross-module identity of a record / union field — the nominal
+# declaration site of its record (`origin`, `decl`) paired with the field name as
+# bytes in the declaring module's source. the field-reference / field-rename walk
+# carries it across every loaded module: a member access or struct-literal init
+# names this field iff its host expression's type peels to the keyed record and the
+# referenced name bytes equal the keyed field name. the name is held as a file +
+# span (not interned) because a field has no Symbol and so no StrId.
+# ---
+# origin:     ModuleId of the module declaring the record / union
+# decl:       DeclId of the rec / uni declaration in `origin`'s Ast
+# decl_file:  SourceFile backing the declaring module (the field-name bytes)
+# field_name: byte span of the field's declared name in `decl_file`
+pub rec FieldKey {
+    origin:     sess.ModuleId;
+    decl:       id.DeclId;
+    decl_file:  *src.SourceFile;
+    field_name: token.Span;
+}
+
+# field_ref_span_at: the field-name span of expr `eid` in module (`a`, `sr`) when
+# it references the keyed field, or none. the field analogue of `expr_ref_span`:
+# resolution never binds a value-field access, so a field reference is recovered
+# by typing the host expression and peeling it to its record's nominal site rather
+# than reading a Symbol. two expression shapes name a field:
+#   - a member access `obj.field`: types the receiver `member.object` and, when
+#     that peels to the keyed record and the member name bytes equal the field
+#     name, yields the member name span;
+#   - a struct literal `T{ field: ... }`: types the literal itself and, when that
+#     peels to the keyed record, yields the matching init-name span.
+# the host type is read from `sr` (the module's SemaResult) and peeled through the
+# session type interner `ti`, so a field reached through `*T` or a generic instance
+# of the record matches the same key. pure over (`a`, `sr`, `ti`) — the caller
+# walks `[0, a.expr_len)` feeding the spans this returns to a sink.
+# ---
+# a:    the module's parsed Ast
+# sr:   the module's SemaResult (per-expr typing)
+# ti:   the session type interner (for nominal peeling)
+# eid:  the expr id to test
+# qf:   the SourceFile backing `a` (the referenced name bytes)
+# key:  the field identity to match
+# ret:  some(name span) when `eid` references the keyed field, or none
+pub fun field_ref_span_at(a: *ast.Ast, sr: *sema.SemaResult, ti: *type.TypeInterner, eid: id.ExprId, qf: *src.SourceFile, key: FieldKey) Option[token.Span] {
+    val eo: Option[*expr.Expr] = ast.get_expr(a, eid);
+    if (!is_some[*expr.Expr](eo)) { ret none[token.Span](); }
+    val e: *expr.Expr = unwrap[*expr.Expr](eo);
+
+    if (e.kind == expr.EXPR_KIND_MEMBER) {
+        if (!host_matches(sr, ti, e.data.member.object, key)) { ret none[token.Span](); }
+        if (!span_bytes_equal(qf, e.data.member.name, key.decl_file, key.field_name)) { ret none[token.Span](); }
+        ret some[token.Span](e.data.member.name);
+    }
+
+    if (e.kind == expr.EXPR_KIND_STRUCT_LIT) {
+        if (!host_matches(sr, ti, eid, key)) { ret none[token.Span](); }
+        val start: u32 = e.data.struct_lit.fields_start;
+        val len:   u32 = e.data.struct_lit.fields_len;
+        var i: u32 = 0;
+        for (i < len) {
+            val fi: *expr.FieldInit = ?a.field_inits[start + i];
+            if (span_bytes_equal(qf, fi.name, key.decl_file, key.field_name)) {
+                ret some[token.Span](fi.name);
+            }
+            i = i + 1;
+        }
+    }
+
+    ret none[token.Span]();
+}
+
+# host_matches: whether host expression `eid`'s type peels to the keyed record's
+# nominal declaration site. the type-identity half of `field_ref_span_at`: a
+# member receiver or a struct literal whose `(origin, decl)` equals the key names
+# the same record across modules, regardless of pointer / generic-instance wrapping
+# (peeled by `nominal_of`).
+fun host_matches(sr: *sema.SemaResult, ti: *type.TypeInterner, eid: id.ExprId, key: FieldKey) bool {
+    val tid: type.TypeId = mtypes.type_of(sr, eid);
+    val no: Option[mtypes.Nominal] = mtypes.nominal_of(ti, tid);
+    if (is_none[mtypes.Nominal](no)) { ret false; }
+    val n: mtypes.Nominal = unwrap[mtypes.Nominal](no);
+    ret n.origin == key.origin && n.decl == key.decl;
+}
+
+# doc_component_name_span: the byte span to rewrite when a doc component's name is
+# renamed — the component in doc block `doc` (within `source`) whose name matches
+# the binding `query` (in `qf`), narrowed to the exact identifier token a rename
+# replaces. for a field or value parameter the component head is `# <name>:` and
+# the whole component `name_span` is the identifier, so it is returned as-is. for a
+# generic the component head keeps its syntactic `# [T]:` bracket form (see
+# `mach.lang.fe.doc`), so the returned span is the inner `T` only — the brackets
+# are preserved. none when no component matches, or (for a generic) the matched
+# component carries no bracketed identifier. matching compares the inner identifier
+# against `query` so a `# [T]:` head matches the generic named `T`.
+# ---
+# source:      the declaring module's source text (the doc block points into it)
+# doc:         the owning decl's `Decl.doc` span
+# qf:          the SourceFile backing `query`
+# query:       byte span of the field / param / generic binding name
+# is_generic:  true to match / rewrite the bracket form `# [T]:`
+# ret:         some(span to rewrite) for the matching component, or none
+pub fun doc_component_name_span(source: str, doc: token.Span, qf: *src.SourceFile, query: token.Span, is_generic: bool) Option[token.Span] {
+    if (doc.len == 0 || query.len == 0) { ret none[token.Span](); }
+    var it: fedoc.DocComponentIter = fedoc.component_iter(source, doc);
+    var c: fedoc.DocComponent;
+    for (fedoc.component_next(?it, ?c)) {
+        val ident: token.Span = component_ident(source, c.name_span, is_generic);
+        if (ident.len == 0) { cnt; }
+        if (span_bytes_equal_2(source, ident, qf, query)) { ret some[token.Span](ident); }
+    }
+    ret none[token.Span]();
+}
+
+# component_ident: the identifier token within a component name span — the whole
+# span for a plain `name`, or the bracketed inner identifier for a generic's `[T]`
+# head. an empty span when a generic head has no `[...]` enclosed single-word
+# identifier. the narrowing `doc_component_name_span` applies so a generic rename
+# rewrites `T` inside `[T]` without disturbing the brackets.
+fun component_ident(source: str, name: token.Span, is_generic: bool) token.Span {
+    if (!is_generic) { ret name; }
+    if (name.len < 3) { ret empty_span(); }
+    val lo: usize = name.offset;
+    val hi: usize = name.offset + name.len;
+    if (source[lo] != '[' || source[hi - 1] != ']') { ret empty_span(); }
+    var sp: token.Span;
+    sp.offset = lo + 1;
+    sp.len    = (hi - 1) - (lo + 1);
+    ret sp;
+}
+
+# empty_span: a zero-length span, the "absent" marker for component_ident.
+fun empty_span() token.Span {
+    var s: token.Span;
+    s.offset = 0;
+    s.len    = 0;
+    ret s;
+}
+
+# span_bytes_equal_2: true when span `sa` in `source` and span `sb` in `fb` cover
+# identical bytes. a cross-source compare where one side is a raw `str` (a doc
+# block lives in the declaring module's source) and the other a SourceFile (the
+# binding name) — bridging `same_source_span_equal` and `span_bytes_equal`.
+fun span_bytes_equal_2(source: str, sa: token.Span, fb: *src.SourceFile, sb: token.Span) bool {
+    if (sa.len != sb.len) { ret false; }
+    val b: *u8 = fb.text::*u8;
+    var i: usize = 0;
+    for (i < sa.len) {
+        if (source[sa.offset + i] != b[sb.offset + i]) { ret false; }
+        i = i + 1;
+    }
+    ret true;
 }
 
 # span_bytes_equal: true when the bytes of `sa` in `fa` exactly equal the bytes of

--- a/src/features.mach
+++ b/src/features.mach
@@ -695,40 +695,31 @@ fun type_name_span(a: *ast.Ast, tid: id.TypeId) Option[token.Span] {
     ret none[token.Span]();
 }
 
-# FIELD_NONE / FIELD_MEMBER / FIELD_STRUCT_LIT: the shape of a field reference the
-# cursor pivots to. a member access `foo.bar` carries the receiver expression to
-# type; a struct literal `T{ bar: ... }` carries the named type the field belongs
-# to. both also carry the referenced field-name span (the `.bar` / `bar` token).
-pub val FIELD_NONE:        u8 = 0;
-pub val FIELD_MEMBER:      u8 = 1;
-pub val FIELD_STRUCT_LIT:  u8 = 2;
-
 # FieldRef: a record / union field a cursor position references, before the field
 # is typed. name resolution leaves a value-field access unbound (`expr_resolved`
 # is SYMBOL_NIL for a MEMBER node), so this is the type-driven parallel to
-# `SymbolRef`: the feature layer resolves it to a field declaration through the
-# record's TypeId rather than the symbol table. the kind selects which of
-# `object` / `lit_ty` to follow.
+# `SymbolRef`: the feature layer resolves it to a field declaration through a
+# TypeId rather than the symbol table. `host` is the expression whose semantic
+# type names the record / union the field belongs to — the receiver for a member
+# access `foo.bar`, the struct literal itself for `T{ bar: ... }` (whose inferred
+# type is the record). the caller types `host`, peels it to a record site, then
+# matches `name_span` against the site's fields.
 # ---
-# kind:      FIELD_MEMBER (follow `object`) or FIELD_STRUCT_LIT (follow `lit_ty`)
-# object:    receiver expression id for a member access (EXPR_NIL otherwise)
-# lit_ty:    named type id of the struct literal (TYPE_NIL otherwise)
-# name_span: byte span of the referenced field-name token
+# host:      expression id to type (member receiver, or the struct literal itself)
+# name_span: byte span of the referenced field-name token (`.bar` / `bar`)
 pub rec FieldRef {
-    kind:      u8;
-    object:    id.ExprId;
-    lit_ty:    id.TypeId;
+    host:      id.ExprId;
     name_span: token.Span;
 }
 
 # field_ref_at: the record / union field a byte offset references through a member
 # access or a struct-literal field name, or none. the type-driven pivot for
 # go-to-definition on fields: `expr_resolved` never binds a value-field access, so
-# this recovers the field name (and the receiver / literal type the field decl is
-# reached through) directly from the syntax. it is consulted only when the
-# symbol-table pivot (`ref_at`) finds nothing, so an ordinary symbol still wins.
-# pure over the Ast — the actual field-decl lookup needs types and runs in the
-# caller via `field_decl_span`.
+# this recovers the field name and the expression whose type names the field's
+# record directly from the syntax. it is consulted only when the symbol-table
+# pivot (`ref_at`) finds nothing, so an ordinary symbol still wins. pure over the
+# Ast — the actual field-decl lookup needs types and runs in the caller via
+# `field_decl_span`.
 # ---
 # a:      the buffer's parsed Ast
 # offset: byte offset into the buffer
@@ -743,9 +734,7 @@ pub fun field_ref_at(a: *ast.Ast, offset: usize) Option[FieldRef] {
     if (e.kind == expr.EXPR_KIND_MEMBER) {
         if (!ast.span_contains(e.data.member.name, offset)) { ret none[FieldRef](); }
         var fr: FieldRef;
-        fr.kind      = FIELD_MEMBER;
-        fr.object    = e.data.member.object;
-        fr.lit_ty    = id.TYPE_NIL;
+        fr.host      = e.data.member.object;
         fr.name_span = e.data.member.name;
         ret some[FieldRef](fr);
     }
@@ -758,9 +747,7 @@ pub fun field_ref_at(a: *ast.Ast, offset: usize) Option[FieldRef] {
             val fi: *expr.FieldInit = ?a.field_inits[start + i];
             if (ast.span_contains(fi.name, offset)) {
                 var fr: FieldRef;
-                fr.kind      = FIELD_STRUCT_LIT;
-                fr.object    = id.EXPR_NIL;
-                fr.lit_ty    = e.data.struct_lit.ty;
+                fr.host      = eid;
                 fr.name_span = fi.name;
                 ret some[FieldRef](fr);
             }

--- a/src/features.mach
+++ b/src/features.mach
@@ -34,6 +34,8 @@ use std.types.result.is_err;
 use std.types.result.unwrap_ok;
 
 use std.allocator.Allocator;
+use std.allocator.allocate;
+use std.allocator.deallocate;
 use page: std.allocator.page;
 
 use sess:   mach.lang.session;
@@ -911,6 +913,48 @@ fun host_matches(sr: *sema.SemaResult, ti: *type.TypeInterner, eid: id.ExprId, k
     ret n.origin == key.origin && n.decl == key.decl;
 }
 
+# collect_field_sites: write into `out` (up to `cap` spans) every site naming the
+# keyed field in module (`a`, `sr`) and return the count. the spans are, in walk
+# order: every member-access / struct-literal init whose host type peels to the
+# keyed record (`field_ref_span_at` over `[0, a.expr_len)`), and — when `declaring`
+# (this module declares the record) — the field declaration's own name span, then
+# (when `want_doc` and the record's `doc` block carries a matching component) that
+# component's name token. this is the complete edit set a field rename applies to
+# one module and the location set references reports; it is pulled out of the JSON
+# emission so it can be asserted directly. the doc block is read from the declaring
+# module's source (`decl_src`), the same file `key.field_name` indexes into.
+# ---
+# a:         the module's Ast
+# sr:        the module's SemaResult
+# ti:        the session type interner
+# qf:        the SourceFile backing `a`
+# key:       the field identity
+# declaring: true when this module declares the record
+# want_doc:  true to include the doc component (rename); false for references
+# decl_src:  the declaring module's source text (for the doc block)
+# doc:       the record decl's `Decl.doc` span (empty when none)
+# out:       array of at least `cap` Span slots
+# cap:       capacity of `out`
+# ret:       number of spans written
+pub fun collect_field_sites(a: *ast.Ast, sr: *sema.SemaResult, ti: *type.TypeInterner, qf: *src.SourceFile, key: FieldKey, declaring: bool, want_doc: bool, decl_src: str, doc: token.Span, out: *token.Span, cap: usize) usize {
+    var n: usize = 0;
+    var ei: usize = 0;
+    for (ei < a.expr_len && n < cap) {
+        val so: Option[token.Span] = field_ref_span_at(a, sr, ti, ei::id.ExprId, qf, key);
+        if (is_some[token.Span](so)) { out[n] = unwrap[token.Span](so); n = n + 1; }
+        ei = ei + 1;
+    }
+    if (declaring && n < cap) {
+        out[n] = key.field_name;
+        n = n + 1;
+        if (want_doc && doc.len != 0 && n < cap) {
+            val co: Option[token.Span] = doc_component_name_span(decl_src, doc, key.decl_file, key.field_name, false);
+            if (is_some[token.Span](co)) { out[n] = unwrap[token.Span](co); n = n + 1; }
+        }
+    }
+    ret n;
+}
+
 # doc_component_name_span: the byte span to rewrite when a doc component's name is
 # renamed — the component in doc block `doc` (within `source`) whose name matches
 # the binding `query` (in `qf`), narrowed to the exact identifier token a rename
@@ -1309,4 +1353,439 @@ fun region_eq(source: str, span: token.Span, expect: str) bool {
         i = i + 1;
     }
     ret true;
+}
+
+# fk: a FieldKey naming the field at `[off, off + len)` in `decl_file` of the
+# record (`origin`, `decl`), the test builder for the field-reference matcher.
+fun fk(origin: u32, decl: u32, decl_file: *src.SourceFile, off: usize, len: usize) FieldKey {
+    var k: FieldKey;
+    k.origin     = origin::sess.ModuleId;
+    k.decl       = decl::id.DeclId;
+    k.decl_file  = decl_file;
+    k.field_name = span_at(off, len);
+    ret k;
+}
+
+# mk_sema: a standalone SemaResult with an `expr_type` array of `n` slots, every
+# slot TYPE_NIL. the test stand-in for sema's own typing output, so the field
+# matcher can be driven without a whole analysis. released with `free_sema`.
+fun mk_sema(pa: *Allocator, n: u32) sema.SemaResult {
+    var sr: sema.SemaResult;
+    sr.alloc            = pa;
+    sr.expr_type        = nil;
+    sr.type_resolved_ty = nil;
+    sr.decl_type        = nil;
+    sr.expr_count       = 0;
+    sr.type_count       = 0;
+    sr.decl_count       = 0;
+    if (n > 0) {
+        val r: Result[*type.TypeId, str] = allocate[type.TypeId](pa, n::usize);
+        if (!is_err[*type.TypeId, str](r)) {
+            sr.expr_type  = unwrap_ok[*type.TypeId, str](r);
+            sr.expr_count = n;
+            var i: u32 = 0;
+            for (i < n) { sr.expr_type[i] = type.TYPE_NIL; i = i + 1; }
+        }
+    }
+    ret sr;
+}
+
+fun free_sema(pa: *Allocator, sr: *sema.SemaResult) {
+    if (sr.expr_type != nil && sr.expr_count > 0) {
+        deallocate[type.TypeId](pa, sr.expr_type, sr.expr_count::usize);
+    }
+}
+
+# add_ident: append an IDENT expr spanning `[off, off + len)`, returning its id.
+# the receiver of a member access is an IDENT whose type the SemaResult carries.
+fun add_ident(a: *ast.Ast, off: usize, len: usize) id.ExprId {
+    var e: expr.Expr;
+    e.span = span_at(off, len);
+    e.kind = expr.EXPR_KIND_IDENT;
+    val r: Result[id.ExprId, str] = ast.add_expr(a, e);
+    ret unwrap_ok[id.ExprId, str](r);
+}
+
+# add_member: append a member access `obj.<name>` where `obj` is expr `object`
+# and the field-name token spans `[name_off, name_off + name_len)`, returning the
+# member expr id.
+fun add_member(a: *ast.Ast, object: id.ExprId, name_off: usize, name_len: usize) id.ExprId {
+    var e: expr.Expr;
+    e.span = span_at(name_off, name_len);
+    e.kind = expr.EXPR_KIND_MEMBER;
+    e.data.member.object = object;
+    e.data.member.name   = span_at(name_off, name_len);
+    val r: Result[id.ExprId, str] = ast.add_expr(a, e);
+    ret unwrap_ok[id.ExprId, str](r);
+}
+
+# add_struct_lit: append a struct literal with a single field init named over
+# `[name_off, name_off + name_len)`, returning the struct-lit expr id.
+fun add_struct_lit(a: *ast.Ast, name_off: usize, name_len: usize) id.ExprId {
+    var fi: expr.FieldInit;
+    fi.name  = span_at(name_off, name_len);
+    fi.value = id.EXPR_NIL;
+    val fr: Result[u32, str] = ast.add_field_init(a, fi);
+    val start: u32 = unwrap_ok[u32, str](fr);
+
+    var e: expr.Expr;
+    e.span = span_at(name_off, name_len);
+    e.kind = expr.EXPR_KIND_STRUCT_LIT;
+    e.data.struct_lit.ty           = id.TYPE_NIL;
+    e.data.struct_lit.fields_start = start;
+    e.data.struct_lit.fields_len   = 1;
+    val r: Result[id.ExprId, str] = ast.add_expr(a, e);
+    ret unwrap_ok[id.ExprId, str](r);
+}
+
+test "features: field_ref_span_at matches a member access of the keyed record" {
+    var pa: Allocator;
+    page.make(?pa);
+    var a: ast.Ast = ast.init(?pa, 0::src.FileId);
+    var ti: type.TypeInterner = unwrap_ok[type.TypeInterner, str](type.init(?pa));
+    # the record P is declared in module 2, decl 4; its field "x" lives at offset
+    # 8 of the declaring source. the buffer text "p.x" carries the member access.
+    val recp: type.TypeId = unwrap_ok[type.TypeId, str](
+        type.intern_nominal(?ti, intern.STR_NIL, 2::sess.ModuleId, 4::id.DeclId, type.TYPE_REC));
+    var declf: src.SourceFile = stub_file("rec P { x: i32; }");   # "x" at offset 8
+    var buf:   src.SourceFile = stub_file("p.x");
+
+    # expr 0 = receiver "p" (typed P); expr 1 = member access "p.x" (name "x"@2).
+    val recv: id.ExprId = add_ident(?a, 0, 1);
+    val mem:  id.ExprId = add_member(?a, recv, 2, 1);
+    var sr: sema.SemaResult = mk_sema(?pa, 2);
+    sr.expr_type[recv] = recp;
+
+    val key: FieldKey = fk(2, 4, ?declf, 8, 1);
+    var fail: bool = false;
+    val o: Option[token.Span] = field_ref_span_at(?a, ?sr, ?ti, mem, ?buf, key);
+    if (is_none[token.Span](o)) { fail = true; }
+    or {
+        val sp: token.Span = unwrap[token.Span](o);
+        if (sp.offset != 2 || sp.len != 1) { fail = true; }
+    }
+    # the receiver IDENT itself is not a member access — no field span.
+    if (is_some[token.Span](field_ref_span_at(?a, ?sr, ?ti, recv, ?buf, key))) { fail = true; }
+
+    free_sema(?pa, ?sr);
+    type.dnit(?ti);
+    ast.dnit(?a);
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+test "features: field_ref_span_at peels a pointer receiver to the record" {
+    var pa: Allocator;
+    page.make(?pa);
+    var a: ast.Ast = ast.init(?pa, 0::src.FileId);
+    var ti: type.TypeInterner = unwrap_ok[type.TypeInterner, str](type.init(?pa));
+    val recp: type.TypeId = unwrap_ok[type.TypeId, str](
+        type.intern_nominal(?ti, intern.STR_NIL, 1::sess.ModuleId, 0::id.DeclId, type.TYPE_REC));
+    val ptr: type.TypeId = unwrap_ok[type.TypeId, str](type.intern_pointer(?ti, recp));
+    var declf: src.SourceFile = stub_file("name");   # "name" at offset 0
+    var buf:   src.SourceFile = stub_file("q.name");
+
+    val recv: id.ExprId = add_ident(?a, 0, 1);
+    val mem:  id.ExprId = add_member(?a, recv, 2, 4);   # ".name"
+    var sr: sema.SemaResult = mk_sema(?pa, 2);
+    sr.expr_type[recv] = ptr;   # *P
+
+    val key: FieldKey = fk(1, 0, ?declf, 0, 4);
+    val ok: bool = is_some[token.Span](field_ref_span_at(?a, ?sr, ?ti, mem, ?buf, key));
+
+    free_sema(?pa, ?sr);
+    type.dnit(?ti);
+    ast.dnit(?a);
+    if (!ok) { ret 1; }
+    ret 0;
+}
+
+test "features: field_ref_span_at matches a struct-literal field init" {
+    var pa: Allocator;
+    page.make(?pa);
+    var a: ast.Ast = ast.init(?pa, 0::src.FileId);
+    var ti: type.TypeInterner = unwrap_ok[type.TypeInterner, str](type.init(?pa));
+    val recp: type.TypeId = unwrap_ok[type.TypeId, str](
+        type.intern_nominal(?ti, intern.STR_NIL, 3::sess.ModuleId, 1::id.DeclId, type.TYPE_REC));
+    var declf: src.SourceFile = stub_file("rec P { x: i32; }");   # "x" at offset 8
+    var buf:   src.SourceFile = stub_file("P{ x: 1 }");           # init "x" at offset 3
+
+    # expr 0 = the struct literal itself, typed P; its single init names "x"@3.
+    val lit: id.ExprId = add_struct_lit(?a, 3, 1);
+    var sr: sema.SemaResult = mk_sema(?pa, 1);
+    sr.expr_type[lit] = recp;
+
+    val key: FieldKey = fk(3, 1, ?declf, 8, 1);
+    var fail: bool = false;
+    val o: Option[token.Span] = field_ref_span_at(?a, ?sr, ?ti, lit, ?buf, key);
+    if (is_none[token.Span](o)) { fail = true; }
+    or {
+        val sp: token.Span = unwrap[token.Span](o);
+        if (sp.offset != 3 || sp.len != 1) { fail = true; }
+    }
+
+    free_sema(?pa, ?sr);
+    type.dnit(?ti);
+    ast.dnit(?a);
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+test "features: field_ref_span_at rejects a different record and a different field" {
+    var pa: Allocator;
+    page.make(?pa);
+    var a: ast.Ast = ast.init(?pa, 0::src.FileId);
+    var ti: type.TypeInterner = unwrap_ok[type.TypeInterner, str](type.init(?pa));
+    val recp: type.TypeId = unwrap_ok[type.TypeId, str](
+        type.intern_nominal(?ti, intern.STR_NIL, 2::sess.ModuleId, 4::id.DeclId, type.TYPE_REC));
+    var declf: src.SourceFile = stub_file("rec P { x: i32; }");   # "x" at offset 8
+    var buf:   src.SourceFile = stub_file("p.x");
+
+    val recv: id.ExprId = add_ident(?a, 0, 1);
+    val mem:  id.ExprId = add_member(?a, recv, 2, 1);
+    var sr: sema.SemaResult = mk_sema(?pa, 2);
+    sr.expr_type[recv] = recp;
+
+    var fail: bool = false;
+    # right record, wrong field name ("y" vs the access "x"): no match.
+    var decly: src.SourceFile = stub_file("y");
+    if (is_some[token.Span](field_ref_span_at(?a, ?sr, ?ti, mem, ?buf, fk(2, 4, ?decly, 0, 1)))) { fail = true; }
+    # right field name, wrong record identity (decl 9): no match.
+    if (is_some[token.Span](field_ref_span_at(?a, ?sr, ?ti, mem, ?buf, fk(2, 9, ?declf, 8, 1)))) { fail = true; }
+    # receiver untyped (TYPE_NIL): no match.
+    sr.expr_type[recv] = type.TYPE_NIL;
+    if (is_some[token.Span](field_ref_span_at(?a, ?sr, ?ti, mem, ?buf, fk(2, 4, ?declf, 8, 1)))) { fail = true; }
+
+    free_sema(?pa, ?sr);
+    type.dnit(?ti);
+    ast.dnit(?a);
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+# empty_doc: a zero-length doc span, for the no-doc test cases.
+fun empty_doc() token.Span {
+    var d: token.Span;
+    d.offset = 0;
+    d.len    = 0;
+    ret d;
+}
+
+test "features: collect_field_sites gathers every site, the decl, and the doc component (rename)" {
+    var pa: Allocator;
+    page.make(?pa);
+    var a: ast.Ast = ast.init(?pa, 0::src.FileId);
+    var ti: type.TypeInterner = unwrap_ok[type.TypeInterner, str](type.init(?pa));
+    val recp: type.TypeId = unwrap_ok[type.TypeId, str](
+        type.intern_nominal(?ti, intern.STR_NIL, 0::sess.ModuleId, 4::id.DeclId, type.TYPE_REC));
+
+    # the declaring module's source: the doc block then `rec P { x: i32; y: i32; }`.
+    # the doc `# x:` component name is at offset 18 (after "# a point\n# ---\n# ").
+    val declsrc: str = "# a point\n# ---\n# x: the abscissa\nrec P { x: i32; y: i32; }";
+    var declf: src.SourceFile = stub_file(declsrc);
+    var doc: token.Span;
+    doc.offset = 0;
+    doc.len    = 33;   # through the `# x: ...` component, before the rec body
+    # the field "x" name in the rec body sits at offset 42 (within `rec P { x`).
+    val xoff: usize = 42;
+
+    # the module under walk also contains two member accesses and a struct lit on x.
+    var buf: src.SourceFile = stub_file("p.x q.x P{ x: 1 }");
+    val r1: id.ExprId = add_ident(?a, 0, 1);          # "p"
+    val m1: id.ExprId = add_member(?a, r1, 2, 1);     # "p.x" name @2
+    val r2: id.ExprId = add_ident(?a, 4, 1);          # "q"
+    val m2: id.ExprId = add_member(?a, r2, 6, 1);     # "q.x" name @6
+    val lit: id.ExprId = add_struct_lit(?a, 11, 1);   # "P{ x" name @11
+    var sr: sema.SemaResult = mk_sema(?pa, 5);
+    sr.expr_type[r1]  = recp;
+    sr.expr_type[r2]  = recp;
+    sr.expr_type[lit] = recp;
+
+    val key: FieldKey = fk(0, 4, ?declf, xoff, 1);
+    var out: [8]token.Span;
+
+    var fail: bool = false;
+    # rename over the declaring module: two members, one init, the decl, the doc.
+    val n: usize = collect_field_sites(?a, ?sr, ?ti, ?buf, key, true, true, declsrc, doc, ?out[0], 8);
+    if (n != 5) { fail = true; }
+    or {
+        # the three body sites in walk order: m1@2, m2@6, lit@11.
+        if (out[0].offset != 2  || out[0].len != 1) { fail = true; }
+        if (out[1].offset != 6  || out[1].len != 1) { fail = true; }
+        if (out[2].offset != 11 || out[2].len != 1) { fail = true; }
+        # the field declaration name.
+        if (out[3].offset != xoff || out[3].len != 1) { fail = true; }
+        # the doc component name token "x" at offset 18.
+        if (!region_eq(declsrc, out[4], "x")) { fail = true; }
+        if (declsrc[out[4].offset - 2] != '#') { fail = true; }
+    }
+
+    free_sema(?pa, ?sr);
+    type.dnit(?ti);
+    ast.dnit(?a);
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+test "features: collect_field_sites omits the doc component for references (want_doc false)" {
+    var pa: Allocator;
+    page.make(?pa);
+    var a: ast.Ast = ast.init(?pa, 0::src.FileId);
+    var ti: type.TypeInterner = unwrap_ok[type.TypeInterner, str](type.init(?pa));
+    val recp: type.TypeId = unwrap_ok[type.TypeId, str](
+        type.intern_nominal(?ti, intern.STR_NIL, 0::sess.ModuleId, 4::id.DeclId, type.TYPE_REC));
+    val declsrc: str = "# a point\n# ---\n# x: the abscissa\nrec P { x: i32; }";
+    var declf: src.SourceFile = stub_file(declsrc);
+    var doc: token.Span;
+    doc.offset = 0;
+    doc.len    = 33;
+    var buf: src.SourceFile = stub_file("p.x");
+    val r1: id.ExprId = add_ident(?a, 0, 1);
+    val m1: id.ExprId = add_member(?a, r1, 2, 1);
+    var sr: sema.SemaResult = mk_sema(?pa, 2);
+    sr.expr_type[r1] = recp;
+
+    val key: FieldKey = fk(0, 4, ?declf, 42, 1);
+    var out: [4]token.Span;
+    # references: the one member access + the field decl, but NOT the doc component.
+    val n: usize = collect_field_sites(?a, ?sr, ?ti, ?buf, key, true, false, declsrc, doc, ?out[0], 4);
+
+    free_sema(?pa, ?sr);
+    type.dnit(?ti);
+    ast.dnit(?a);
+    if (n != 2) { ret 1; }
+    if (out[0].offset != 2) { ret 1; }
+    ret 0;
+}
+
+test "features: collect_field_sites in a non-declaring module yields only body sites" {
+    var pa: Allocator;
+    page.make(?pa);
+    var a: ast.Ast = ast.init(?pa, 0::src.FileId);
+    var ti: type.TypeInterner = unwrap_ok[type.TypeInterner, str](type.init(?pa));
+    # the record is declared in module 0; this is a different (importing) module
+    # whose only contribution is a member access on the imported record's value.
+    val recp: type.TypeId = unwrap_ok[type.TypeId, str](
+        type.intern_nominal(?ti, intern.STR_NIL, 0::sess.ModuleId, 4::id.DeclId, type.TYPE_REC));
+    var declf: src.SourceFile = stub_file("rec P { x: i32; }");   # "x" @8
+    var buf:   src.SourceFile = stub_file("p.x");
+    val r1: id.ExprId = add_ident(?a, 0, 1);
+    val m1: id.ExprId = add_member(?a, r1, 2, 1);
+    var sr: sema.SemaResult = mk_sema(?pa, 2);
+    sr.expr_type[r1] = recp;
+
+    val key: FieldKey = fk(0, 4, ?declf, 8, 1);
+    var out: [4]token.Span;
+    # declaring=false: no decl span, no doc — just the body site.
+    val n: usize = collect_field_sites(?a, ?sr, ?ti, ?buf, key, false, true, "", empty_doc(), ?out[0], 4);
+
+    free_sema(?pa, ?sr);
+    type.dnit(?ti);
+    ast.dnit(?a);
+    if (n != 1) { ret 1; }
+    if (out[0].offset != 2 || out[0].len != 1) { ret 1; }
+    ret 0;
+}
+
+test "features: collect_field_sites adds the decl but no doc edit when the record has no docstring" {
+    var pa: Allocator;
+    page.make(?pa);
+    var a: ast.Ast = ast.init(?pa, 0::src.FileId);
+    var ti: type.TypeInterner = unwrap_ok[type.TypeInterner, str](type.init(?pa));
+    val recp: type.TypeId = unwrap_ok[type.TypeId, str](
+        type.intern_nominal(?ti, intern.STR_NIL, 0::sess.ModuleId, 4::id.DeclId, type.TYPE_REC));
+    var declf: src.SourceFile = stub_file("rec P { x: i32; }");   # "x" @8
+    var buf:   src.SourceFile = stub_file("p.x");
+    val r1: id.ExprId = add_ident(?a, 0, 1);
+    val m1: id.ExprId = add_member(?a, r1, 2, 1);
+    var sr: sema.SemaResult = mk_sema(?pa, 2);
+    sr.expr_type[r1] = recp;
+
+    val key: FieldKey = fk(0, 4, ?declf, 8, 1);
+    var out: [4]token.Span;
+    # rename, declaring, but the doc span is empty -> the decl edit, no doc edit.
+    val n: usize = collect_field_sites(?a, ?sr, ?ti, ?buf, key, true, true, "rec P { x: i32; }", empty_doc(), ?out[0], 4);
+
+    free_sema(?pa, ?sr);
+    type.dnit(?ti);
+    ast.dnit(?a);
+    if (n != 2) { ret 1; }
+    if (out[0].offset != 2) { ret 1; }   # the member access
+    if (out[1].offset != 8) { ret 1; }   # the field decl
+    ret 0;
+}
+
+test "features: doc_component_name_span rewrites a plain field / param component" {
+    val txt: str = "# sums\n# ---\n# a: the addend\n# b: the augend\n";
+    var doc: token.Span;
+    doc.offset = 0;
+    doc.len    = str_len(txt);
+    var qf: src.SourceFile = stub_file("b");
+
+    var fail: bool = false;
+    val o: Option[token.Span] = doc_component_name_span(txt, doc, ?qf, span_at(0, 1), false);
+    if (is_none[token.Span](o)) { fail = true; }
+    or {
+        val sp: token.Span = unwrap[token.Span](o);
+        if (!region_eq(txt, sp, "b")) { fail = true; }
+        if (sp.len != 1) { fail = true; }
+        # it must be the component head "b", not the "b" inside "the augend".
+        if (txt[sp.offset - 2] != '#') { fail = true; }
+    }
+
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+test "features: doc_component_name_span rewrites the inner identifier of a generic [T]" {
+    val txt: str = "# a box\n# ---\n# [T]: the element\n# v: the value\n";
+    var doc: token.Span;
+    doc.offset = 0;
+    doc.len    = str_len(txt);
+    var qf: src.SourceFile = stub_file("T");
+
+    var fail: bool = false;
+    # generic match: the inner "T" only, brackets preserved.
+    val o: Option[token.Span] = doc_component_name_span(txt, doc, ?qf, span_at(0, 1), true);
+    if (is_none[token.Span](o)) { fail = true; }
+    or {
+        val sp: token.Span = unwrap[token.Span](o);
+        if (!region_eq(txt, sp, "T")) { fail = true; }
+        if (sp.len != 1) { fail = true; }
+        # the byte before the matched span is the '[' and after is the ']'.
+        if (txt[sp.offset - 1] != '[' || txt[sp.offset + sp.len] != ']') { fail = true; }
+    }
+    # the same query in non-generic mode must NOT match "[T]" (it is not "T").
+    if (is_some[token.Span](doc_component_name_span(txt, doc, ?qf, span_at(0, 1), false))) { fail = true; }
+
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+test "features: doc_component_name_span returns none with no doc, no match, summary-only" {
+    var qf: src.SourceFile = stub_file("x");
+    var fail: bool = false;
+
+    # empty doc span -> none.
+    var empty: token.Span;
+    empty.offset = 0;
+    empty.len    = 0;
+    if (is_some[token.Span](doc_component_name_span("", empty, ?qf, span_at(0, 1), false))) { fail = true; }
+
+    # a real doc block whose components do not include "x" -> none.
+    val txt: str = "# d\n# ---\n# a: one\n# b: two\n";
+    var doc: token.Span;
+    doc.offset = 0;
+    doc.len    = str_len(txt);
+    if (is_some[token.Span](doc_component_name_span(txt, doc, ?qf, span_at(0, 1), false))) { fail = true; }
+
+    # a summary-only block (no `# ---`) -> no components -> none.
+    val s2: str = "# just a summary mentioning x\n";
+    var d2: token.Span;
+    d2.offset = 0;
+    d2.len    = str_len(s2);
+    if (is_some[token.Span](doc_component_name_span(s2, d2, ?qf, span_at(0, 1), false))) { fail = true; }
+
+    if (fail) { ret 1; }
+    ret 0;
 }

--- a/src/features.mach
+++ b/src/features.mach
@@ -694,3 +694,150 @@ fun type_name_span(a: *ast.Ast, tid: id.TypeId) Option[token.Span] {
     if (t.kind == atype.TYPE_KIND_NAMED) { ret some[token.Span](t.data.named.name); }
     ret none[token.Span]();
 }
+
+# FIELD_NONE / FIELD_MEMBER / FIELD_STRUCT_LIT: the shape of a field reference the
+# cursor pivots to. a member access `foo.bar` carries the receiver expression to
+# type; a struct literal `T{ bar: ... }` carries the named type the field belongs
+# to. both also carry the referenced field-name span (the `.bar` / `bar` token).
+pub val FIELD_NONE:        u8 = 0;
+pub val FIELD_MEMBER:      u8 = 1;
+pub val FIELD_STRUCT_LIT:  u8 = 2;
+
+# FieldRef: a record / union field a cursor position references, before the field
+# is typed. name resolution leaves a value-field access unbound (`expr_resolved`
+# is SYMBOL_NIL for a MEMBER node), so this is the type-driven parallel to
+# `SymbolRef`: the feature layer resolves it to a field declaration through the
+# record's TypeId rather than the symbol table. the kind selects which of
+# `object` / `lit_ty` to follow.
+# ---
+# kind:      FIELD_MEMBER (follow `object`) or FIELD_STRUCT_LIT (follow `lit_ty`)
+# object:    receiver expression id for a member access (EXPR_NIL otherwise)
+# lit_ty:    named type id of the struct literal (TYPE_NIL otherwise)
+# name_span: byte span of the referenced field-name token
+pub rec FieldRef {
+    kind:      u8;
+    object:    id.ExprId;
+    lit_ty:    id.TypeId;
+    name_span: token.Span;
+}
+
+# field_ref_at: the record / union field a byte offset references through a member
+# access or a struct-literal field name, or none. the type-driven pivot for
+# go-to-definition on fields: `expr_resolved` never binds a value-field access, so
+# this recovers the field name (and the receiver / literal type the field decl is
+# reached through) directly from the syntax. it is consulted only when the
+# symbol-table pivot (`ref_at`) finds nothing, so an ordinary symbol still wins.
+# pure over the Ast — the actual field-decl lookup needs types and runs in the
+# caller via `field_decl_span`.
+# ---
+# a:      the buffer's parsed Ast
+# offset: byte offset into the buffer
+# ret:    some(FieldRef) on a field-name position, or none
+pub fun field_ref_at(a: *ast.Ast, offset: usize) Option[FieldRef] {
+    val eid: id.ExprId = ast.offset_to_expr(a, offset);
+    if (eid == id.EXPR_NIL) { ret none[FieldRef](); }
+    val eo: Option[*expr.Expr] = ast.get_expr(a, eid);
+    if (!is_some[*expr.Expr](eo)) { ret none[FieldRef](); }
+    val e: *expr.Expr = unwrap[*expr.Expr](eo);
+
+    if (e.kind == expr.EXPR_KIND_MEMBER) {
+        if (!ast.span_contains(e.data.member.name, offset)) { ret none[FieldRef](); }
+        var fr: FieldRef;
+        fr.kind      = FIELD_MEMBER;
+        fr.object    = e.data.member.object;
+        fr.lit_ty    = id.TYPE_NIL;
+        fr.name_span = e.data.member.name;
+        ret some[FieldRef](fr);
+    }
+
+    if (e.kind == expr.EXPR_KIND_STRUCT_LIT) {
+        val start: u32 = e.data.struct_lit.fields_start;
+        val len:   u32 = e.data.struct_lit.fields_len;
+        var i: u32 = 0;
+        for (i < len) {
+            val fi: *expr.FieldInit = ?a.field_inits[start + i];
+            if (ast.span_contains(fi.name, offset)) {
+                var fr: FieldRef;
+                fr.kind      = FIELD_STRUCT_LIT;
+                fr.object    = id.EXPR_NIL;
+                fr.lit_ty    = e.data.struct_lit.ty;
+                fr.name_span = fi.name;
+                ret some[FieldRef](fr);
+            }
+            i = i + 1;
+        }
+    }
+
+    ret none[FieldRef]();
+}
+
+# field_decl_span: the name span of the field declared in `decl_a` (its rec / uni
+# field range `[fields_start, fields_start + fields_len)` in `decl_a.typed_names`)
+# whose name bytes equal the referencing token `query` in `query_file`, or none
+# when no field matches. pure and session-free — the field-decl locator the
+# go-to-definition path drives once a value's type has been resolved to its record
+# site. comparing bytes across the two files lets the receiver and the declaration
+# live in different modules.
+# ---
+# decl_a:       the declaring module's Ast (its typed_names hold the fields)
+# decl_file:    the SourceFile backing `decl_a` (field-name bytes)
+# fields_start: start index of the field range in `decl_a.typed_names`
+# fields_len:   number of fields
+# query_file:   the SourceFile backing the referencing token
+# query:        byte span of the referenced field name
+# ret:          some(field name span in `decl_a`), or none
+pub fun field_decl_span(decl_a: *ast.Ast, decl_file: *src.SourceFile, fields_start: u32, fields_len: u32, query_file: *src.SourceFile, query: token.Span) Option[token.Span] {
+    if (query.len == 0) { ret none[token.Span](); }
+    var i: u32 = 0;
+    for (i < fields_len) {
+        val tn: *decl.TypedName = ?decl_a.typed_names[fields_start + i];
+        if (span_bytes_equal(decl_file, tn.name, query_file, query)) {
+            ret some[token.Span](tn.name);
+        }
+        i = i + 1;
+    }
+    ret none[token.Span]();
+}
+
+# field_decl_self_at: the name span of the rec / uni field whose own declaration
+# name covers `offset` in `decl_file`, or none. resolves the field's declaration
+# site to itself (go-to-definition on a field where it is declared). scans the
+# field range `[fields_start, fields_start + fields_len)` in `decl_a.typed_names`.
+# ---
+# decl_a:       the Ast holding the field declarations
+# decl_file:    the SourceFile backing `decl_a`
+# fields_start: start index of the field range in `decl_a.typed_names`
+# fields_len:   number of fields
+# offset:       byte offset into `decl_file`
+# ret:          some(field name span) when the offset is on a field name, or none
+pub fun field_decl_self_at(decl_a: *ast.Ast, fields_start: u32, fields_len: u32, offset: usize) Option[token.Span] {
+    var i: u32 = 0;
+    for (i < fields_len) {
+        val tn: *decl.TypedName = ?decl_a.typed_names[fields_start + i];
+        if (ast.span_contains(tn.name, offset)) { ret some[token.Span](tn.name); }
+        i = i + 1;
+    }
+    ret none[token.Span]();
+}
+
+# span_bytes_equal: true when the bytes of `sa` in `fa` exactly equal the bytes of
+# `sb` in `fb`. the cross-file identifier compare the field-decl locator matches a
+# field name against the referencing token with — the two may sit in different
+# source files (a field declared in a dependency, referenced in the buffer).
+# ---
+# fa: source file backing span `sa`
+# sa: byte span in `fa`
+# fb: source file backing span `sb`
+# sb: byte span in `fb`
+# ret: true on an exact byte-for-byte match
+pub fun span_bytes_equal(fa: *src.SourceFile, sa: token.Span, fb: *src.SourceFile, sb: token.Span) bool {
+    if (sa.len != sb.len) { ret false; }
+    val a: *u8 = fa.text::*u8;
+    val b: *u8 = fb.text::*u8;
+    var i: usize = 0;
+    for (i < sa.len) {
+        if (a[sa.offset + i] != b[sb.offset + i]) { ret false; }
+        i = i + 1;
+    }
+    ret true;
+}

--- a/src/features.mach
+++ b/src/features.mach
@@ -47,6 +47,7 @@ use decl:   mach.lang.fe.ast.decl;
 use stmt:   mach.lang.fe.ast.stmt;
 use expr:   mach.lang.fe.ast.expr;
 use atype:  mach.lang.fe.ast.type;
+use fedoc:  mach.lang.fe.doc;
 use res:    mach.lang.fe.resolve;
 
 # SymbolRef: a symbol a position references, joined with the location of the
@@ -433,54 +434,64 @@ fun param_signature_span(a: *ast.Ast, sym: *res.Symbol) Option[token.Span] {
     ret some[token.Span](sp);
 }
 
-# doc_comment_span: the byte span of the contiguous run of `#` comment lines
-# immediately above a local symbol's declaration — its doc comment. the lexer
-# discards comment tokens, so this back-scans the file's line index the way
-# `mach doc` scans raw text: from the decl's line it walks backward over
-# comment lines (tolerating leading whitespace before the `#`), stopping at
-# the first non-comment line. none for a param / generic, a decl with no
-# comment run flush above it, or a decl on the first line.
+# doc_span_of: the first-class doc-block span the parser attached to a local
+# symbol's declaration (`Decl.doc`) — the `#`-comment run directly above the
+# decl with its `#[...]` attribute lines excluded, or none. the attribute-aware
+# replacement for the old source line-scan: it carries no `#[attr]` bytes, so the
+# rendered doc never folds in attribute syntax. none for a param / generic (which
+# carry no Decl node), a decl with no docstring (empty `doc` span), or an absent /
+# out-of-range decl.
 # ---
-# a:    the Ast owning the decl
-# sym:  the symbol whose doc comment is wanted
-# file: the source file owning the decl
-# ret:  some(span) covering the comment run (its line endings included), or none
-pub fun doc_comment_span(a: *ast.Ast, sym: *res.Symbol, file: *src.SourceFile) Option[token.Span] {
+# a:   the Ast owning the decl
+# sym: the symbol whose doc block is wanted
+# ret: some(span) covering the doc block within the file text, or none
+pub fun doc_span_of(a: *ast.Ast, sym: *res.Symbol) Option[token.Span] {
     if (sym.kind == res.SYM_PARAM || sym.kind == res.SYM_GENERIC) { ret none[token.Span](); }
-    val dso: Option[token.Span] = decl_span_of(a, sym);
-    if (!is_some[token.Span](dso)) { ret none[token.Span](); }
-    val decl_line: usize = src.position(file, unwrap[token.Span](dso).offset).line;
-
-    var first: usize = decl_line;
-    for (first > 1 && comment_line(file, first - 1)) { first = first - 1; }
-    if (first == decl_line) { ret none[token.Span](); }
-
-    val so: Option[usize] = src.line_start(file, first);
-    val eo: Option[usize] = src.line_start(file, decl_line);
-    if (!is_some[usize](so) || !is_some[usize](eo)) { ret none[token.Span](); }
-
-    var sp: token.Span;
-    sp.offset = unwrap[usize](so);
-    sp.len    = unwrap[usize](eo) - sp.offset;
-    ret some[token.Span](sp);
+    if (sym.decl == id.DECL_NIL) { ret none[token.Span](); }
+    val d_opt: Option[*decl.Decl] = ast.get_decl(a, sym.decl);
+    if (!is_some[*decl.Decl](d_opt)) { ret none[token.Span](); }
+    val d: *decl.Decl = unwrap[*decl.Decl](d_opt);
+    if (d.doc.len == 0) { ret none[token.Span](); }
+    ret some[token.Span](d.doc);
 }
 
-# first_nonspace: index of the first non-space, non-tab byte in `s` at or after
-# `pos`, clamped to `end`. shared by the doc-comment scan and its renderer.
-pub fun first_nonspace(s: *u8, pos: usize, end: usize) usize {
-    var i: usize = pos;
-    for (i < end && (s[i] == ' ' || s[i] == '\t')) { i = i + 1; }
-    ret i;
+# field_doc_desc: the description span of the component in the record / union doc
+# block `doc` whose component name matches the field name `field_name` — scanned
+# through `fe/doc.mach`'s component cursor, comparing each component's `name_span`
+# bytes against the field-name bytes. both spans index into the declaring module's
+# `source`, since the doc block and the field declaration share that file. none
+# when the doc block has no matching component, no component block at all, or an
+# empty matching description.
+# ---
+# source:     the declaring module's source text (both spans point into it)
+# doc:        the record / union declaration's `Decl.doc` span
+# field_name: the field's declared-name span in `source`
+# ret:        some(description span) for the matching component, or none
+pub fun field_doc_desc(source: str, doc: token.Span, field_name: token.Span) Option[token.Span] {
+    if (doc.len == 0 || field_name.len == 0) { ret none[token.Span](); }
+    var it: fedoc.DocComponentIter = fedoc.component_iter(source, doc);
+    var c: fedoc.DocComponent;
+    for (fedoc.component_next(?it, ?c)) {
+        if (same_source_span_equal(source, c.name_span, field_name)) {
+            if (c.desc_span.len == 0) { ret none[token.Span](); }
+            ret some[token.Span](c.desc_span);
+        }
+    }
+    ret none[token.Span]();
 }
 
-# comment_line: true when the 1-based `line`'s first significant byte is `#`.
-fun comment_line(file: *src.SourceFile, line: usize) bool {
-    val bo: Option[src.LineSpan] = src.line_bounds(file, line);
-    if (!is_some[src.LineSpan](bo)) { ret false; }
-    val lb: src.LineSpan = unwrap[src.LineSpan](bo);
-    val s: *u8 = file.text::*u8;
-    val i: usize = first_nonspace(s, lb.start, lb.end);
-    ret i < lb.end && s[i] == '#';
+# same_source_span_equal: true when spans `a` and `b` cover identical bytes within
+# the single source text `source`. the same-file analogue of `span_bytes_equal`,
+# used to match a doc component's name against a field name (both spans into the
+# declaring module's source).
+fun same_source_span_equal(source: str, a: token.Span, b: token.Span) bool {
+    if (a.len != b.len) { ret false; }
+    var i: usize = 0;
+    for (i < a.len) {
+        if (source[a.offset + i] != source[b.offset + i]) { ret false; }
+        i = i + 1;
+    }
+    ret true;
 }
 
 # kind_label: a human-readable label for a symbol kind, for hover rendering.

--- a/src/features.mach
+++ b/src/features.mach
@@ -999,3 +999,159 @@ test "features: field_decl_self_at hits a field name and misses elsewhere" {
     if (fail) { ret 1; }
     ret 0;
 }
+
+# add_doc_fun: append a function decl carrying the doc-block span `[doc_off,
+# doc_off + doc_len)` to `a`, returning its DeclId. the function payload is left
+# zeroed; only `kind` and `doc` matter for the doc-retrieval tests.
+fun add_doc_fun(a: *ast.Ast, doc_off: usize, doc_len: usize) id.DeclId {
+    var d: decl.Decl;
+    d.kind             = decl.DECL_KIND_FUN;
+    d.flags            = 0;
+    d.doc.offset       = doc_off;
+    d.doc.len          = doc_len;
+    d.decorators_start = 0;
+    d.decorators_len   = 0;
+    d.data.fun_.name.offset   = 0;
+    d.data.fun_.name.len      = 0;
+    d.data.fun_.generics_start = 0;
+    d.data.fun_.generics_len   = 0;
+    d.data.fun_.params_start   = 0;
+    d.data.fun_.params_len     = 0;
+    d.data.fun_.return_type    = id.TYPE_NIL;
+    d.data.fun_.body           = id.STMT_NIL;
+    val r: Result[id.DeclId, str] = ast.add_decl(a, d);
+    ret unwrap_ok[id.DeclId, str](r);
+}
+
+# fun_sym: a SYM_FUN symbol whose decl is `did`, for the doc-retrieval tests.
+fun fun_sym(did: id.DeclId) res.Symbol {
+    var s: res.Symbol;
+    s.kind   = res.SYM_FUN;
+    s.name   = intern.STR_NIL;
+    s.decl   = did;
+    s.slot   = 0;
+    s.origin = 0::sess.ModuleId;
+    ret s;
+}
+
+test "features: doc_span_of returns the decl's first-class doc span" {
+    var pa: Allocator;
+    page.make(?pa);
+    var a: ast.Ast = ast.init(?pa, 0::src.FileId);
+    val did: id.DeclId = add_doc_fun(?a, 4, 9);
+    var sym: res.Symbol = fun_sym(did);
+
+    var fail: bool = false;
+    val o: Option[token.Span] = doc_span_of(?a, ?sym);
+    if (is_none[token.Span](o)) { fail = true; }
+    or {
+        val sp: token.Span = unwrap[token.Span](o);
+        if (sp.offset != 4 || sp.len != 9) { fail = true; }
+    }
+
+    ast.dnit(?a);
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+test "features: doc_span_of returns none for a decl with no docstring" {
+    var pa: Allocator;
+    page.make(?pa);
+    var a: ast.Ast = ast.init(?pa, 0::src.FileId);
+    val did: id.DeclId = add_doc_fun(?a, 0, 0);   # empty doc span = no docstring
+    var sym: res.Symbol = fun_sym(did);
+
+    val ok: bool = is_none[token.Span](doc_span_of(?a, ?sym));
+    ast.dnit(?a);
+    if (!ok) { ret 1; }
+    ret 0;
+}
+
+test "features: doc_span_of returns none for a param symbol" {
+    var pa: Allocator;
+    page.make(?pa);
+    var a: ast.Ast = ast.init(?pa, 0::src.FileId);
+    val did: id.DeclId = add_doc_fun(?a, 4, 9);
+    var sym: res.Symbol = fun_sym(did);
+    sym.kind = res.SYM_PARAM;
+
+    val ok: bool = is_none[token.Span](doc_span_of(?a, ?sym));
+    ast.dnit(?a);
+    if (!ok) { ret 1; }
+    ret 0;
+}
+
+test "features: field_doc_desc finds the matching component's description" {
+    # the doc block and the rec body share one source, so the field-name query
+    # span and the component name span both point into `src` — the same-file
+    # match field_doc_desc performs in `field_hover_markdown`.
+    #             0         1         2         3         4         5         6         7         8         9
+    #             0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456
+    val src: str = "# a point\n# ---\n# x: the horizontal coordinate\n# y: the vertical coordinate\nrec P { x: i32; y: i32; }";
+    var doc: token.Span;
+    doc.offset = 0;
+    doc.len    = 75;   # through the end of the `# y: ...` component, before the rec body
+    # the rec-body field names: "x" at offset 84, "y" at offset 92.
+
+    var fail: bool = false;
+    # "y" field -> the "y" component description.
+    val oy: Option[token.Span] = field_doc_desc(src, doc, name_span_in(92, 1));
+    if (is_none[token.Span](oy)) { fail = true; }
+    or {
+        val sp: token.Span = unwrap[token.Span](oy);
+        if (!region_eq(src, sp, "the vertical coordinate")) { fail = true; }
+    }
+    # "x" field -> the "x" component description.
+    val ox: Option[token.Span] = field_doc_desc(src, doc, name_span_in(84, 1));
+    if (is_none[token.Span](ox)) { fail = true; }
+    or {
+        val sp: token.Span = unwrap[token.Span](ox);
+        if (!region_eq(src, sp, "the horizontal coordinate")) { fail = true; }
+    }
+
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+test "features: field_doc_desc returns none when no component matches" {
+    val src: str = "# a point\n# ---\n# x: the horizontal coordinate\nrec P { z: i32; }";
+    var doc: token.Span;
+    doc.offset = 0;
+    doc.len    = 46;
+    # "z" field name at offset 55 — no matching component.
+    val ok: bool = is_none[token.Span](field_doc_desc(src, doc, name_span_in(55, 1)));
+    if (!ok) { ret 1; }
+    ret 0;
+}
+
+test "features: field_doc_desc returns none for a summary-only doc block" {
+    val src: str = "# just a summary, no components\nrec P { x: i32; }";
+    var doc: token.Span;
+    doc.offset = 0;
+    doc.len    = 31;
+    # "x" field name at offset 40 — the block has no component lines.
+    val ok: bool = is_none[token.Span](field_doc_desc(src, doc, name_span_in(40, 1)));
+    if (!ok) { ret 1; }
+    ret 0;
+}
+
+# name_span_in: a span over `[offset, offset + len)`, the test builder for a
+# field-name query into the shared doc/body source.
+fun name_span_in(offset: usize, len: usize) token.Span {
+    var sp: token.Span;
+    sp.offset = offset;
+    sp.len    = len;
+    ret sp;
+}
+
+# region_eq: true when `span` of `source` equals the byte content of `expect`.
+fun region_eq(source: str, span: token.Span, expect: str) bool {
+    val n: usize = str_len(expect);
+    if (span.len != n) { ret false; }
+    var i: usize = 0;
+    for (i < n) {
+        if (source[span.offset + i] != expect[i]) { ret false; }
+        i = i + 1;
+    }
+    ret true;
+}

--- a/src/language.mach
+++ b/src/language.mach
@@ -632,6 +632,395 @@ fun reply_result(alloc: *Allocator, id_raw: str, result: str) {
     json.free_str(id_raw, alloc);
 }
 
+# FieldTarget: a record / union field resolved from a cursor, the type-driven twin
+# of a SymbolRef for the field references / rename / prepareRename paths. carries
+# the field's cross-module identity (`key`), the record's declaring site (`rs`,
+# for the field-declaration span and its doc block), and whether that site is the
+# active buffer (so the declaring module's edits — the field decl name and the doc
+# component — are placed in the buffer's URI rather than a loaded module's).
+# ---
+# key:            the field's cross-module identity
+# rs:             the record's declaring site (field range, Ast, file, doc)
+# decl_in_buffer: true when the record is declared in the active buffer
+rec FieldTarget {
+    key:            features.FieldKey;
+    rs:             project.RecordSite;
+    decl_in_buffer: bool;
+}
+
+# field_target_at: the record / union field a cursor references, resolved to its
+# cross-module identity and declaring site, or none. drives the field references /
+# rename / prepareRename paths: pivots the offset through `field_ref_at` (a member
+# access or struct-literal field name) or `field_self_at` (a field's own decl
+# name), types the host expression, peels it to a `RecordSite`, and matches the
+# field name to recover its declaring span. none when the position is not on a
+# field, the host cannot be typed, or no field matches. requires a loaded project
+# root for typing.
+# ---
+# ws:     the workspace
+# an:     the analyzed request document
+# offset: cursor byte offset into the buffer
+# ret:    some(FieldTarget) on a field position, or none
+fun field_target_at(ws: *project.Workspace, an: *Analyzed, offset: usize) Option[FieldTarget] {
+    if (an.root == nil) { ret none[FieldTarget](); }
+
+    val fo: Option[features.FieldRef] = features.field_ref_at(an.a, offset);
+    if (is_some[features.FieldRef](fo)) {
+        val fr: features.FieldRef = unwrap[features.FieldRef](fo);
+        val sr_r: Result[*sema.SemaResult, str] = project.sema_doc(ws, an.root, an.fid);
+        if (is_err[*sema.SemaResult, str](sr_r)) { ret none[FieldTarget](); }
+        val tid: type.TypeId = project.type_of(unwrap_ok[*sema.SemaResult, str](sr_r), fr.host);
+        val rso: Option[project.RecordSite] = project.record_decl_in(ws, an.root, an.own, an.a, an.file, tid);
+        if (!is_some[project.RecordSite](rso)) { ret none[FieldTarget](); }
+        val rs: project.RecordSite = unwrap[project.RecordSite](rso);
+        val spo: Option[token.Span] = features.field_decl_span(rs.a, rs.file, rs.fields_start, rs.fields_len, an.file, fr.name_span);
+        if (!is_some[token.Span](spo)) { ret none[FieldTarget](); }
+        ret some[FieldTarget](make_field_target(an, rs, unwrap[token.Span](spo)));
+    }
+
+    # the cursor may sit on a field's own declaration name inside a rec / uni in
+    # the buffer; resolve it to itself, then to that record's site for the walk.
+    val self_o: Option[FieldSelf] = field_self_at(an, offset);
+    if (is_some[FieldSelf](self_o)) {
+        val fs: FieldSelf = unwrap[FieldSelf](self_o);
+        val did: id.DeclId = ast.offset_to_decl(an.a, offset);
+        val rso: Option[project.RecordSite] = project.record_site_at(ws, an.root, an.own, an.a, an.file, did);
+        if (!is_some[project.RecordSite](rso)) { ret none[FieldTarget](); }
+        ret some[FieldTarget](make_field_target(an, unwrap[project.RecordSite](rso), fs.name));
+    }
+
+    ret none[FieldTarget]();
+}
+
+# make_field_target: assemble a FieldTarget from a resolved record site and the
+# field's declared-name span. the field name and its source live in the record's
+# declaring module (`rs.file`), which is the cross-module byte identity every
+# other module's references are matched against.
+fun make_field_target(an: *Analyzed, rs: project.RecordSite, field_name: token.Span) FieldTarget {
+    var t: FieldTarget;
+    t.key.origin     = rs.origin;
+    t.key.decl       = rs.decl;
+    t.key.decl_file  = rs.file;
+    t.key.field_name = field_name;
+    t.rs             = rs;
+    t.decl_in_buffer = rs.origin == an.own;
+    ret t;
+}
+
+# FieldXRef: one module contributing field references — its Ast, SemaResult (for
+# typing each host expression), source file, document URI, and whether it is the
+# record's declaring module (so its field-declaration name span and doc component
+# are emitted). the active buffer is always `out[0]`; each other loaded module
+# that types a reference is another (owned `file://` URI freed by free_field_refs).
+rec FieldXRef {
+    a:        *ast.Ast;
+    sr:       *sema.SemaResult;
+    file:     *src.SourceFile;
+    uri:      str;
+    declaring: bool;
+}
+
+# build_field_refs: populate `out` with the modules that reference the keyed field
+# and return the count. `out[0]` is always the active buffer (live SemaResult);
+# each subsequent entry is a loaded module whose SemaResult types at least one
+# reference to the field, skipping the buffer's on-disk twin so its live edits are
+# not double-counted. every module is walked (a field is reachable wherever its
+# record is imported), so this is not gated on project ownership — the rename gate
+# is applied separately by the caller.
+# ---
+# ws:    the workspace
+# an:    the active buffer's analysis
+# uri:   the active buffer's document URI
+# t:     the resolved field target
+# out:   array of at least `cap` FieldXRef slots
+# cap:   capacity of `out` (module_count + 1)
+# ret:   number of populated entries (>= 1), or 0 when the buffer cannot be typed
+fun build_field_refs(ws: *project.Workspace, an: Analyzed, uri: str, t: FieldTarget, out: *FieldXRef, cap: usize) usize {
+    val sr_r: Result[*sema.SemaResult, str] = project.sema_doc(ws, an.root, an.fid);
+    if (is_err[*sema.SemaResult, str](sr_r)) { ret 0; }
+    out[0].a         = an.a;
+    out[0].sr        = unwrap_ok[*sema.SemaResult, str](sr_r);
+    out[0].file      = an.file;
+    out[0].uri       = uri;
+    out[0].declaring = t.decl_in_buffer;
+    var n: usize = 1;
+
+    val self_o: Option[sess.ModuleId] = project.module_for_uri(ws, an.root, uri);
+    val have_self: bool = is_some[sess.ModuleId](self_o);
+    var self_mid: sess.ModuleId = 0::sess.ModuleId;
+    if (have_self) { self_mid = unwrap[sess.ModuleId](self_o); }
+
+    val mc: u32 = project.module_count(an.root);
+    var mid: u32 = 0;
+    for (mid < mc && n < cap) {
+        val cur: sess.ModuleId = mid::sess.ModuleId;
+        if (have_self && cur == self_mid) { mid = mid + 1; cnt; }
+        val mv_o: Option[project.ModuleView] = project.module_view(ws, an.root, cur);
+        val ms_o: Option[*sema.SemaResult] = project.module_sema(ws, an.root, cur);
+        if (!is_some[project.ModuleView](mv_o) || !is_some[*sema.SemaResult](ms_o)) { mid = mid + 1; cnt; }
+        val muri: str = project.module_uri(ws, an.root, cur);
+        if (muri == nil) { mid = mid + 1; cnt; }
+        val mv: project.ModuleView = unwrap[project.ModuleView](mv_o);
+        out[n].a         = mv.a;
+        out[n].sr        = unwrap[*sema.SemaResult](ms_o);
+        out[n].file      = mv.file;
+        out[n].uri       = muri;
+        out[n].declaring = cur == t.key.origin;
+        n = n + 1;
+        mid = mid + 1;
+    }
+    ret n;
+}
+
+# free_field_refs: release the owned `file://` URIs of the graph-module entries.
+# refs[0] borrows the request URI and is skipped.
+fun free_field_refs(ws: *project.Workspace, refs: *FieldXRef, n: usize) {
+    var i: usize = 1;
+    for (i < n) {
+        if (refs[i].uri != nil) { json.free_str(refs[i].uri, ws.alloc); }
+        i = i + 1;
+    }
+}
+
+# walk_field_sites: feed every site naming the keyed field in module `s` to the
+# sink — every member access / struct-literal init whose host type peels to the
+# keyed record, plus (when `s` is the record's declaring module) the field
+# declaration's own name span and, for rename, the matching `# <field>:` doc
+# component name token. the field decl and doc spans always carry the field name
+# and bypass the (nil) spelling guard.
+fun walk_field_sites(s: *FieldXRef, ti: *type.TypeInterner, t: FieldTarget, want_doc: bool, k: *WalkSink) {
+    var ei: usize = 0;
+    for (ei < s.a.expr_len) {
+        val so: Option[token.Span] = features.field_ref_span_at(s.a, s.sr, ti, ei::id.ExprId, s.file, t.key);
+        if (is_some[token.Span](so)) { sink_emit(k, s.file, s.uri, unwrap[token.Span](so)); }
+        ei = ei + 1;
+    }
+    if (s.declaring) {
+        sink_emit(k, s.file, s.uri, t.key.field_name);
+        if (want_doc) {
+            val d_opt: Option[*decl.Decl] = ast.get_decl(t.rs.a, t.rs.decl);
+            if (is_some[*decl.Decl](d_opt)) {
+                val d: *decl.Decl = unwrap[*decl.Decl](d_opt);
+                if (d.doc.len != 0) {
+                    val co: Option[token.Span] = features.doc_component_name_span(t.rs.file.text, d.doc, t.rs.file, t.key.field_name, false);
+                    if (is_some[token.Span](co)) { sink_emit(k, s.file, s.uri, unwrap[token.Span](co)); }
+                }
+            }
+        }
+    }
+}
+
+# field_references: the type-driven references path for a record / union field.
+# resolves the field, walks every loaded module's SemaResult collecting its
+# member-access / struct-literal sites plus the field declaration, and emits a
+# Location[]. true when a field was resolved and replied; false (without replying)
+# so the caller falls back to an empty array.
+fun field_references(ws: *project.Workspace, alloc: *Allocator, an: *Analyzed, uri: str, offset: usize, id_raw: str) bool {
+    val to: Option[FieldTarget] = field_target_at(ws, an, offset);
+    if (!is_some[FieldTarget](to)) { ret false; }
+    val t: FieldTarget = unwrap[FieldTarget](to);
+
+    val cap: usize = (project.module_count(an.root) + 1)::usize;
+    val ra: Result[*FieldXRef, str] = allocate[FieldXRef](alloc, cap);
+    if (is_err[*FieldXRef, str](ra)) { ret false; }
+    val refs: *FieldXRef = unwrap_ok[*FieldXRef, str](ra);
+
+    val n: usize = build_field_refs(ws, @an, uri, t, refs, cap);
+    if (n == 0) { deallocate[FieldXRef](alloc, refs, cap); ret false; }
+
+    emit_field_locations(ws, alloc, id_raw, refs, n, t);
+    free_field_refs(ws, refs, n);
+    deallocate[FieldXRef](alloc, refs, cap);
+    ret true;
+}
+
+# field_rename: the type-driven rename path for a record / union field. refuses
+# (returns false without replying — the caller emits an empty edit) when the
+# field's record is declared in a vendored dependency: such a declaration is not
+# the editor's to rewrite. otherwise resolves the field, walks every loaded
+# module, and emits a WorkspaceEdit replacing every member-access / struct-literal
+# site, the field declaration, and the record's matching doc component. true when
+# the edit was replied.
+fun field_rename(ws: *project.Workspace, alloc: *Allocator, an: *Analyzed, uri: str, offset: usize, id_raw: str, new_name: str) bool {
+    val to: Option[FieldTarget] = field_target_at(ws, an, offset);
+    if (!is_some[FieldTarget](to)) { ret false; }
+    val t: FieldTarget = unwrap[FieldTarget](to);
+
+    if (!field_record_renameable(ws, an.root, uri, t)) { reply_empty_edit(alloc, id_raw); ret true; }
+
+    val cap: usize = (project.module_count(an.root) + 1)::usize;
+    val ra: Result[*FieldXRef, str] = allocate[FieldXRef](alloc, cap);
+    if (is_err[*FieldXRef, str](ra)) { ret false; }
+    val refs: *FieldXRef = unwrap_ok[*FieldXRef, str](ra);
+
+    val n: usize = build_field_refs(ws, @an, uri, t, refs, cap);
+    if (n == 0) { deallocate[FieldXRef](alloc, refs, cap); reply_empty_edit(alloc, id_raw); ret true; }
+
+    emit_field_rename(ws, alloc, id_raw, refs, n, t, new_name);
+    free_field_refs(ws, refs, n);
+    deallocate[FieldXRef](alloc, refs, cap);
+    ret true;
+}
+
+# field_record_renameable: whether the field's record is the editor's to rewrite —
+# the same gate the symbol rename `renameable` applies, keyed on the record's
+# declaring module. a record declared in a loaded module keys directly on
+# `is_project_module`; a record declared in the active buffer keys on the buffer's
+# on-disk twin (a dependency source opened for editing has a loaded twin that is
+# not project-owned), and on the buffer's governing root not being a vendored
+# dependency project when it has no twin.
+fun field_record_renameable(ws: *project.Workspace, root: *project.Root, uri: str, t: FieldTarget) bool {
+    if (!t.decl_in_buffer) { ret project.is_project_module(ws, root, t.key.origin); }
+    val twin_o: Option[sess.ModuleId] = project.module_for_uri(ws, root, uri);
+    if (!is_some[sess.ModuleId](twin_o)) { ret !project.root_vendored(root); }
+    ret project.is_project_module(ws, root, unwrap[sess.ModuleId](twin_o));
+}
+
+# field_prepare_span: write the field-name span the cursor sits on into `out` and
+# return true when it resolves to a field of a project-owned record, or false. the
+# prepareRename gate for field positions.
+fun field_prepare_span(ws: *project.Workspace, an: *Analyzed, uri: str, offset: usize, out: *token.Span) bool {
+    val to: Option[FieldTarget] = field_target_at(ws, an, offset);
+    if (!is_some[FieldTarget](to)) { ret false; }
+    val t: FieldTarget = unwrap[FieldTarget](to);
+    if (!field_record_renameable(ws, an.root, uri, t)) { ret false; }
+    # the range reported is the cursor's own field-name token in the buffer; the
+    # decl-site name lives in the record's module, which may not be the buffer.
+    val fo: Option[features.FieldRef] = features.field_ref_at(an.a, offset);
+    if (is_some[features.FieldRef](fo)) { @out = unwrap[features.FieldRef](fo).name_span; ret true; }
+    val self_o: Option[FieldSelf] = field_self_at(an, offset);
+    if (is_some[FieldSelf](self_o)) { @out = unwrap[FieldSelf](self_o).name; ret true; }
+    ret false;
+}
+
+# emit_field_locations: send a Location[] of every field site across `refs` (each
+# module's member-access / struct-literal sites plus the field declaration). takes
+# ownership of `id_raw` and frees it.
+fun emit_field_locations(ws: *project.Workspace, alloc: *Allocator, id_raw: str, refs: *FieldXRef, nref: usize, t: FieldTarget) {
+    val ti: *type.TypeInterner = project.type_interner(ws);
+    val prefix: str = "{\"jsonrpc\":\"2.0\",\"id\":";
+    val mid:    str = ",\"result\":[";
+    val suffix: str = "]}";
+
+    var k: WalkSink = sink_init(alloc, nil, nil);
+    var si: usize = 0;
+    for (si < nref) { walk_field_sites(?refs[si], ti, t, false, ?k); si = si + 1; }
+
+    val total: usize = str_len(prefix) + str_len(id_raw) + str_len(mid) + k.total + str_len(suffix);
+    val br: Result[*u8, str] = allocate[u8](alloc, total + 1);
+    if (is_err[*u8, str](br)) { reply_empty_array(alloc, id_raw); ret; }
+    val buf: *u8 = unwrap_ok[*u8, str](br);
+
+    var off: usize = 0;
+    off = append(buf, off, prefix);
+    off = append(buf, off, id_raw);
+    off = append(buf, off, mid);
+    k.buf   = buf;
+    k.off   = off;
+    k.count = 0;
+    var sj: usize = 0;
+    for (sj < nref) { walk_field_sites(?refs[sj], ti, t, false, ?k); sj = sj + 1; }
+    off = k.off;
+    off = append(buf, off, suffix);
+    buf[off] = 0;
+    transport.send_message(buf::str, alloc);
+    deallocate[u8](alloc, buf, total + 1);
+    json.free_str(id_raw, alloc);
+}
+
+# emit_field_rename: send a WorkspaceEdit renaming the field to `new_name` across
+# `refs`, one `changes` entry per module. each entry rewrites that module's
+# member-access / struct-literal sites; the declaring module's entry also rewrites
+# the field declaration and the record's matching doc component. takes ownership of
+# `id_raw` and frees it.
+fun emit_field_rename(ws: *project.Workspace, alloc: *Allocator, id_raw: str, refs: *FieldXRef, nref: usize, t: FieldTarget, new_name: str) {
+    val ti: *type.TypeInterner = project.type_interner(ws);
+    val qname: str = json.quote(new_name, alloc);
+    if (qname == nil) { reply_empty_edit(alloc, id_raw); ret; }
+
+    val ga: Result[*str, str] = allocate[str](alloc, nref);
+    if (is_err[*str, str](ga)) { json.free_str(qname, alloc); reply_empty_edit(alloc, id_raw); ret; }
+    val groups: *str = unwrap_ok[*str, str](ga);
+
+    val prefix: str = "{\"jsonrpc\":\"2.0\",\"id\":";
+    val mid:    str = ",\"result\":{\"changes\":{";
+    val suffix: str = "}}}";
+    var total: usize = str_len(prefix) + str_len(id_raw) + str_len(mid) + str_len(suffix);
+    var ng: usize = 0;
+    var si: usize = 0;
+    for (si < nref) {
+        val g: str = field_rename_group_json(?refs[si], ti, t, qname, alloc);
+        if (g != nil) {
+            if (ng > 0) { total = total + 1; }
+            total = total + str_len(g);
+            groups[ng] = g;
+            ng = ng + 1;
+        }
+        si = si + 1;
+    }
+
+    val br: Result[*u8, str] = allocate[u8](alloc, total + 1);
+    if (is_err[*u8, str](br)) {
+        free_groups(groups, ng, alloc);
+        deallocate[str](alloc, groups, nref);
+        json.free_str(qname, alloc);
+        reply_empty_edit(alloc, id_raw); ret;
+    }
+    val buf: *u8 = unwrap_ok[*u8, str](br);
+
+    var off: usize = 0;
+    off = append(buf, off, prefix);
+    off = append(buf, off, id_raw);
+    off = append(buf, off, mid);
+    var gi: usize = 0;
+    for (gi < ng) {
+        if (gi > 0) { buf[off] = ','; off = off + 1; }
+        off = append(buf, off, groups[gi]);
+        gi = gi + 1;
+    }
+    off = append(buf, off, suffix);
+    buf[off] = 0;
+    transport.send_message(buf::str, alloc);
+    deallocate[u8](alloc, buf, total + 1);
+
+    free_groups(groups, ng, alloc);
+    deallocate[str](alloc, groups, nref);
+    json.free_str(qname, alloc);
+    json.free_str(id_raw, alloc);
+}
+
+# field_rename_group_json: the `changes`-map entry `"<uri>":[<edits>]` for module
+# `s`, rewriting its field sites (and, for the declaring module, the declaration
+# and doc component) to the quoted `qname`, or nil when `s` contributes no edit.
+fun field_rename_group_json(s: *FieldXRef, ti: *type.TypeInterner, t: FieldTarget, qname: str, alloc: *Allocator) str {
+    val quri: str = json.quote(s.uri, alloc);
+    if (quri == nil) { ret nil; }
+
+    var k: WalkSink = sink_init(alloc, qname, nil);
+    walk_field_sites(s, ti, t, true, ?k);
+    if (k.count == 0) { json.free_str(quri, alloc); ret nil; }
+
+    val open:  str = ":[";
+    val close: str = "]";
+    val total: usize = str_len(quri) + str_len(open) + k.total + str_len(close);
+    val r: Result[*u8, str] = allocate[u8](alloc, total + 1);
+    if (is_err[*u8, str](r)) { json.free_str(quri, alloc); ret nil; }
+    val buf: *u8 = unwrap_ok[*u8, str](r);
+
+    var off: usize = 0;
+    off = append(buf, off, quri);
+    off = append(buf, off, open);
+    k.buf   = buf;
+    k.off   = off;
+    k.count = 0;
+    walk_field_sites(s, ti, t, true, ?k);
+    off = k.off;
+    off = append(buf, off, close);
+    buf[off] = 0;
+    json.free_str(quri, alloc);
+    ret buf::str;
+}
+
 # references: answer textDocument/references with every Location resolving to
 # the symbol at the cursor — its declaration plus every use-site across the
 # loaded project graph (the requesting buffer and every other module that
@@ -646,7 +1035,13 @@ pub fun references(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Al
     val offset: usize = unwrap[usize](off_o);
 
     val ro: Option[features.SymbolRef] = features.ref_at(an.a, an.rr, an.own, offset);
-    if (!is_some[features.SymbolRef](ro)) { reply_empty_array(alloc, id_raw); ret; }
+    if (!is_some[features.SymbolRef](ro)) {
+        # name resolution leaves a value-field access unbound, so a cursor on a
+        # field name yields no SymbolRef — fall through to the type-driven field
+        # references before giving up.
+        if (field_references(ws, alloc, ?an, uri, offset, id_raw)) { ret; }
+        reply_empty_array(alloc, id_raw); ret;
+    }
     val sr: features.SymbolRef = unwrap[features.SymbolRef](ro);
 
     val so: Option[*res.Symbol] = features.symbol(an.rr, sr.sym_id);
@@ -692,7 +1087,12 @@ pub fun rename(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Alloca
     val offset: usize = unwrap[usize](off_o);
 
     val ro: Option[features.SymbolRef] = features.ref_at(an.a, an.rr, an.own, offset);
-    if (!is_some[features.SymbolRef](ro)) { reply_empty_edit(alloc, id_raw); json.free_str(new_name, alloc); ret; }
+    if (!is_some[features.SymbolRef](ro)) {
+        # a cursor on a field name yields no SymbolRef — fall through to the
+        # type-driven field rename, which gates on the record's ownership.
+        if (field_rename(ws, alloc, ?an, uri, offset, id_raw, new_name)) { json.free_str(new_name, alloc); ret; }
+        reply_empty_edit(alloc, id_raw); json.free_str(new_name, alloc); ret;
+    }
     val sr: features.SymbolRef = unwrap[features.SymbolRef](ro);
 
     val so: Option[*res.Symbol] = features.symbol(an.rr, sr.sym_id);
@@ -708,6 +1108,13 @@ pub fun rename(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Alloca
 
     var bind: token.Span;
     val has_bind: bool = binding_span(an, sr.sym_id, ?bind);
+
+    # a param / generic carries its name in its owning decl's docstring component
+    # block too (`# <param>:` / `# [T]:`); rename rewrites that name token in the
+    # buffer where the decl lives. a fun / rec / val / etc. summary line no longer
+    # carries the name, so only param / generic bindings contribute a doc edit.
+    var doc: token.Span;
+    val has_doc: bool = param_generic_doc_span(an, sym, name, ?doc);
 
     val cap: usize = (project.module_count(an.root) + 1)::usize;
     val ra: Result[*XRef, str] = allocate[XRef](alloc, cap);
@@ -725,15 +1132,41 @@ pub fun rename(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Alloca
         reply_empty_edit(alloc, id_raw);
         ret;
     }
-    emit_rename(alloc, id_raw, refs, n, new_name, name, bind, has_bind);
+    emit_rename(alloc, id_raw, refs, n, new_name, name, bind, has_bind, doc, has_doc);
     free_refs(ws, refs, n);
     deallocate[XRef](alloc, refs, cap);
     json.free_str(new_name, alloc);
 }
 
+# param_generic_doc_span: write the doc-component name token for a param / generic
+# symbol's binding into `out` and return true, or false when the symbol is not a
+# param / generic, its owning decl has no docstring, or no component matches its
+# name. the doc block lives in the buffer the decl is declared in, so its name span
+# (`Decl.doc` resolved through `mach.lang.fe.doc`) is a buffer edit. a generic's
+# component head is the bracket form `# [T]:`, so the returned span is the inner
+# identifier only (the brackets stay).
+fun param_generic_doc_span(an: Analyzed, sym: *res.Symbol, name: str, out: *token.Span) bool {
+    if (sym.kind != res.SYM_PARAM && sym.kind != res.SYM_GENERIC) { ret false; }
+    if (sym.decl == id.DECL_NIL) { ret false; }
+    val d_opt: Option[*decl.Decl] = ast.get_decl(an.a, sym.decl);
+    if (!is_some[*decl.Decl](d_opt)) { ret false; }
+    val d: *decl.Decl = unwrap[*decl.Decl](d_opt);
+    if (d.doc.len == 0) { ret false; }
+
+    val bo: Option[token.Span] = features.binding_name_span(an.a, sym);
+    if (!is_some[token.Span](bo)) { ret false; }
+    val is_generic: bool = sym.kind == res.SYM_GENERIC;
+    val co: Option[token.Span] = features.doc_component_name_span(an.file.text, d.doc, an.file, unwrap[token.Span](bo), is_generic);
+    if (!is_some[token.Span](co)) { ret false; }
+    @out = unwrap[token.Span](co);
+    ret true;
+}
+
 # prepare_rename: answer textDocument/prepareRename with the range of the name
 # token at the cursor when it is a renameable symbol (a buffer-local symbol, or a
-# project-owned cross-module one), or null when it is not the editor's to rename.
+# project-owned cross-module one) or a field of a known, project-owned record, or
+# null when it is not the editor's to rename (an unresolved position, a dependency
+# symbol, or a field of a vendored record).
 pub fun prepare_rename(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
     val id_raw: str = json.extract_raw(body, "\"id\"", alloc);
     if (id_raw == nil) { ret; }
@@ -744,21 +1177,32 @@ pub fun prepare_rename(ws: *project.Workspace, es: *editor.EditorSession, alloc:
     val offset: usize = unwrap[usize](off_o);
 
     val ro: Option[features.SymbolRef] = features.ref_at(an.a, an.rr, an.own, offset);
-    if (!is_some[features.SymbolRef](ro)) { reply_null(alloc, id_raw); ret; }
+    if (!is_some[features.SymbolRef](ro)) {
+        # a cursor on a field name yields no SymbolRef — accept it when it resolves
+        # to a field of a project-owned record (the same gate field rename uses).
+        var name_span: token.Span;
+        if (field_prepare_span(ws, ?an, uri, offset, ?name_span)) {
+            reply_range(alloc, id_raw, an.file, name_span); ret;
+        }
+        reply_null(alloc, id_raw); ret;
+    }
     val sr: features.SymbolRef = unwrap[features.SymbolRef](ro);
 
     val so: Option[*res.Symbol] = features.symbol(an.rr, sr.sym_id);
     if (!is_some[*res.Symbol](so)) { reply_null(alloc, id_raw); ret; }
     if (!renameable(ws, an.root, uri, unwrap[*res.Symbol](so), sr)) { reply_null(alloc, id_raw); ret; }
 
-    val range: positions.LspRange = positions.range_of(an.file, sr.name_span);
-    val rng: str = range_json(range, alloc);
+    reply_range(alloc, id_raw, an.file, sr.name_span);
+}
 
+# reply_range: send a prepareRename success reply carrying the range of `span` in
+# `file`, freeing `id_raw`. shared by the symbol and field prepare paths.
+fun reply_range(alloc: *Allocator, id_raw: str, file: *src.SourceFile, span: token.Span) {
+    val rng: str = range_json(positions.range_of(file, span), alloc);
     val p1: str = "{\"jsonrpc\":\"2.0\",\"id\":";
     val p2: str = ",\"result\":";
     val p3: str = "}";
     send6(alloc, p1, id_raw, p2, rng, p3, nil, nil);
-
     json.free_str(rng, alloc);
     json.free_str(id_raw, alloc);
 }
@@ -1008,46 +1452,49 @@ fun sink_init(alloc: *Allocator, qname: str, guard: str) WalkSink {
     ret k;
 }
 
-# sink_emit: size or write one Location / TextEdit for `span` of source `s`,
-# per the sink's mode.
-fun sink_emit(k: *WalkSink, s: *XRef, span: token.Span) {
+# sink_emit: size or write one Location / TextEdit for `span` in `file` (located
+# at `uri`), per the sink's mode. taking `file` / `uri` rather than a source
+# record lets the symbol walk (XRef) and the field walk (FieldXRef) share it.
+fun sink_emit(k: *WalkSink, file: *src.SourceFile, uri: str, span: token.Span) {
     if (k.qname == nil) {
-        if (k.buf == nil) { k.total = k.total + loc_len(s.file, s.uri, span, k.alloc, k.count); }
-        or                { k.off   = put_loc(k.buf, k.off, s.file, s.uri, span, k.alloc, k.count); }
+        if (k.buf == nil) { k.total = k.total + loc_len(file, uri, span, k.alloc, k.count); }
+        or                { k.off   = put_loc(k.buf, k.off, file, uri, span, k.alloc, k.count); }
     }
     or {
-        if (k.buf == nil) { k.total = k.total + edit_len(s.file, span, k.qname, k.alloc, k.count); }
-        or                { k.off   = put_edit(k.buf, k.off, s.file, span, k.qname, k.alloc, k.count); }
+        if (k.buf == nil) { k.total = k.total + edit_len(file, span, k.qname, k.alloc, k.count); }
+        or                { k.off   = put_edit(k.buf, k.off, file, span, k.qname, k.alloc, k.count); }
     }
     k.count = k.count + 1;
 }
 
 # walk_refs: feed every reference to `s.target` in source `s` to the sink — the
 # declaration name, `use` / `fwd` import-path leaves, and the body (expr / type)
-# use-sites, plus the active buffer's param / generic binding when
-# `include_bind`. body spans pass the sink's spelling guard (see WalkSink);
-# declaration and import leaves always carry the declared name and are exempt.
-fun walk_refs(s: *XRef, include_bind: bool, bind: token.Span, k: *WalkSink) {
+# use-sites, plus the active buffer's param / generic binding when `include_bind`
+# and its owning decl's matching doc-component name token when `include_doc`. body
+# spans pass the sink's spelling guard (see WalkSink); declaration, import leaves,
+# binding, and doc-component spans always carry the declared name and are exempt.
+fun walk_refs(s: *XRef, include_bind: bool, bind: token.Span, include_doc: bool, doc: token.Span, k: *WalkSink) {
     if (s.target == res.SYMBOL_NIL) { ret; }
-    if (include_bind) { sink_emit(k, s, bind); }
+    if (include_bind) { sink_emit(k, s.file, s.uri, bind); }
+    if (include_doc)  { sink_emit(k, s.file, s.uri, doc); }
     var di: usize = 0;
     for (di < s.a.decl_len) {
         val dso: Option[token.Span] = features.decl_ref_span(s.a, s.rr, di::id.DeclId, s.target);
-        if (is_some[token.Span](dso)) { sink_emit(k, s, unwrap[token.Span](dso)); }
+        if (is_some[token.Span](dso)) { sink_emit(k, s.file, s.uri, unwrap[token.Span](dso)); }
         val iso: Option[token.Span] = features.import_ref_span(s.a, s.rr, di::id.DeclId, s.target, s.file);
-        if (is_some[token.Span](iso)) { sink_emit(k, s, unwrap[token.Span](iso)); }
+        if (is_some[token.Span](iso)) { sink_emit(k, s.file, s.uri, unwrap[token.Span](iso)); }
         di = di + 1;
     }
     var ei: usize = 0;
     for (ei < s.a.expr_len) {
         val so: Option[token.Span] = features.expr_ref_span(s.a, s.rr, ei::id.ExprId, s.target);
-        if (is_some[token.Span](so) && guard_admits(s, k, unwrap[token.Span](so))) { sink_emit(k, s, unwrap[token.Span](so)); }
+        if (is_some[token.Span](so) && guard_admits(s, k, unwrap[token.Span](so))) { sink_emit(k, s.file, s.uri, unwrap[token.Span](so)); }
         ei = ei + 1;
     }
     var ti: usize = 0;
     for (ti < s.a.type_len) {
         val so: Option[token.Span] = features.type_ref_span(s.a, s.rr, ti::id.TypeId, s.target);
-        if (is_some[token.Span](so) && guard_admits(s, k, unwrap[token.Span](so))) { sink_emit(k, s, unwrap[token.Span](so)); }
+        if (is_some[token.Span](so) && guard_admits(s, k, unwrap[token.Span](so))) { sink_emit(k, s.file, s.uri, unwrap[token.Span](so)); }
         ti = ti + 1;
     }
 }
@@ -1068,9 +1515,10 @@ fun emit_locations(alloc: *Allocator, id_raw: str, refs: *XRef, nref: usize, bin
     val mid:    str = ",\"result\":[";
     val suffix: str = "]}";
 
+    var empty: token.Span;
     var k: WalkSink = sink_init(alloc, nil, nil);
     var si: usize = 0;
-    for (si < nref) { walk_refs(?refs[si], si == 0 && has_bind, bind, ?k); si = si + 1; }
+    for (si < nref) { walk_refs(?refs[si], si == 0 && has_bind, bind, false, empty, ?k); si = si + 1; }
 
     val total: usize = str_len(prefix) + str_len(id_raw) + str_len(mid) + k.total + str_len(suffix);
     val br: Result[*u8, str] = allocate[u8](alloc, total + 1);
@@ -1086,7 +1534,7 @@ fun emit_locations(alloc: *Allocator, id_raw: str, refs: *XRef, nref: usize, bin
     k.off   = off;
     k.count = 0;
     var sj: usize = 0;
-    for (sj < nref) { walk_refs(?refs[sj], sj == 0 && has_bind, bind, ?k); sj = sj + 1; }
+    for (sj < nref) { walk_refs(?refs[sj], sj == 0 && has_bind, bind, false, empty, ?k); sj = sj + 1; }
     off = k.off;
 
     off = append(buf, off, suffix);
@@ -1100,9 +1548,10 @@ fun emit_locations(alloc: *Allocator, id_raw: str, refs: *XRef, nref: usize, bin
 # files in `refs`, one `changes` entry per file. each entry renames the
 # declaration, the import-path leaves, and every body reference spelled with the
 # declared name `name` (so an aliased import's references are not rewritten); the
-# active buffer's param / generic binding is included when `has_bind`. takes
-# ownership of `id_raw` and frees it.
-fun emit_rename(alloc: *Allocator, id_raw: str, refs: *XRef, nref: usize, new_name: str, name: str, bind: token.Span, has_bind: bool) {
+# active buffer's param / generic binding is included when `has_bind`, and its
+# owning decl's matching doc-component name token when `has_doc`. takes ownership
+# of `id_raw` and frees it.
+fun emit_rename(alloc: *Allocator, id_raw: str, refs: *XRef, nref: usize, new_name: str, name: str, bind: token.Span, has_bind: bool, doc: token.Span, has_doc: bool) {
     val qname: str = json.quote(new_name, alloc);
     if (qname == nil) { reply_empty_edit(alloc, id_raw); ret; }
 
@@ -1117,7 +1566,7 @@ fun emit_rename(alloc: *Allocator, id_raw: str, refs: *XRef, nref: usize, new_na
     var ng: usize = 0;
     var si: usize = 0;
     for (si < nref) {
-        val g: str = rename_group_json(?refs[si], si == 0 && has_bind, bind, name, qname, alloc);
+        val g: str = rename_group_json(?refs[si], si == 0 && has_bind, bind, si == 0 && has_doc, doc, name, qname, alloc);
         if (g != nil) {
             if (ng > 0) { total = total + 1; }
             total = total + str_len(g);
@@ -1160,15 +1609,16 @@ fun emit_rename(alloc: *Allocator, id_raw: str, refs: *XRef, nref: usize, new_na
 # rename_group_json: the `changes`-map entry `"<uri>":[<edits>]` for source `s`,
 # renaming the declaration, import-path leaves, and every body reference spelled
 # `name` to the already-quoted `qname` (via the shared walk; see WalkSink), or
-# nil when `s` contributes no edit. the active buffer's param / generic binding
-# is included when `include_bind`.
-fun rename_group_json(s: *XRef, include_bind: bool, bind: token.Span, name: str, qname: str, alloc: *Allocator) str {
+# nil when `s` contributes no edit. the active buffer's param / generic binding is
+# included when `include_bind` and its owning decl's doc-component name token when
+# `include_doc`.
+fun rename_group_json(s: *XRef, include_bind: bool, bind: token.Span, include_doc: bool, doc: token.Span, name: str, qname: str, alloc: *Allocator) str {
     if (s.target == res.SYMBOL_NIL) { ret nil; }
     val quri: str = json.quote(s.uri, alloc);
     if (quri == nil) { ret nil; }
 
     var k: WalkSink = sink_init(alloc, qname, name);
-    walk_refs(s, include_bind, bind, ?k);
+    walk_refs(s, include_bind, bind, include_doc, doc, ?k);
     if (k.count == 0) { json.free_str(quri, alloc); ret nil; }
 
     val open:  str = ":[";
@@ -1184,7 +1634,7 @@ fun rename_group_json(s: *XRef, include_bind: bool, bind: token.Span, name: str,
     k.buf   = buf;
     k.off   = off;
     k.count = 0;
-    walk_refs(s, include_bind, bind, ?k);
+    walk_refs(s, include_bind, bind, include_doc, doc, ?k);
     off = k.off;
     off = append(buf, off, close);
     buf[off] = 0;

--- a/src/language.mach
+++ b/src/language.mach
@@ -27,7 +27,6 @@ use std.types.size.usize;
 use std.types.string.str;
 use std.types.string.str_len;
 use std.types.string.str_equals;
-use std.types.string.str_starts_with;
 use std.types.option.Option;
 use std.types.option.some;
 use std.types.option.none;
@@ -52,6 +51,8 @@ use token:  mach.lang.fe.token;
 use ast:    mach.lang.fe.ast;
 use id:     mach.lang.fe.ast.id;
 use decl:   mach.lang.fe.ast.decl;
+use atype:  mach.lang.fe.ast.type;
+use fedoc:  mach.lang.fe.doc;
 use res:    mach.lang.fe.resolve;
 use sema:   mach.lang.fe.sema;
 
@@ -93,7 +94,13 @@ pub fun hover(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocat
     val offset: usize = unwrap[usize](off_o);
 
     val ro: Option[features.SymbolRef] = features.ref_at(an.a, an.rr, an.own, offset);
-    if (!is_some[features.SymbolRef](ro)) { reply_null(alloc, id_raw); ret; }
+    if (!is_some[features.SymbolRef](ro)) {
+        # name resolution leaves a value-field access unbound, so a cursor on a
+        # field name yields no SymbolRef — fall through to the type-driven field
+        # hover before giving up.
+        if (field_hover(ws, alloc, ?an, offset, id_raw)) { ret; }
+        reply_null(alloc, id_raw); ret;
+    }
     val sr: features.SymbolRef = unwrap[features.SymbolRef](ro);
 
     val so: Option[*res.Symbol] = features.symbol(an.rr, sr.sym_id);
@@ -103,11 +110,18 @@ pub fun hover(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocat
     val md: str = hover_markdown(ws, an, sym, uri, alloc);
     if (md == nil) { reply_null(alloc, id_raw); ret; }
 
+    reply_hover(alloc, id_raw, an.file, sr.name_span, md);
+}
+
+# reply_hover: send a `textDocument/hover` reply rendering Markdown `md` over the
+# name span `name_span` in `file`, freeing `md` and `id_raw`. nil-replies when the
+# Markdown cannot be quoted. shared by the symbol and field hover paths.
+fun reply_hover(alloc: *Allocator, id_raw: str, file: *src.SourceFile, name_span: token.Span, md: str) {
     val qmd: str = json.quote(md, alloc);
     json.free_str(md, alloc);
     if (qmd == nil) { reply_null(alloc, id_raw); ret; }
 
-    val range: positions.LspRange = positions.range_of(an.file, sr.name_span);
+    val range: positions.LspRange = positions.range_of(file, name_span);
     val rng: str = range_json(range, alloc);
 
     val p1: str = "{\"jsonrpc\":\"2.0\",\"id\":";
@@ -119,6 +133,152 @@ pub fun hover(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocat
     json.free_str(rng, alloc);
     json.free_str(qmd, alloc);
     json.free_str(id_raw, alloc);
+}
+
+# field_hover: the type-driven hover path for a record / union field, consulted
+# when the symbol-table pivot finds nothing at `offset`. types the referencing
+# expression (a member access `foo.bar` or a struct-literal field name
+# `T{ bar: ... }`), peels it to its record site, and renders the field's name,
+# its declared type, and — when the record's doc block carries a matching
+# `# <name>: <desc>` component — that description. cross-module aware: the record
+# may be declared in a dependency module, in which case its Ast / file / doc all
+# come from the loaded module. emits the hover over the cursor's field-name span
+# and returns true when a field was rendered; returns false (without replying) so
+# the caller can fall back to a null reply. requires a loaded project root.
+# ---
+# ws:     the workspace
+# alloc:  request allocator
+# an:     the analyzed request document
+# offset: cursor byte offset into the buffer
+# id_raw: the raw JSON request id (for the reply)
+# ret:    true when a field hover was rendered and replied
+fun field_hover(ws: *project.Workspace, alloc: *Allocator, an: *Analyzed, offset: usize, id_raw: str) bool {
+    if (an.root == nil) { ret false; }
+
+    val fo: Option[features.FieldRef] = features.field_ref_at(an.a, offset);
+    if (!is_some[features.FieldRef](fo)) { ret false; }
+    val fr: features.FieldRef = unwrap[features.FieldRef](fo);
+
+    val sr_r: Result[*sema.SemaResult, str] = project.sema_doc(ws, an.root, an.fid);
+    if (is_err[*sema.SemaResult, str](sr_r)) { ret false; }
+    val sr: *sema.SemaResult = unwrap_ok[*sema.SemaResult, str](sr_r);
+
+    val tid: type.TypeId = project.type_of(sr, fr.host);
+    val rso: Option[project.RecordSite] = project.record_decl_in(ws, an.root, an.own, an.a, an.file, tid);
+    if (!is_some[project.RecordSite](rso)) { ret false; }
+    val rs: project.RecordSite = unwrap[project.RecordSite](rso);
+
+    val md: str = field_hover_markdown(rs, an.file, fr.name_span, alloc);
+    if (md == nil) { ret false; }
+
+    reply_hover(alloc, id_raw, an.file, fr.name_span, md);
+    ret true;
+}
+
+# field_hover_markdown: a fenced `mach` code block rendering a field as
+# `<name>: <type>`, with the field's matching doc component description following
+# as prose when present. the field is located by matching the cursor's field-name
+# bytes `query` (in `query_file`, the buffer) against the record site's declared
+# field names; name and type spans are read from the declaring module's source so
+# a cross-module field renders. nil when no field matches, the field name cannot
+# be read, or allocation fails. a field with no matching doc component renders the
+# `name: type` block alone (no description, no error).
+fun field_hover_markdown(rs: project.RecordSite, query_file: *src.SourceFile, query: token.Span, alloc: *Allocator) str {
+    val i: usize = field_index(rs, query_file, query);
+    if (i >= rs.fields_len::usize) { ret nil; }
+    val tn: *decl.TypedName = ?rs.a.typed_names[rs.fields_start + i::u32];
+
+    val name: str = positions.span_text(rs.file, tn.name, alloc);
+    if (name == nil) { ret nil; }
+    val ty: str = field_type_text(rs, tn, alloc);
+
+    var doc: str = nil;
+    val do_opt: Option[*decl.Decl] = ast.get_decl(rs.a, rs.decl);
+    if (is_some[*decl.Decl](do_opt)) {
+        val d: *decl.Decl = unwrap[*decl.Decl](do_opt);
+        val dso: Option[token.Span] = features.field_doc_desc(rs.file.text, d.doc, tn.name);
+        if (is_some[token.Span](dso)) { doc = doc_desc_prose(rs.file, unwrap[token.Span](dso), alloc); }
+    }
+
+    val r: str = compose_field_hover(name, ty, doc, alloc);
+    json.free_str(name, alloc);
+    json.free_str(ty, alloc);
+    json.free_str(doc, alloc);
+    ret r;
+}
+
+# field_index: the index into the record site's field range whose declared name
+# bytes equal `query` (in `query_file`), or fields_len when no field matches. the
+# cross-source byte compare lets the receiver and the declaration live in
+# different modules.
+fun field_index(rs: project.RecordSite, query_file: *src.SourceFile, query: token.Span) usize {
+    if (query.len == 0) { ret rs.fields_len::usize; }
+    var i: u32 = 0;
+    for (i < rs.fields_len) {
+        val tn: *decl.TypedName = ?rs.a.typed_names[rs.fields_start + i];
+        if (features.span_bytes_equal(rs.file, tn.name, query_file, query)) { ret i::usize; }
+        i = i + 1;
+    }
+    ret rs.fields_len::usize;
+}
+
+# field_type_text: the declared-type text of a field, read from the declaring
+# module's source (`TypedName.ty` -> its AST type span), or nil when the field
+# carries no type node. the declaring module's file backs the span, so a
+# cross-module field's type renders.
+fun field_type_text(rs: project.RecordSite, tn: *decl.TypedName, alloc: *Allocator) str {
+    if (tn.ty == id.TYPE_NIL) { ret nil; }
+    val to: Option[*atype.Type] = ast.get_type(rs.a, tn.ty);
+    if (!is_some[*atype.Type](to)) { ret nil; }
+    ret positions.span_text(rs.file, unwrap[*atype.Type](to).span, alloc);
+}
+
+# doc_desc_prose: render a single doc-component description span as prose,
+# folding its embedded comment-line breaks the way `doc_text` does. nil on an
+# empty span or allocation failure.
+fun doc_desc_prose(file: *src.SourceFile, span: token.Span, alloc: *Allocator) str {
+    if (span.len == 0) { ret nil; }
+    val source: str = file.text;
+    val total: usize = doc_text(nil, 0, source, span);
+    if (total == 0) { ret nil; }
+    val r: Result[*u8, str] = allocate[u8](alloc, total + 1);
+    if (is_err[*u8, str](r)) { ret nil; }
+    val buf: *u8 = unwrap_ok[*u8, str](r);
+    doc_text(buf, 0, source, span);
+    buf[total] = 0;
+    ret buf::str;
+}
+
+# compose_field_hover: assemble the field hover Markdown — a fenced `mach` block
+# of `name: type` (or just `name` when the type is unavailable), followed by the
+# description prose as a paragraph when present. nil on allocation failure.
+fun compose_field_hover(name: str, ty: str, doc: str, alloc: *Allocator) str {
+    val pre:  str = "```mach\n";
+    val post: str = "\n```";
+    val sep:  str = "\n\n";
+    val colon: str = ": ";
+
+    var total: usize = str_len(pre) + str_len(name) + str_len(post);
+    if (ty != nil)  { total = total + str_len(colon) + str_len(ty); }
+    if (doc != nil) { total = total + str_len(sep) + str_len(doc); }
+
+    val r: Result[*u8, str] = allocate[u8](alloc, total + 1);
+    if (is_err[*u8, str](r)) { ret nil; }
+    val buf: *u8 = unwrap_ok[*u8, str](r);
+    var off: usize = 0;
+    off = append(buf, off, pre);
+    off = append(buf, off, name);
+    if (ty != nil) {
+        off = append(buf, off, colon);
+        off = append(buf, off, ty);
+    }
+    off = append(buf, off, post);
+    if (doc != nil) {
+        off = append(buf, off, sep);
+        off = append(buf, off, doc);
+    }
+    buf[off] = 0;
+    ret buf::str;
 }
 
 # hover_markdown: a fenced `mach` code block rendering the symbol at hover. it
@@ -138,7 +298,7 @@ fun hover_markdown(ws: *project.Workspace, an: Analyzed, sym: *res.Symbol, uri: 
             if (is_some[token.Span](sso)) {
                 sig = positions.span_text(site.file, unwrap[token.Span](sso), alloc);
             }
-            val dso: Option[token.Span] = features.doc_comment_span(site.a, sym, site.file);
+            val dso: Option[token.Span] = features.doc_span_of(site.a, sym);
             if (is_some[token.Span](dso)) { doc = doc_prose(site.file, unwrap[token.Span](dso), alloc); }
         }
         project.free_site(ws, ?site);
@@ -170,117 +330,79 @@ fun hover_markdown(ws: *project.Workspace, an: Analyzed, sym: *res.Symbol, uri: 
     ret buf::str;
 }
 
-# break kinds threaded through doc_render: the join emitted before the next
-# rendered block — nothing, a soft newline, or a blank-line paragraph break.
-val DOC_BREAK_NONE: usize = 0;
-val DOC_BREAK_LINE: usize = 1;
-val DOC_BREAK_PARA: usize = 2;
-
-# doc_prose: render a doc-comment span (the contiguous `#` run above a decl) as
-# Markdown. prose lines before the first `# ---` separator are joined by single
-# newlines; the separator becomes a thematic break (`---` fenced by blank lines
-# so CommonMark reads a horizontal rule, not a setext heading); and each
-# `ident:` line in the trailing field stanza renders as a `- **ident** — desc`
-# list item, with indented continuation lines folded into the open item. one
+# doc_prose: render a declaration's first-class doc block (`Decl.doc`) as
+# Markdown. the block is read through `fe/doc.mach`: the summary becomes a prose
+# paragraph; when a `# ---` component block follows, a thematic break (`---`
+# fenced by blank lines so CommonMark reads a horizontal rule, not a setext
+# heading) precedes each `# <name>: <desc>` component rendered as a
+# `- **name** — desc` list item. because `Decl.doc` excludes the decl's `#[...]`
+# attribute lines, no attribute syntax can leak into the rendering. one
 # `doc_render` walk both sizes and fills the buffer, so the two passes cannot
-# diverge and the allocation is str_len + 1 as `json.free_str` expects. nil on
-# an empty span, a run carrying no rendered text, or allocation failure.
+# diverge and the allocation is str_len + 1 as `json.free_str` expects. nil on an
+# empty span, a block carrying no rendered text, or allocation failure.
+# ---
+# file:  the source file the doc span points into
+# span:  the declaration's `Decl.doc` span
+# alloc: request allocator
+# ret:   the rendered Markdown, or nil
 fun doc_prose(file: *src.SourceFile, span: token.Span, alloc: *Allocator) str {
     if (span.len == 0) { ret nil; }
-    val first: usize = src.position(file, span.offset).line;
-    val last:  usize = src.position(file, span.offset + span.len - 1).line;
+    val source: str = file.text;
 
     var has_text: bool = false;
-    val total: usize = doc_render(file, first, last, nil, ?has_text);
+    val total: usize = doc_render(source, span, nil, ?has_text);
     if (!has_text) { ret nil; }
 
     val r: Result[*u8, str] = allocate[u8](alloc, total + 1);
     if (is_err[*u8, str](r)) { ret nil; }
     val buf: *u8 = unwrap_ok[*u8, str](r);
 
-    doc_render(file, first, last, buf, ?has_text);
+    doc_render(source, span, buf, ?has_text);
     buf[total] = 0;
     ret buf::str;
 }
 
-# doc_render: walk doc-comment lines `first`..`last` (1-based) once, writing the
-# Markdown rendering into `buf` when it is non-nil and only measuring otherwise.
-# both the measure and fill passes share this walk, so the sized length and the
-# written bytes stay identical. sets `has_text` when any non-separator body byte
-# is rendered. returns the rendered length in bytes.
-fun doc_render(file: *src.SourceFile, first: usize, last: usize, buf: *u8, has_text: *bool) usize {
+# doc_render: walk a doc block once, writing the Markdown rendering into `buf`
+# when it is non-nil and only measuring otherwise. both passes share this walk so
+# the sized length and the written bytes stay identical. sets `has_text` when any
+# summary or component byte is rendered. returns the rendered length in bytes.
+fun doc_render(source: str, span: token.Span, buf: *u8, has_text: *bool) usize {
     @has_text = false;
-    var off:     usize = 0;
-    var stanza:  bool  = false;
-    var open:    bool  = false;
-    var pending: usize = DOC_BREAK_NONE;
+    var off: usize = 0;
 
-    var line: usize = first;
-    for (line <= last) {
-        if (doc_separator(file, line)) {
-            if (off > 0) { off = doc_break(buf, off, DOC_BREAK_PARA); }
+    val sum: token.Span = fedoc.summary_span(source, span);
+    if (sum.len > 0) {
+        off = doc_text(buf, off, source, sum);
+        @has_text = true;
+    }
+
+    var it: fedoc.DocComponentIter = fedoc.component_iter(source, span);
+    var c: fedoc.DocComponent;
+    var first: bool = true;
+    for (fedoc.component_next(?it, ?c)) {
+        if (first) {
+            if (off > 0) { off = doc_lf(buf, off); off = doc_lf(buf, off); }
             off = doc_emit(buf, off, "---");
-            stanza  = true;
-            open    = false;
-            pending = DOC_BREAK_PARA;
-            line = line + 1;
-            cnt;
+            first = false;
         }
-
-        val body: token.Span = doc_line_body(file, line);
-
-        if (stanza) {
-            var name: token.Span;
-            var desc: token.Span;
-            if (doc_field(file, body, ?name, ?desc)) {
-                off = doc_break(buf, off, pending);
-                off = doc_emit(buf, off, "- **");
-                off = doc_copy(buf, off, file, name);
-                off = doc_emit(buf, off, "** \xe2\x80\x94 ");
-                off = doc_copy(buf, off, file, desc);
-                @has_text = true;
-                open    = true;
-                pending = DOC_BREAK_LINE;
-                line = line + 1;
-                cnt;
-            }
-            if (open) {
-                if (body.len > 0) {
-                    off = doc_emit(buf, off, " ");
-                    off = doc_copy(buf, off, file, body);
-                    @has_text = true;
-                }
-                line = line + 1;
-                cnt;
-            }
-            off = doc_break(buf, off, pending);
-            off = doc_copy(buf, off, file, body);
-            if (body.len > 0) { @has_text = true; }
-            pending = DOC_BREAK_LINE;
-            line = line + 1;
-            cnt;
+        off = doc_lf(buf, off);
+        off = doc_emit(buf, off, "- **");
+        off = doc_text(buf, off, source, c.name_span);
+        off = doc_emit(buf, off, "**");
+        if (c.desc_span.len > 0) {
+            off = doc_emit(buf, off, " \xe2\x80\x94 ");
+            off = doc_text(buf, off, source, c.desc_span);
         }
-
-        off = doc_break(buf, off, pending);
-        off = doc_copy(buf, off, file, body);
-        if (body.len > 0) { @has_text = true; }
-        pending = DOC_BREAK_LINE;
-        line = line + 1;
+        @has_text = true;
     }
     ret off;
 }
 
-# doc_break: emit the join for break `kind` (none / soft newline / blank-line
-# paragraph) into `buf` when non-nil, returning the advanced offset.
-fun doc_break(buf: *u8, off: usize, kind: usize) usize {
-    if (kind == DOC_BREAK_NONE) { ret off; }
+# doc_lf: write a single newline into `buf` when non-nil, returning the advanced
+# offset.
+fun doc_lf(buf: *u8, off: usize) usize {
     if (buf != nil) { buf[off] = '\n'; }
-    off = off + 1;
-    if (kind == DOC_BREAK_PARA) {
-        if (buf != nil) { buf[off] = '\n'; }
-        off = off + 1;
-    }
-    ret off;
+    ret off + 1;
 }
 
 # doc_emit: write null-terminated `s` into `buf` at `off` when non-nil, only
@@ -291,80 +413,30 @@ fun doc_emit(buf: *u8, off: usize, s: str) usize {
     ret off + n;
 }
 
-# doc_copy: copy byte span `sp` of the file text into `buf` at `off` when
-# non-nil, only measuring its length otherwise, returning the advanced offset.
-fun doc_copy(buf: *u8, off: usize, file: *src.SourceFile, sp: token.Span) usize {
-    if (buf != nil && sp.len > 0) {
-        mem.raw_copy((buf::usize + off)::ptr, (file.text::usize + sp.offset)::ptr, sp.len);
+# doc_text: copy a summary / description span into `buf`, folding each embedded
+# comment-line break (`\n` then the next line's `#`, whitespace, and an optional
+# single space) into a single rendered space. a span returned by `fe/doc.mach`
+# spans only the first line's leading `#`; continuation lines keep their `#`
+# prefix, so this strips them to leave clean prose. measures when `buf` is nil.
+fun doc_text(buf: *u8, off: usize, source: str, sp: token.Span) usize {
+    val s: *u8 = source::*u8;
+    val end: usize = sp.offset + sp.len;
+    var i: usize = sp.offset;
+    for (i < end) {
+        if (s[i] == '\n') {
+            i = i + 1;
+            for (i < end && (s[i] == ' ' || s[i] == '\t')) { i = i + 1; }
+            if (i < end && s[i] == '#') { i = i + 1; }
+            for (i < end && (s[i] == ' ' || s[i] == '\t')) { i = i + 1; }
+            if (buf != nil) { buf[off] = ' '; }
+            off = off + 1;
+            cnt;
+        }
+        if (buf != nil) { buf[off] = s[i]; }
+        off = off + 1;
+        i = i + 1;
     }
-    ret off + sp.len;
-}
-
-# doc_line_body: the rendered slice of comment line `line` (1-based) as a byte
-# span into the file text — past the leading whitespace, `#`, and a single
-# following space. zero-length for an out-of-range line. unlike doc_separator
-# this does not special-case a `---` row, so callers see its raw text.
-fun doc_line_body(file: *src.SourceFile, line: usize) token.Span {
-    var sp: token.Span;
-    sp.offset = 0;
-    sp.len    = 0;
-    val bo: Option[src.LineSpan] = src.line_bounds(file, line);
-    if (!is_some[src.LineSpan](bo)) { ret sp; }
-    val lb: src.LineSpan = unwrap[src.LineSpan](bo);
-    val s: *u8 = file.text::*u8;
-    var i: usize = features.first_nonspace(s, lb.start, lb.end);
-    if (i < lb.end && s[i] == '#') { i = i + 1; }
-    if (i < lb.end && s[i] == ' ') { i = i + 1; }
-    sp.offset = i;
-    sp.len    = lb.end - i;
-    ret sp;
-}
-
-# doc_separator: true when comment `line`'s rendered body begins with `---`,
-# marking a stanza separator that renders as a horizontal rule.
-fun doc_separator(file: *src.SourceFile, line: usize) bool {
-    val body: token.Span = doc_line_body(file, line);
-    val s: *u8 = file.text::*u8;
-    ret str_starts_with((s::usize + body.offset)::str, "---");
-}
-
-# doc_field: when body span `body` is an `ident:` field row (an identifier, a
-# colon, then whitespace or end of line), write the identifier span into `name`
-# and the description span — past the colon and its alignment padding — into
-# `desc`, and return true. false for any non-field row.
-fun doc_field(file: *src.SourceFile, body: token.Span, name: *token.Span, desc: *token.Span) bool {
-    val s: *u8 = file.text::*u8;
-    val start: usize = body.offset;
-    val end:   usize = body.offset + body.len;
-    if (start >= end || !doc_ident_start(s[start])) { ret false; }
-
-    var i: usize = start + 1;
-    for (i < end && doc_ident_char(s[i])) { i = i + 1; }
-    if (i >= end || s[i] != ':') { ret false; }
-    val name_end: usize = i;
-    i = i + 1;
-    if (i < end && s[i] != ' ' && s[i] != '\t') { ret false; }
-
-    val d: usize = features.first_nonspace(s, i, end);
-    var nm: token.Span;
-    nm.offset = start;
-    nm.len    = name_end - start;
-    @name = nm;
-    var ds: token.Span;
-    ds.offset = d;
-    ds.len    = end - d;
-    @desc = ds;
-    ret true;
-}
-
-# doc_ident_start: true when `c` may begin a field identifier.
-fun doc_ident_start(c: u8) bool {
-    ret (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_';
-}
-
-# doc_ident_char: true when `c` may continue a field identifier.
-fun doc_ident_char(c: u8) bool {
-    ret doc_ident_start(c) || (c >= '0' && c <= '9');
+    ret off;
 }
 
 # compose_kind_name: a `<kind> <name>` rendering for a symbol with no local

--- a/src/language.mach
+++ b/src/language.mach
@@ -29,6 +29,7 @@ use std.types.string.str_len;
 use std.types.string.str_equals;
 use std.types.string.str_starts_with;
 use std.types.option.Option;
+use std.types.option.some;
 use std.types.option.none;
 use std.types.option.is_some;
 use std.types.option.unwrap;
@@ -46,11 +47,13 @@ use sess:   mach.lang.session;
 use src:    mach.lang.source;
 use intern: mach.lang.intern;
 use editor: mach.lang.editor;
+use type:   mach.lang.type;
 use token:  mach.lang.fe.token;
 use ast:    mach.lang.fe.ast;
 use id:     mach.lang.fe.ast.id;
 use decl:   mach.lang.fe.ast.decl;
 use res:    mach.lang.fe.resolve;
+use sema:   mach.lang.fe.sema;
 
 use transport: mls.transport;
 use json:      mls.json;
@@ -63,6 +66,7 @@ use project:   mls.project;
 # ---
 # interner: the session's string interner, for resolving symbol-name StrIds
 # file:     the document's SourceFile (text + line index for offset/position)
+# fid:      the document's FileId (for the type-aware field path's sema_doc)
 # a:        the buffer's parsed Ast
 # rr:       the buffer's ResolveResult side tables
 # own:      this buffer's module id (Symbol.origin equals it for local symbols)
@@ -70,6 +74,7 @@ use project:   mls.project;
 rec Analyzed {
     interner: *intern.Interner;
     file:     *src.SourceFile;
+    fid:      src.FileId;
     a:        *ast.Ast;
     rr:       *res.ResolveResult;
     own:      sess.ModuleId;
@@ -396,7 +401,13 @@ pub fun definition(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Al
     val offset: usize = unwrap[usize](off_o);
 
     val ro: Option[features.SymbolRef] = features.ref_at(an.a, an.rr, an.own, offset);
-    if (!is_some[features.SymbolRef](ro)) { reply_null(alloc, id_raw); ret; }
+    if (!is_some[features.SymbolRef](ro)) {
+        # name resolution leaves a value-field access unbound, so a cursor on a
+        # field name yields no SymbolRef — fall through to the type-driven field
+        # path before giving up.
+        if (field_definition(ws, alloc, ?an, uri, offset, id_raw)) { ret; }
+        reply_null(alloc, id_raw); ret;
+    }
     val sr: features.SymbolRef = unwrap[features.SymbolRef](ro);
 
     val so: Option[*res.Symbol] = features.symbol(an.rr, sr.sym_id);
@@ -421,6 +432,131 @@ pub fun definition(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Al
     send6(alloc, p1, id_raw, p2, loc, p3, nil, nil);
 
     json.free_str(loc, alloc);
+    json.free_str(id_raw, alloc);
+}
+
+# field_definition: the type-driven go-to-definition path for a record / union
+# field, consulted when the symbol-table pivot finds nothing at `offset`. handles
+# three field positions: a member access `foo.bar`, a struct-literal field name
+# `T{ bar: ... }`, and a field's own declaration site (which resolves to itself).
+# the first two type the referencing expression, peel it to its record site, and
+# match the field name; the third matches the cursor against the rec / uni decl's
+# own field names. emits the field declaration's Location and returns true when a
+# field is found and replied; returns false (without replying) so the caller can
+# fall back to a null reply otherwise. requires a loaded project root for typing.
+# ---
+# ws:     the workspace
+# alloc:  request allocator
+# an:     the analyzed request document
+# uri:    the request document URI
+# offset: cursor byte offset into the buffer
+# id_raw: the raw JSON request id (for the reply)
+# ret:    true when a field declaration was located and emitted
+fun field_definition(ws: *project.Workspace, alloc: *Allocator, an: *Analyzed, uri: str, offset: usize, id_raw: str) bool {
+    if (an.root == nil) { ret false; }
+
+    val fo: Option[features.FieldRef] = features.field_ref_at(an.a, offset);
+    if (is_some[features.FieldRef](fo)) {
+        val fr: features.FieldRef = unwrap[features.FieldRef](fo);
+
+        val sr_r: Result[*sema.SemaResult, str] = project.sema_doc(ws, an.root, an.fid);
+        if (is_err[*sema.SemaResult, str](sr_r)) { ret false; }
+        val sr: *sema.SemaResult = unwrap_ok[*sema.SemaResult, str](sr_r);
+
+        val tid: type.TypeId = project.type_of(sr, fr.host);
+        val rso: Option[project.RecordSite] = project.record_decl_in(ws, an.root, an.own, an.a, an.file, tid);
+        if (!is_some[project.RecordSite](rso)) { ret false; }
+        val rs: project.RecordSite = unwrap[project.RecordSite](rso);
+
+        val spo: Option[token.Span] = features.field_decl_span(rs.a, rs.file, rs.fields_start, rs.fields_len, an.file, fr.name_span);
+        if (!is_some[token.Span](spo)) { ret false; }
+        ret emit_field_location(ws, alloc, an, uri, rs, unwrap[token.Span](spo), id_raw);
+    }
+
+    # the cursor may sit on a field's own declaration name inside a rec / uni;
+    # resolve it to itself by matching the offset against the decl's field names.
+    val self_o: Option[FieldSelf] = field_self_at(an, offset);
+    if (is_some[FieldSelf](self_o)) {
+        val fs: FieldSelf = unwrap[FieldSelf](self_o);
+        val loc: str = location_json(an.file, uri, fs.name, alloc);
+        if (loc == nil) { ret false; }
+        reply_result(alloc, id_raw, loc);
+        json.free_str(loc, alloc);
+        ret true;
+    }
+
+    ret false;
+}
+
+# FieldSelf: a field declaration the cursor sits on at its own definition site —
+# the field name span resolves to itself for go-to-definition.
+# ---
+# name: byte span of the field name in the buffer
+rec FieldSelf {
+    name: token.Span;
+}
+
+# field_self_at: the rec / uni field whose own declaration name covers `offset` in
+# the buffer, or none. enumerates the buffer's record / union declarations and
+# their fields so a cursor on a field's binding name resolves to itself.
+# ---
+# an:     the analyzed request document
+# offset: cursor byte offset into the buffer
+# ret:    some(FieldSelf) on a field declaration name, or none
+fun field_self_at(an: *Analyzed, offset: usize) Option[FieldSelf] {
+    val did: id.DeclId = ast.offset_to_decl(an.a, offset);
+    if (did == id.DECL_NIL) { ret none[FieldSelf](); }
+    val d_opt: Option[*decl.Decl] = ast.get_decl(an.a, did);
+    if (!is_some[*decl.Decl](d_opt)) { ret none[FieldSelf](); }
+    val d: *decl.Decl = unwrap[*decl.Decl](d_opt);
+
+    var start: u32 = 0;
+    var len:   u32 = 0;
+    if (d.kind == decl.DECL_KIND_REC) {
+        start = d.data.rec_.fields_start;
+        len   = d.data.rec_.fields_len;
+    } or (d.kind == decl.DECL_KIND_UNI) {
+        start = d.data.uni_.fields_start;
+        len   = d.data.uni_.fields_len;
+    } or {
+        ret none[FieldSelf]();
+    }
+
+    val nso: Option[token.Span] = features.field_decl_self_at(an.a, start, len, offset);
+    if (!is_some[token.Span](nso)) { ret none[FieldSelf](); }
+    var fs: FieldSelf;
+    fs.name = unwrap[token.Span](nso);
+    ret some[FieldSelf](fs);
+}
+
+# emit_field_location: send the Location of a field declaration at its record
+# site. builds the site's `file://` URI (the buffer's own URI when the record is
+# declared in this module, else the defining module's on-disk file) and emits the
+# field name span. true on success; false on a URI / allocation failure.
+fun emit_field_location(ws: *project.Workspace, alloc: *Allocator, an: *Analyzed, uri: str, rs: project.RecordSite, name: token.Span, id_raw: str) bool {
+    var furi: str = uri;
+    var owned: bool = false;
+    if (rs.origin != an.own) {
+        furi = project.module_uri(ws, an.root, rs.origin);
+        if (furi == nil) { ret false; }
+        owned = true;
+    }
+
+    val loc: str = location_json(rs.file, furi, name, alloc);
+    if (owned) { json.free_str(furi, ws.alloc); }
+    if (loc == nil) { ret false; }
+    reply_result(alloc, id_raw, loc);
+    json.free_str(loc, alloc);
+    ret true;
+}
+
+# reply_result: send a JSON-RPC success reply carrying `result` for request
+# `id_raw`. shared by the field-definition replies.
+fun reply_result(alloc: *Allocator, id_raw: str, result: str) {
+    val p1: str = "{\"jsonrpc\":\"2.0\",\"id\":";
+    val p2: str = ",\"result\":";
+    val p3: str = "}";
+    send6(alloc, p1, id_raw, p2, result, p3, nil, nil);
     json.free_str(id_raw, alloc);
 }
 
@@ -748,6 +884,7 @@ fun analyze(ws: *project.Workspace, es: *editor.EditorSession, docs: *documents.
     if (!is_some[*src.SourceFile](fo)) { ret false; }
     out.interner = project.interner(ws);
     out.file     = unwrap[*src.SourceFile](fo);
+    out.fid      = doc.file_id;
     out.root     = root;
     out.own      = project.own_module(root, doc.file_id);
     ret true;

--- a/src/language.mach
+++ b/src/language.mach
@@ -786,28 +786,27 @@ fun free_field_refs(ws: *project.Workspace, refs: *FieldXRef, n: usize) {
 # sink — every member access / struct-literal init whose host type peels to the
 # keyed record, plus (when `s` is the record's declaring module) the field
 # declaration's own name span and, for rename, the matching `# <field>:` doc
-# component name token. the field decl and doc spans always carry the field name
-# and bypass the (nil) spelling guard.
+# component name token. the span set is computed by the pure
+# `features.collect_field_sites` (a module can name a field at most once per expr,
+# so the buffer is sized to the expr count plus the two declaring extras).
 fun walk_field_sites(s: *FieldXRef, ti: *type.TypeInterner, t: FieldTarget, want_doc: bool, k: *WalkSink) {
-    var ei: usize = 0;
-    for (ei < s.a.expr_len) {
-        val so: Option[token.Span] = features.field_ref_span_at(s.a, s.sr, ti, ei::id.ExprId, s.file, t.key);
-        if (is_some[token.Span](so)) { sink_emit(k, s.file, s.uri, unwrap[token.Span](so)); }
-        ei = ei + 1;
-    }
+    var doc: token.Span;
+    doc.offset = 0;
+    doc.len    = 0;
     if (s.declaring) {
-        sink_emit(k, s.file, s.uri, t.key.field_name);
-        if (want_doc) {
-            val d_opt: Option[*decl.Decl] = ast.get_decl(t.rs.a, t.rs.decl);
-            if (is_some[*decl.Decl](d_opt)) {
-                val d: *decl.Decl = unwrap[*decl.Decl](d_opt);
-                if (d.doc.len != 0) {
-                    val co: Option[token.Span] = features.doc_component_name_span(t.rs.file.text, d.doc, t.rs.file, t.key.field_name, false);
-                    if (is_some[token.Span](co)) { sink_emit(k, s.file, s.uri, unwrap[token.Span](co)); }
-                }
-            }
-        }
+        val d_opt: Option[*decl.Decl] = ast.get_decl(t.rs.a, t.rs.decl);
+        if (is_some[*decl.Decl](d_opt)) { doc = unwrap[*decl.Decl](d_opt).doc; }
     }
+
+    val cap: usize = s.a.expr_len + 2;
+    val ra: Result[*token.Span, str] = allocate[token.Span](k.alloc, cap);
+    if (is_err[*token.Span, str](ra)) { ret; }
+    val spans: *token.Span = unwrap_ok[*token.Span, str](ra);
+
+    val n: usize = features.collect_field_sites(s.a, s.sr, ti, s.file, t.key, s.declaring, want_doc, t.rs.file.text, doc, spans, cap);
+    var i: usize = 0;
+    for (i < n) { sink_emit(k, s.file, s.uri, spans[i]); i = i + 1; }
+    deallocate[token.Span](k.alloc, spans, cap);
 }
 
 # field_references: the type-driven references path for a record / union field.

--- a/src/project.mach
+++ b/src/project.mach
@@ -279,6 +279,18 @@ pub fun sources(w: *Workspace) *src.SourceMap {
     ret ?w.s.sources;
 }
 
+# type_interner: the session's type interner, for peeling a record / union TypeId
+# to its nominal declaration site (the cross-module field-reference walk reads
+# each module's typing and matches the field's host type against its key through
+# it). the narrow read the feature layer makes; see `interner` for why the whole
+# session is kept out of feature signatures.
+# ---
+# w:   the workspace
+# ret: the session's type interner
+pub fun type_interner(w: *Workspace) *type.TypeInterner {
+    ret ?w.s.types;
+}
+
 # set_watch_active: record that the client delivers
 # workspace/didChangeWatchedFiles for the registered manifest / lockfile /
 # source globs, so invalidation is event-driven and the per-request
@@ -1326,6 +1338,25 @@ pub fun record_decl_in(w: *Workspace, root: *Root, own: sess.ModuleId, own_a: *a
     val n: mtypes.Nominal = unwrap[mtypes.Nominal](no);
     if (n.origin == own) { ret record_site_from(own, n.decl, own_a, own_file); }
     ret record_decl(w, root, tid);
+}
+
+# record_site_at: a RecordSite for the rec / uni declaration `decl` in the active
+# buffer (`own` / `own_a` / `own_file`), or none when `decl` is not a rec / uni.
+# the buffer-side entry point for a cursor sitting on a field's own declaration
+# name: the decl is in the buffer being edited, so its Ast / file are the live
+# ones. the resulting site carries the buffer's own module id, the cross-module
+# identity every other module's references are matched against.
+# ---
+# w:        the workspace (unused, kept for signature symmetry with record_decl_in)
+# root:     the project root, or nil
+# own:      the buffer's own module id
+# own_a:    the buffer's live Ast
+# own_file: the buffer's SourceFile
+# decl:     the rec / uni DeclId in the buffer
+# ret:      some(RecordSite), or none
+pub fun record_site_at(w: *Workspace, root: *Root, own: sess.ModuleId, own_a: *ast.Ast, own_file: *src.SourceFile, decl: id.DeclId) Option[RecordSite] {
+    if (decl == id.DECL_NIL) { ret none[RecordSite](); }
+    ret record_site_from(own, decl, own_a, own_file);
 }
 
 # nominal_of_tid: the nominal back-link of `tid` against the session type interner,

--- a/src/project.mach
+++ b/src/project.mach
@@ -1259,22 +1259,25 @@ pub fun decl_type_of(sr: *sema.SemaResult, did: id.DeclId) type.TypeId {
 
 # RecordSite: the nominal back-link from a record / union TypeId to its declaring
 # site — what a field go-to-def / rename follows from a value's type to the `rec` /
-# `uni` declaration whose fields it must walk. carries both the declaration payload
-# and the module's Ast / source so field spans can be read directly.
+# `uni` declaration whose fields it must walk. carries the field range (uniform
+# across rec / uni, both being TypedName slices in `a.typed_names`) and the
+# module's Ast / source so field spans can be read directly.
 # ---
-# origin: ModuleId of the declaring module
-# decl:   DeclId of the rec / uni declaration in `origin`'s Ast
-# a:      the declaring module's parsed Ast (field spans index into it)
-# file:   SourceFile backing `a`
-# rec:    the DeclRec payload (field range), valid when kind is TYPE_REC
-# is_rec: true for a record, false for a union (selects the payload)
+# origin:       ModuleId of the declaring module
+# decl:         DeclId of the rec / uni declaration in `origin`'s Ast
+# a:            the declaring module's parsed Ast (field spans index into it)
+# file:         SourceFile backing `a`
+# fields_start: start index into `a.typed_names` of the first field
+# fields_len:   number of fields (record fields / union variants)
+# is_rec:       true for a record, false for a union
 pub rec RecordSite {
-    origin: sess.ModuleId;
-    decl:   id.DeclId;
-    a:      *ast.Ast;
-    file:   *src.SourceFile;
-    rec:    adecl.DeclRec;
-    is_rec: bool;
+    origin:       sess.ModuleId;
+    decl:         id.DeclId;
+    a:            *ast.Ast;
+    file:         *src.SourceFile;
+    fields_start: u32;
+    fields_len:   u32;
+    is_rec:       bool;
 }
 
 # record_decl: the declaring site a record / union TypeId nominally refers to,
@@ -1311,7 +1314,13 @@ pub fun record_decl(w: *Workspace, root: *Root, tid: type.TypeId) Option[RecordS
     rs.a      = ?m.a;
     rs.file   = unwrap[*src.SourceFile](fo);
     rs.is_rec = is_rec;
-    if (is_rec) { rs.rec = d.data.rec_; }
+    if (is_rec) {
+        rs.fields_start = d.data.rec_.fields_start;
+        rs.fields_len   = d.data.rec_.fields_len;
+    } or {
+        rs.fields_start = d.data.uni_.fields_start;
+        rs.fields_len   = d.data.uni_.fields_len;
+    }
     ret some[RecordSite](rs);
 }
 

--- a/src/project.mach
+++ b/src/project.mach
@@ -1281,38 +1281,76 @@ pub rec RecordSite {
 }
 
 # record_decl: the declaring site a record / union TypeId nominally refers to,
-# resolved against the session's type interner and the root's module array — the
-# nominal back-link field features follow. peels a pointer to its pointee and maps
-# a generic instance to its template. none when `tid` is not a nominal type, the
-# declaring module is out of range, or the declaration is not a rec / uni. the
-# returned Ast / file pointers are owned by the loaded project / session.
+# resolved against the session's type interner and the root's loaded module array —
+# the nominal back-link field features follow. peels a pointer to its pointee and
+# maps a generic instance to its template. none when `tid` is not a nominal type,
+# the declaring module is not a loaded project module, or the declaration is not a
+# rec / uni. the returned Ast / file pointers are owned by the loaded project /
+# session. a record declared in the active buffer (whose synthetic module id is not
+# in the loaded array) is not found here — use `record_decl_in`, which falls back to
+# the buffer's live Ast for that case.
 # ---
 # w:    the workspace
 # root: the root the type was resolved under, or nil
 # tid:  a TypeId, typically read from a SemaResult via `type_of`
 # ret:  some(RecordSite), or none
 pub fun record_decl(w: *Workspace, root: *Root, tid: type.TypeId) Option[RecordSite] {
-    if (root == nil || !root.loaded) { ret none[RecordSite](); }
-    val no: Option[mtypes.Nominal] = mtypes.nominal_of(?w.s.types, tid);
+    val no: Option[mtypes.Nominal] = nominal_of_tid(w, root, tid);
     if (is_none[mtypes.Nominal](no)) { ret none[RecordSite](); }
     val n: mtypes.Nominal = unwrap[mtypes.Nominal](no);
 
     val m: *driver.ModuleEntry = module_entry(root, n.origin);
     if (m == nil) { ret none[RecordSite](); }
-    val d_opt: Option[*adecl.Decl] = ast.get_decl(?m.a, n.decl);
+    val fo: Option[*src.SourceFile] = src.get(?w.s.sources, m.file_id);
+    if (!is_some[*src.SourceFile](fo)) { ret none[RecordSite](); }
+    ret record_site_from(n.origin, n.decl, ?m.a, unwrap[*src.SourceFile](fo));
+}
+
+# record_decl_in: `record_decl` extended to resolve a record / union declared in
+# the active buffer. a buffer's own nominal type is interned under its synthetic
+# module id (`own`), which is not in the loaded module array, so `record_decl`
+# alone would miss a field access on a record the edited buffer itself declares.
+# when the nominal's origin is `own`, the declaration is read from the buffer's
+# live Ast / file (`own_a` / `own_file`); otherwise it defers to a loaded module.
+# ---
+# w:        the workspace
+# root:     the root the type was resolved under, or nil
+# own:      the buffer's own module id
+# own_a:    the buffer's live Ast
+# own_file: the buffer's SourceFile
+# tid:      a TypeId, typically read from a SemaResult via `type_of`
+# ret:      some(RecordSite), or none
+pub fun record_decl_in(w: *Workspace, root: *Root, own: sess.ModuleId, own_a: *ast.Ast, own_file: *src.SourceFile, tid: type.TypeId) Option[RecordSite] {
+    val no: Option[mtypes.Nominal] = nominal_of_tid(w, root, tid);
+    if (is_none[mtypes.Nominal](no)) { ret none[RecordSite](); }
+    val n: mtypes.Nominal = unwrap[mtypes.Nominal](no);
+    if (n.origin == own) { ret record_site_from(own, n.decl, own_a, own_file); }
+    ret record_decl(w, root, tid);
+}
+
+# nominal_of_tid: the nominal back-link of `tid` against the session type interner,
+# guarded on a loaded root. none when there is no project or `tid` is not nominal.
+fun nominal_of_tid(w: *Workspace, root: *Root, tid: type.TypeId) Option[mtypes.Nominal] {
+    if (root == nil || !root.loaded) { ret none[mtypes.Nominal](); }
+    ret mtypes.nominal_of(?w.s.types, tid);
+}
+
+# record_site_from: build a RecordSite for the rec / uni decl `decl` in `a` (backed
+# by `file`), or none when the decl is absent or not a rec / uni. the shared core
+# of `record_decl` / `record_decl_in` — both having chosen which Ast / file the
+# declaration lives in.
+fun record_site_from(origin: sess.ModuleId, decl: id.DeclId, a: *ast.Ast, file: *src.SourceFile) Option[RecordSite] {
+    val d_opt: Option[*adecl.Decl] = ast.get_decl(a, decl);
     if (is_none[*adecl.Decl](d_opt)) { ret none[RecordSite](); }
     val d: *adecl.Decl = unwrap[*adecl.Decl](d_opt);
     val is_rec: bool = d.kind == adecl.DECL_KIND_REC;
     if (!is_rec && d.kind != adecl.DECL_KIND_UNI) { ret none[RecordSite](); }
 
-    val fo: Option[*src.SourceFile] = src.get(?w.s.sources, m.file_id);
-    if (!is_some[*src.SourceFile](fo)) { ret none[RecordSite](); }
-
     var rs: RecordSite;
-    rs.origin = n.origin;
-    rs.decl   = n.decl;
-    rs.a      = ?m.a;
-    rs.file   = unwrap[*src.SourceFile](fo);
+    rs.origin = origin;
+    rs.decl   = decl;
+    rs.a      = a;
+    rs.file   = file;
     rs.is_rec = is_rec;
     if (is_rec) {
         rs.fields_start = d.data.rec_.fields_start;

--- a/src/project.mach
+++ b/src/project.mach
@@ -64,6 +64,7 @@ use std.types.option.Option;
 use std.types.option.some;
 use std.types.option.none;
 use std.types.option.is_some;
+use std.types.option.is_none;
 use std.types.option.unwrap;
 use std.types.result.Result;
 use std.types.result.ok;
@@ -89,8 +90,12 @@ use src:      mach.lang.source;
 use editor:   mach.lang.editor;
 use intern:   mach.lang.intern;
 use ast:      mach.lang.fe.ast;
+use id:       mach.lang.fe.ast.id;
+use adecl:    mach.lang.fe.ast.decl;
 use diag:     mach.lang.diagnostic;
 use res:      mach.lang.fe.resolve;
+use sema:     mach.lang.fe.sema;
+use type:     mach.lang.type;
 use comptime: mach.lang.fe.comptime;
 use driver:   mach.lang.driver;
 use tgt:      mach.lang.target;
@@ -98,6 +103,7 @@ use tgt:      mach.lang.target;
 use transport: mls.transport;
 use json:      mls.json;
 use trace:     mls.trace;
+use mtypes:    mls.types;
 
 # Site: where a resolved symbol's declaration lives — the Ast and SourceFile to
 # read its spans from, and the document URI to report. for a buffer-local symbol
@@ -115,19 +121,23 @@ pub rec Site {
     owned: bool;
 }
 
-# Cached: one buffer's dep-aware resolve result, stamped with the Ast it was
-# resolved from and the generation of the root build it resolved against. the
-# editor replaces a buffer's `*ast.Ast` on every text update (`drop_analysis`),
-# so Ast pointer identity catches a text edit — the same contract
-# `editor.resolve` uses for its own cached result; `gen` catches a cross-root or
-# post-reload staleness, since a result resolved against one build never matches
-# a different build's stamp.
+# Cached: one buffer's dep-aware resolve result — and, lazily, its sema result —
+# stamped with the Ast it was resolved from and the generation of the root build
+# it resolved against. the editor replaces a buffer's `*ast.Ast` on every text
+# update (`drop_analysis`), so Ast pointer identity catches a text edit — the same
+# contract `editor.resolve` uses for its own cached result; `gen` catches a
+# cross-root or post-reload staleness, since a result resolved against one build
+# never matches a different build's stamp. the resolve result is populated on every
+# resolve; the sema result is populated only when a type-aware feature first asks
+# for it (`sema_doc`), so the diagnostics publish path never pays for sema.
 # ---
-# rr:  the cached dep-aware ResolveResult, owned by the cache
-# a:   the Ast the result was resolved from (text-edit staleness check)
-# gen: generation of the root build it resolved against, or 0 for single-file
+# rr:   the cached dep-aware ResolveResult, owned by the cache
+# sr:   the cached SemaResult for the same Ast / gen, or nil until first demanded
+# a:    the Ast both results were derived from (text-edit staleness check)
+# gen:  generation of the root build they were derived against, or 0 for single-file
 rec Cached {
     rr:  *res.ResolveResult;
+    sr:  *sema.SemaResult;
     a:   *ast.Ast;
     gen: u32;
 }
@@ -162,6 +172,12 @@ rec Cached {
 #                 editor's to rewrite, regardless of any loaded graph's closure.
 #                 intrinsic to the path (computed at load_root from the ancestor
 #                 manifests), not to the routing that materialized the root
+# sema:           per-loaded-module SemaResult, indexed by ModuleId, parallel to
+#                 the project's module array; populated lazily by ensure_sema on
+#                 the first type-aware feature request, NEVER at load time
+# sema_count:     number of entries in `sema` (= module_len once sema'd, else 0)
+# sema_loaded:    whether sema has run over this build's module graph; reset on
+#                 every (re)load so a fresh build re-runs sema on next demand
 pub rec Root {
     path:           str;
     loaded:         bool;
@@ -174,6 +190,9 @@ pub rec Root {
     lock_mtime:     i64;
     gen:            u32;
     vendored:       bool;
+    sema:           *sema.SemaResult;
+    sema_count:     u32;
+    sema_loaded:    bool;
 }
 
 # Workspace: the session's project roots plus the per-buffer resolve cache.
@@ -378,6 +397,103 @@ fun resolve_fresh(w: *Workspace, root: *Root, fid: src.FileId, a: *ast.Ast) Resu
         ret err[*res.ResolveResult, str]("project: resolve cache allocation failed");
     }
     ret ok[*res.ResolveResult, str](slot);
+}
+
+# sema_doc: the buffer's SemaResult under `root` — its per-expression typing,
+# computed against the root's dep-closure typing. the type-aware twin of
+# `resolve_doc`: it first resolves the buffer (populating the resolve cache entry),
+# then, on a cache miss for the same Ast / build, lazily sema's the whole root
+# graph (`ensure_sema`) so every dependency's decl types are available, and finally
+# sema's the buffer itself against a SemaDeps spanning every sema'd root module —
+# keyed on the same Ast-pointer / generation stamp the resolve cache uses, so an
+# unedited buffer reuses it. heavy on a cold root (the first call pays for the whole
+# dep closure), so it is reached only from a type-aware feature, never the
+# diagnostics publish path. `root` must be non-nil: a single-file document has no
+# dep typing to check against. the returned pointer is owned by the cache.
+# ---
+# w:    the workspace
+# root: the loaded root governing the document (non-nil)
+# fid:  FileId of an open editor buffer
+# ret:  a borrowed pointer to the cached SemaResult, or an error
+pub fun sema_doc(w: *Workspace, root: *Root, fid: src.FileId) Result[*sema.SemaResult, str] {
+    if (root == nil) { ret err[*sema.SemaResult, str]("project: sema requires a loaded project root"); }
+
+    val rr_r: Result[*res.ResolveResult, str] = resolve_doc(w, root, fid);
+    if (is_err[*res.ResolveResult, str](rr_r)) {
+        ret err[*sema.SemaResult, str](unwrap_err[*res.ResolveResult, str](rr_r));
+    }
+    val rr: *res.ResolveResult = unwrap_ok[*res.ResolveResult, str](rr_r);
+
+    val c: *Cached = cache_slot(w, fid);
+    if (c == nil) { ret err[*sema.SemaResult, str]("project: buffer not cached for sema"); }
+    if (c.sr != nil) { ret ok[*sema.SemaResult, str](c.sr); }
+
+    val a: *ast.Ast = editor.ast_of(w.es, fid);
+    if (a == nil) { ret err[*sema.SemaResult, str]("project: buffer ast unavailable for sema"); }
+
+    # the buffer types against the dep closure, so the whole graph must be sema'd
+    # first; ensure_sema is idempotent and cached for the build.
+    ensure_sema(w, root);
+
+    var deps: sema.SemaDeps;
+    build_full_sema_deps(w, root, ?deps);
+
+    val own: sess.ModuleId = own_module(root, fid);
+    var ctx: comptime.ComptimeCtx = comptime.init(w.alloc, root.p.target.os_id, root.p.target.arch_id, root.p.target.abi_id, comptime.MODE_DEBUG, root.p.target.arch.pointer_width, root.p.compiler_name, root.p.compiler_ver);
+    val sr_r: Result[sema.SemaResult, str] = sema.sema(w.s, a, rr, ?deps, ?ctx, own);
+    comptime.dnit(?ctx);
+    free_sema_deps(w, ?deps);
+    if (is_err[sema.SemaResult, str](sr_r)) {
+        ret err[*sema.SemaResult, str](unwrap_err[sema.SemaResult, str](sr_r));
+    }
+
+    val slot_r: Result[*sema.SemaResult, str] = allocate[sema.SemaResult](w.alloc, 1);
+    if (is_err[*sema.SemaResult, str](slot_r)) {
+        var local: sema.SemaResult = unwrap_ok[sema.SemaResult, str](sr_r);
+        sema.dnit_result(?local);
+        ret slot_r;
+    }
+    val slot: *sema.SemaResult = unwrap_ok[*sema.SemaResult, str](slot_r);
+    @slot = unwrap_ok[sema.SemaResult, str](sr_r);
+    c.sr = slot;
+    ret ok[*sema.SemaResult, str](slot);
+}
+
+# build_full_sema_deps: assemble a SemaDeps spanning EVERY sema'd module of
+# `root`, for typing the active buffer (which may `use` any loaded module). each
+# entry borrows the module's retained decl_type snapshot; an un-sema'd module
+# contributes a decl-type-less entry (a lookup against it yields TYPE_ERROR, like a
+# miss). writes the deps into `out`, leaving it empty on allocation failure or when
+# the root has no retained sema. the borrowed arrays are owned by the Root's
+# SemaResults, so the result must be released with `free_sema_deps`.
+fun build_full_sema_deps(w: *Workspace, root: *Root, out: *sema.SemaDeps) {
+    out.entries = nil;
+    out.count   = 0;
+    val n: u32 = root.sema_count;
+    if (root.sema == nil || n == 0) { ret; }
+
+    val r: Result[*sema.ModuleSema, str] = allocate[sema.ModuleSema](w.alloc, n::usize);
+    if (is_err[*sema.ModuleSema, str](r)) { ret; }
+    out.entries = unwrap_ok[*sema.ModuleSema, str](r);
+    out.count   = n;
+
+    var i: u32 = 0;
+    for (i < n) {
+        var ms: sema.ModuleSema;
+        ms.path       = (?root.p.modules[i]).fqn;
+        ms.module     = i::sess.ModuleId;
+        ms.decl_type  = root.sema[i].decl_type;
+        ms.decl_count = root.sema[i].decl_count;
+        out.entries[i] = ms;
+        i = i + 1;
+    }
+}
+
+# cache_slot: the Cached entry for `fid`, or nil when out of range. the borrowed
+# slot handle sema_doc uses to attach a buffer's SemaResult to its resolve entry.
+fun cache_slot(w: *Workspace, fid: src.FileId) *Cached {
+    if (w.cache == nil || fid::u32 >= w.cache_len) { ret nil; }
+    ret ?w.cache[fid::u32];
 }
 
 # diagnose_doc: parse and dep-aware-resolve the buffer governed by `root`,
@@ -735,6 +851,9 @@ fun reset_slot(r: *Root) {
     r.lock_mtime     = 0;
     r.gen            = 0;
     r.vendored       = false;
+    r.sema           = nil;
+    r.sema_count     = 0;
+    r.sema_loaded    = false;
 }
 
 # alloc_slot: a reusable dead slot, growing the array when every slot is
@@ -797,6 +916,11 @@ fun try_load(w: *Workspace, r: *Root) bool {
     r.loaded   = true;
     r.own_base = r.p.module_len;
     r.gen      = next_gen(w);
+    # sema is lazy: a fresh build starts un-sema'd, run on the first type-aware
+    # feature request (ensure_sema), never here on the load path.
+    r.sema        = nil;
+    r.sema_count  = 0;
+    r.sema_loaded = false;
     w.load_epoch = w.load_epoch + 1;
     build_mod_paths(w, r);
     build_deps(w, r);
@@ -927,6 +1051,7 @@ fun free_root(w: *Workspace, r: *Root) {
 # generation is cleared so a later build claims a fresh, non-matching one.
 fun free_root_graph(w: *Workspace, r: *Root) {
     evict_root(w, r);
+    free_sema(w, r);
     free_deps(w, ?r.deps);
     free_mod_paths(w, r);
     if (r.loaded) {
@@ -934,6 +1059,27 @@ fun free_root_graph(w: *Workspace, r: *Root) {
         r.loaded = false;
     }
     r.gen = 0;
+}
+
+# free_sema: tear down the root's retained per-module SemaResults and the array
+# holding them, resetting the lazy-sema state so a reloaded build re-runs sema on
+# next demand. each SemaResult's parallel TypeId arrays are freed; the interned
+# types they reference live on the session and are not touched here.
+fun free_sema(w: *Workspace, r: *Root) {
+    if (r.sema == nil) {
+        r.sema_count  = 0;
+        r.sema_loaded = false;
+        ret;
+    }
+    var i: u32 = 0;
+    for (i < r.sema_count) {
+        sema.dnit_result(?r.sema[i]);
+        i = i + 1;
+    }
+    deallocate[sema.SemaResult](w.alloc, r.sema, r.sema_count::usize);
+    r.sema        = nil;
+    r.sema_count  = 0;
+    r.sema_loaded = false;
 }
 
 # record_mtimes: snapshot the root's manifest / lockfile mtimes for the
@@ -1065,6 +1211,108 @@ pub fun module_view(w: *Workspace, root: *Root, mid: sess.ModuleId) Option[Modul
     v.rr   = ?m.resolve_result;
     v.file = unwrap[*src.SourceFile](fo);
     ret some[ModuleView](v);
+}
+
+# module_sema: loaded module `mid`'s SemaResult in `root`, lazily running the
+# type checker over the whole graph on first demand (ensure_sema) and retaining
+# every module's result on the root. none when there is no project, the id is out
+# of range, or the module did not resolve / could not be typed (its retained slot
+# stays zeroed). this is the type-aware twin of `module_view`: a workspace-wide
+# type query (e.g. a field rename's cross-module walk) reads each module's typing
+# through it. the returned pointer is owned by the root.
+# ---
+# w:    the workspace
+# root: the root governing the request, or nil
+# mid:  a loaded module id in [0, module_count)
+# ret:  some(*SemaResult), or none
+pub fun module_sema(w: *Workspace, root: *Root, mid: sess.ModuleId) Option[*sema.SemaResult] {
+    if (root == nil || !root.loaded) { ret none[*sema.SemaResult](); }
+    ensure_sema(w, root);
+    if (root.sema == nil || mid::u32 >= root.sema_count) { ret none[*sema.SemaResult](); }
+    val sr: *sema.SemaResult = ?root.sema[mid::u32];
+    if (sr.expr_type == nil) { ret none[*sema.SemaResult](); }
+    ret some[*sema.SemaResult](sr);
+}
+
+# type_of: the semantic type of expression `eid` in SemaResult `sr`, or TYPE_NIL
+# when `sr` is nil or `eid` is out of range. the narrow read the feature layer
+# makes to learn an expression's type — handed a SemaResult (from `sema_doc` or
+# `module_sema`), never the session. delegates to the pure helper so the rule lives
+# in one unit-testable place.
+# ---
+# sr:  a buffer's / module's SemaResult, or nil
+# eid: the expression id to type
+# ret: the expression's TypeId, or TYPE_NIL
+pub fun type_of(sr: *sema.SemaResult, eid: id.ExprId) type.TypeId {
+    ret mtypes.type_of(sr, eid);
+}
+
+# decl_type_of: the declared (or inferred) type of decl `did` in SemaResult `sr`,
+# or TYPE_NIL when unavailable. the decl-keyed twin of `type_of`.
+# ---
+# sr:  a buffer's / module's SemaResult, or nil
+# did: the declaration id to type
+# ret: the declaration's TypeId, or TYPE_NIL
+pub fun decl_type_of(sr: *sema.SemaResult, did: id.DeclId) type.TypeId {
+    ret mtypes.decl_type_of(sr, did);
+}
+
+# RecordSite: the nominal back-link from a record / union TypeId to its declaring
+# site — what a field go-to-def / rename follows from a value's type to the `rec` /
+# `uni` declaration whose fields it must walk. carries both the declaration payload
+# and the module's Ast / source so field spans can be read directly.
+# ---
+# origin: ModuleId of the declaring module
+# decl:   DeclId of the rec / uni declaration in `origin`'s Ast
+# a:      the declaring module's parsed Ast (field spans index into it)
+# file:   SourceFile backing `a`
+# rec:    the DeclRec payload (field range), valid when kind is TYPE_REC
+# is_rec: true for a record, false for a union (selects the payload)
+pub rec RecordSite {
+    origin: sess.ModuleId;
+    decl:   id.DeclId;
+    a:      *ast.Ast;
+    file:   *src.SourceFile;
+    rec:    adecl.DeclRec;
+    is_rec: bool;
+}
+
+# record_decl: the declaring site a record / union TypeId nominally refers to,
+# resolved against the session's type interner and the root's module array — the
+# nominal back-link field features follow. peels a pointer to its pointee and maps
+# a generic instance to its template. none when `tid` is not a nominal type, the
+# declaring module is out of range, or the declaration is not a rec / uni. the
+# returned Ast / file pointers are owned by the loaded project / session.
+# ---
+# w:    the workspace
+# root: the root the type was resolved under, or nil
+# tid:  a TypeId, typically read from a SemaResult via `type_of`
+# ret:  some(RecordSite), or none
+pub fun record_decl(w: *Workspace, root: *Root, tid: type.TypeId) Option[RecordSite] {
+    if (root == nil || !root.loaded) { ret none[RecordSite](); }
+    val no: Option[mtypes.Nominal] = mtypes.nominal_of(?w.s.types, tid);
+    if (is_none[mtypes.Nominal](no)) { ret none[RecordSite](); }
+    val n: mtypes.Nominal = unwrap[mtypes.Nominal](no);
+
+    val m: *driver.ModuleEntry = module_entry(root, n.origin);
+    if (m == nil) { ret none[RecordSite](); }
+    val d_opt: Option[*adecl.Decl] = ast.get_decl(?m.a, n.decl);
+    if (is_none[*adecl.Decl](d_opt)) { ret none[RecordSite](); }
+    val d: *adecl.Decl = unwrap[*adecl.Decl](d_opt);
+    val is_rec: bool = d.kind == adecl.DECL_KIND_REC;
+    if (!is_rec && d.kind != adecl.DECL_KIND_UNI) { ret none[RecordSite](); }
+
+    val fo: Option[*src.SourceFile] = src.get(?w.s.sources, m.file_id);
+    if (!is_some[*src.SourceFile](fo)) { ret none[RecordSite](); }
+
+    var rs: RecordSite;
+    rs.origin = n.origin;
+    rs.decl   = n.decl;
+    rs.a      = ?m.a;
+    rs.file   = unwrap[*src.SourceFile](fo);
+    rs.is_rec = is_rec;
+    if (is_rec) { rs.rec = d.data.rec_; }
+    ret some[RecordSite](rs);
 }
 
 # module_uri: a freshly built, normalized `file://` URI for loaded module `mid`'s
@@ -1292,6 +1540,145 @@ fun free_deps(w: *Workspace, deps: *res.ResolveDeps) {
     deps.count   = 0;
 }
 
+# ensure_sema: run the type checker over `root`'s loaded module graph, retaining
+# one SemaResult per module on the Root — the lazy core of the type-aware layer.
+# a no-op once it has run for the current build (sema_loaded) or for an unloaded
+# root. modules are sema'd in dependency (topological) order, each against a
+# SemaDeps assembled from the decl_type snapshots of the modules already sema'd in
+# this pass, exactly as the compiler's own build does; a module that did not
+# resolve is skipped, leaving a zeroed SemaResult that types to TYPE_NIL. the pass
+# is heavy (it walks the whole dep closure), so it runs only when a feature first
+# demands typing — never on the diagnostics publish hot path — and is cached until
+# the build reloads. allocation failure leaves the root un-sema'd (typing simply
+# stays unavailable) rather than aborting the request.
+# ---
+# w:    the workspace
+# root: the loaded root whose graph to type-check
+pub fun ensure_sema(w: *Workspace, root: *Root) {
+    if (root == nil || !root.loaded || root.sema_loaded) { ret; }
+    val n: u32 = root.p.module_len;
+    if (n == 0) { root.sema_loaded = true; ret; }
+
+    val arr_r: Result[*sema.SemaResult, str] = allocate[sema.SemaResult](w.alloc, n::usize);
+    if (is_err[*sema.SemaResult, str](arr_r)) { ret; }
+    root.sema       = unwrap_ok[*sema.SemaResult, str](arr_r);
+    root.sema_count = n;
+    zero_sema(root.sema, n);
+
+    # ready[mid]: whether module mid has a populated SemaResult this pass, so a
+    # later module's SemaDeps exposes only the snapshots already produced (every
+    # dep is strictly earlier in topo order and thus ready before its dependents).
+    val rdy_r: Result[*bool, str] = allocate[bool](w.alloc, n::usize);
+    if (is_err[*bool, str](rdy_r)) { free_sema(w, root); ret; }
+    val ready: *bool = unwrap_ok[*bool, str](rdy_r);
+    var z: u32 = 0;
+    for (z < n) { ready[z] = false; z = z + 1; }
+
+    var ti: u32 = 0;
+    for (ti < root.p.topo_len) {
+        val mid: sess.ModuleId = root.p.topo[ti];
+        run_module_sema(w, root, mid, ready);
+        ti = ti + 1;
+    }
+
+    deallocate[bool](w.alloc, ready, n::usize);
+    root.sema_loaded = true;
+}
+
+# run_module_sema: type-check one loaded module against the modules already sema'd
+# this pass, storing its SemaResult into `root.sema[mid]` and marking it ready. a
+# module that did not resolve (no resolve_result) is left zeroed and unready — its
+# types stay TYPE_NIL and dependents simply do not see it among their deps. the
+# comptime context the driver populated for the module (`m.ctx`) drives array-length
+# and `$if`-gate evaluation, matching how the compiler sema's the same module. on
+# any failure the slot is left zeroed; the pass continues so a single bad module
+# does not deny typing to the rest.
+fun run_module_sema(w: *Workspace, root: *Root, mid: sess.ModuleId, ready: *bool) {
+    if (mid::u32 >= root.p.module_len) { ret; }
+    val m: *driver.ModuleEntry = ?root.p.modules[mid::u32];
+    if (!m.resolved) { ret; }
+
+    var deps: sema.SemaDeps;
+    if (!build_sema_deps(w, root, ready, ?deps)) { ret; }
+
+    val sr_r: Result[sema.SemaResult, str] = sema.sema(w.s, ?m.a, ?m.resolve_result, ?deps, ?m.ctx, mid);
+    free_sema_deps(w, ?deps);
+    if (is_err[sema.SemaResult, str](sr_r)) { ret; }
+    root.sema[mid::u32] = unwrap_ok[sema.SemaResult, str](sr_r);
+    ready[mid::u32]     = true;
+}
+
+# build_sema_deps: assemble the SemaDeps for the module about to be analysed — one
+# ModuleSema entry per module already sema'd this pass (ready), each borrowing that
+# module's decl_type snapshot. cross-module symbol types are looked up by the
+# symbol's origin ModuleId, and a `fwd` re-export carries the originating
+# (transitive) module as the origin, so the snapshot must cover every ready module,
+# not only the direct dependencies — all of them are strictly earlier in topo order
+# and thus already produced. mirrors the compiler's own build_sema_deps. writes the
+# assembled deps into `out`; false on allocation failure (the caller skips the
+# module). an empty set (no module ready yet) is a successful result.
+fun build_sema_deps(w: *Workspace, root: *Root, ready: *bool, out: *sema.SemaDeps) bool {
+    out.entries = nil;
+    out.count   = 0;
+
+    var count: u32 = 0;
+    var i: u32 = 0;
+    for (i < root.p.module_len) {
+        if (ready[i]) { count = count + 1; }
+        i = i + 1;
+    }
+    if (count == 0) { ret true; }
+
+    val r: Result[*sema.ModuleSema, str] = allocate[sema.ModuleSema](w.alloc, count::usize);
+    if (is_err[*sema.ModuleSema, str](r)) { ret false; }
+    out.entries = unwrap_ok[*sema.ModuleSema, str](r);
+    out.count   = count;
+
+    var k: u32 = 0;
+    var j: u32 = 0;
+    for (j < root.p.module_len) {
+        if (ready[j]) {
+            val dep: *driver.ModuleEntry = ?root.p.modules[j];
+            var ms: sema.ModuleSema;
+            ms.path       = dep.fqn;
+            ms.module     = j::sess.ModuleId;
+            ms.decl_type  = root.sema[j].decl_type;
+            ms.decl_count = root.sema[j].decl_count;
+            out.entries[k] = ms;
+            k = k + 1;
+        }
+        j = j + 1;
+    }
+    ret true;
+}
+
+# free_sema_deps: release the entries array a build_sema_deps allocated. the
+# borrowed decl_type arrays it points into are owned by the producing SemaResults
+# and are NOT freed here.
+fun free_sema_deps(w: *Workspace, deps: *sema.SemaDeps) {
+    if (deps.entries == nil) { ret; }
+    deallocate[sema.ModuleSema](w.alloc, deps.entries, deps.count::usize);
+    deps.entries = nil;
+    deps.count   = 0;
+}
+
+# zero_sema: zero a freshly allocated SemaResult array so an un-run or skipped
+# module's slot has nil arrays — a lookup against it types to TYPE_NIL, never a
+# wild read. mirrors how the resolve cache zero-fills its gaps.
+fun zero_sema(arr: *sema.SemaResult, n: u32) {
+    var i: u32 = 0;
+    for (i < n) {
+        arr[i].alloc            = nil;
+        arr[i].expr_type        = nil;
+        arr[i].type_resolved_ty = nil;
+        arr[i].decl_type        = nil;
+        arr[i].expr_count       = 0;
+        arr[i].type_count       = 0;
+        arr[i].decl_count       = 0;
+        i = i + 1;
+    }
+}
+
 # cache_hit: the cached ResolveResult for `fid` when it was resolved from the
 # exact Ast `a` (the editor replaces the Ast pointer on every text update, so
 # pointer identity proves the text is current) and against the same build as
@@ -1327,19 +1714,26 @@ fun cache_put(w: *Workspace, fid: src.FileId, rr: *res.ResolveResult, a: *ast.As
             w.cache = unwrap_ok[*Cached, str](r);
         }
         var z: u32 = w.cache_len;
-        for (z < new_len) { w.cache[z].rr = nil; w.cache[z].a = nil; w.cache[z].gen = 0; z = z + 1; }
+        for (z < new_len) { w.cache[z].rr = nil; w.cache[z].sr = nil; w.cache[z].a = nil; w.cache[z].gen = 0; z = z + 1; }
         w.cache_len = new_len;
     }
     w.cache[fid::u32].rr  = rr;
+    w.cache[fid::u32].sr  = nil;
     w.cache[fid::u32].a   = a;
     w.cache[fid::u32].gen = gen;
     ret true;
 }
 
-# release_entry: free a cache slot's owned ResolveResult and zero the slot —
-# the one teardown for a Cached entry, shared by every reclamation path.
+# release_entry: free a cache slot's owned ResolveResult and SemaResult and zero
+# the slot — the one teardown for a Cached entry, shared by every reclamation path.
+# the sema result (populated lazily by sema_doc, nil otherwise) is torn down first.
 # callers guard `c.rr != nil`.
 fun release_entry(w: *Workspace, c: *Cached) {
+    if (c.sr != nil) {
+        sema.dnit_result(c.sr);
+        deallocate[sema.SemaResult](w.alloc, c.sr, 1);
+        c.sr = nil;
+    }
     res.dnit_result(c.rr);
     deallocate[res.ResolveResult](w.alloc, c.rr, 1);
     c.rr  = nil;

--- a/src/types.mach
+++ b/src/types.mach
@@ -1,0 +1,98 @@
+# mls.types: pure helpers over sema's typing output.
+#
+# the feature layer reads per-expression types and the nominal back-link from a
+# record TypeId to its declaring module here, so the resolution rules live in one
+# place — and, being free of any session / project state, are unit-testable in
+# isolation. `project.mach` re-exports these through its own narrowed accessors so
+# no feature signature carries a `*sess.Session`.
+
+use std.types.bool.bool;
+use std.types.size.usize;
+
+use std.types.option.Option;
+use std.types.option.some;
+use std.types.option.none;
+use std.types.option.is_some;
+use std.types.option.unwrap;
+
+use sess: mach.lang.session;
+use type: mach.lang.type;
+use id:   mach.lang.fe.ast.id;
+use sema: mach.lang.fe.sema;
+
+# Nominal: the declaration site a record / union TypeId nominally refers to —
+# the back-link a field feature follows from a value's type to the `rec` / `uni`
+# declaration whose fields it must walk. for a generic instance this is the
+# generic template's declaration (`target_origin` / `target_decl`).
+# ---
+# origin: ModuleId of the declaring module
+# decl:   DeclId of the rec / uni declaration in `origin`'s Ast
+# kind:   the resolved type kind (TYPE_REC, TYPE_UNI, or TYPE_INSTANCE)
+pub rec Nominal {
+    origin: sess.ModuleId;
+    decl:   id.DeclId;
+    kind:   type.TypeKind;
+}
+
+# type_of: the semantic type of expression `eid` in `sr`, or TYPE_NIL when `sr`
+# is nil or `eid` is out of range. the one read the feature layer makes against a
+# buffer's / module's SemaResult to learn an expression's type.
+# ---
+# sr:  the module's / buffer's SemaResult, or nil
+# eid: the expression id to type
+# ret: the expression's TypeId, or TYPE_NIL when unavailable
+pub fun type_of(sr: *sema.SemaResult, eid: id.ExprId) type.TypeId {
+    if (sr == nil || sr.expr_type == nil) { ret type.TYPE_NIL; }
+    if (eid::u32 >= sr.expr_count) { ret type.TYPE_NIL; }
+    ret sr.expr_type[eid];
+}
+
+# decl_type_of: the declared (or inferred) type of decl `did` in `sr`, or
+# TYPE_NIL when `sr` is nil or `did` is out of range. the decl-keyed twin of
+# `type_of`, for typing a binding from its declaration rather than a use.
+# ---
+# sr:  the module's / buffer's SemaResult, or nil
+# did: the declaration id to type
+# ret: the declaration's TypeId, or TYPE_NIL when unavailable
+pub fun decl_type_of(sr: *sema.SemaResult, did: id.DeclId) type.TypeId {
+    if (sr == nil || sr.decl_type == nil) { ret type.TYPE_NIL; }
+    if (did::u32 >= sr.decl_count) { ret type.TYPE_NIL; }
+    ret sr.decl_type[did];
+}
+
+# nominal_of: the declaration site a record / union TypeId nominally refers to,
+# or none when `tid` is not a nominal type (a primitive, pointer, array, function,
+# generic parameter, or a sentinel). a pointer to a record is peeled to the record
+# first, so `*T` and `T` resolve to the same declaration — a field access through a
+# pointer reaches the same `rec` decl. a generic instance resolves to its template
+# declaration. this is the nominal back-link a field go-to-def / rename follows.
+# ---
+# ti:  the session's type interner
+# tid: the TypeId to resolve
+# ret: some(Nominal) for a nominal / instance type, none otherwise
+pub fun nominal_of(ti: *type.TypeInterner, tid: type.TypeId) Option[Nominal] {
+    if (tid == type.TYPE_NIL || tid == type.TYPE_ERROR) { ret none[Nominal](); }
+    val t_opt: Option[*type.Type] = type.get(ti, tid);
+    if (!is_some[*type.Type](t_opt)) { ret none[Nominal](); }
+    val t: *type.Type = unwrap[*type.Type](t_opt);
+
+    # peel a single pointer level: a field access through `*T` resolves to T's decl.
+    if (t.kind == type.TYPE_POINTER) {
+        ret nominal_of(ti, t.data.pointer.base);
+    }
+    if (t.kind == type.TYPE_REC || t.kind == type.TYPE_UNI) {
+        var n: Nominal;
+        n.origin = t.data.nominal.origin;
+        n.decl   = t.data.nominal.decl;
+        n.kind   = t.kind;
+        ret some[Nominal](n);
+    }
+    if (t.kind == type.TYPE_INSTANCE) {
+        var n: Nominal;
+        n.origin = t.data.instance.target_origin;
+        n.decl   = t.data.instance.target_decl;
+        n.kind   = t.kind;
+        ret some[Nominal](n);
+    }
+    ret none[Nominal]();
+}

--- a/src/types.mach
+++ b/src/types.mach
@@ -7,18 +7,32 @@
 # no feature signature carries a `*sess.Session`.
 
 use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
 use std.types.size.usize;
+use std.types.string.str;
 
 use std.types.option.Option;
 use std.types.option.some;
 use std.types.option.none;
 use std.types.option.is_some;
+use std.types.option.is_none;
 use std.types.option.unwrap;
 
-use sess: mach.lang.session;
-use type: mach.lang.type;
-use id:   mach.lang.fe.ast.id;
-use sema: mach.lang.fe.sema;
+use std.types.result.Result;
+use std.types.result.is_err;
+use std.types.result.unwrap_ok;
+
+use std.allocator.Allocator;
+use std.allocator.allocate;
+use std.allocator.deallocate;
+use page: std.allocator.page;
+
+use sess:   mach.lang.session;
+use type:   mach.lang.type;
+use id:     mach.lang.fe.ast.id;
+use sema:   mach.lang.fe.sema;
+use intern: mach.lang.intern;
 
 # Nominal: the declaration site a record / union TypeId nominally refers to —
 # the back-link a field feature follows from a value's type to the `rec` / `uni`
@@ -95,4 +109,197 @@ pub fun nominal_of(ti: *type.TypeInterner, tid: type.TypeId) Option[Nominal] {
         ret some[Nominal](n);
     }
     ret none[Nominal]();
+}
+
+# make_sema_result: build a standalone SemaResult over `pa` with the given
+# parallel-array lengths, every slot prefilled to TYPE_NIL. the test helper that
+# stands in for sema's own allocation so the pure accessors can be exercised
+# without running a whole analysis. released with `free_sema_result`.
+fun make_sema_result(pa: *Allocator, expr_n: u32, decl_n: u32) sema.SemaResult {
+    var sr: sema.SemaResult;
+    sr.alloc            = pa;
+    sr.expr_type        = nil;
+    sr.type_resolved_ty = nil;
+    sr.decl_type        = nil;
+    sr.expr_count       = 0;
+    sr.type_count       = 0;
+    sr.decl_count       = 0;
+    if (expr_n > 0) {
+        val r: Result[*type.TypeId, str] = allocate[type.TypeId](pa, expr_n::usize);
+        if (!is_err[*type.TypeId, str](r)) {
+            sr.expr_type  = unwrap_ok[*type.TypeId, str](r);
+            sr.expr_count = expr_n;
+            var i: u32 = 0;
+            for (i < expr_n) { sr.expr_type[i] = type.TYPE_NIL; i = i + 1; }
+        }
+    }
+    if (decl_n > 0) {
+        val r: Result[*type.TypeId, str] = allocate[type.TypeId](pa, decl_n::usize);
+        if (!is_err[*type.TypeId, str](r)) {
+            sr.decl_type  = unwrap_ok[*type.TypeId, str](r);
+            sr.decl_count = decl_n;
+            var i: u32 = 0;
+            for (i < decl_n) { sr.decl_type[i] = type.TYPE_NIL; i = i + 1; }
+        }
+    }
+    ret sr;
+}
+
+# free_sema_result: release a SemaResult built by make_sema_result.
+fun free_sema_result(pa: *Allocator, sr: *sema.SemaResult) {
+    if (sr.expr_type != nil && sr.expr_count > 0) {
+        deallocate[type.TypeId](pa, sr.expr_type, sr.expr_count::usize);
+    }
+    if (sr.decl_type != nil && sr.decl_count > 0) {
+        deallocate[type.TypeId](pa, sr.decl_type, sr.decl_count::usize);
+    }
+}
+
+test "types: type_of returns TYPE_NIL for a nil SemaResult" {
+    if (type_of(nil, 0) != type.TYPE_NIL) { ret 1; }
+    ret 0;
+}
+
+test "types: type_of returns TYPE_NIL for an out-of-range expr id" {
+    var pa: Allocator;
+    page.make(?pa);
+    var sr: sema.SemaResult = make_sema_result(?pa, 2, 0);
+    if (type_of(?sr, 5) != type.TYPE_NIL) { free_sema_result(?pa, ?sr); ret 1; }
+    free_sema_result(?pa, ?sr);
+    ret 0;
+}
+
+test "types: type_of reads the stored expression type" {
+    var pa: Allocator;
+    page.make(?pa);
+    var ti: type.TypeInterner = unwrap_ok[type.TypeInterner, str](type.init(?pa));
+    val i32t: type.TypeId = unwrap[type.TypeId](type.prim(?ti, type.TYPE_I32));
+
+    var sr: sema.SemaResult = make_sema_result(?pa, 3, 0);
+    sr.expr_type[1] = i32t;
+    var fail: bool = false;
+    if (type_of(?sr, 1) != i32t)          { fail = true; }
+    if (type_of(?sr, 0) != type.TYPE_NIL) { fail = true; }
+
+    free_sema_result(?pa, ?sr);
+    type.dnit(?ti);
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+test "types: decl_type_of reads the stored declaration type" {
+    var pa: Allocator;
+    page.make(?pa);
+    var ti: type.TypeInterner = unwrap_ok[type.TypeInterner, str](type.init(?pa));
+    val u8t: type.TypeId = unwrap[type.TypeId](type.prim(?ti, type.TYPE_U8));
+
+    var sr: sema.SemaResult = make_sema_result(?pa, 0, 2);
+    sr.decl_type[0] = u8t;
+    var fail: bool = false;
+    if (decl_type_of(?sr, 0) != u8t)            { fail = true; }
+    if (decl_type_of(?sr, 9) != type.TYPE_NIL)  { fail = true; }
+    if (decl_type_of(nil, 0) != type.TYPE_NIL)  { fail = true; }
+
+    free_sema_result(?pa, ?sr);
+    type.dnit(?ti);
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+test "types: nominal_of resolves a record TypeId to its declaration site" {
+    var pa: Allocator;
+    page.make(?pa);
+    var ti: type.TypeInterner = unwrap_ok[type.TypeInterner, str](type.init(?pa));
+
+    val rec: type.TypeId = unwrap_ok[type.TypeId, str](
+        type.intern_nominal(?ti, intern.STR_NIL, 7::sess.ModuleId, 3::id.DeclId, type.TYPE_REC));
+
+    val no: Option[Nominal] = nominal_of(?ti, rec);
+    var fail: bool = false;
+    if (is_none[Nominal](no)) { fail = true; }
+    or {
+        val n: Nominal = unwrap[Nominal](no);
+        if (n.origin != 7::sess.ModuleId) { fail = true; }
+        if (n.decl   != 3::id.DeclId)     { fail = true; }
+        if (n.kind   != type.TYPE_REC)    { fail = true; }
+    }
+
+    type.dnit(?ti);
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+test "types: nominal_of peels a pointer to the pointee record" {
+    var pa: Allocator;
+    page.make(?pa);
+    var ti: type.TypeInterner = unwrap_ok[type.TypeInterner, str](type.init(?pa));
+
+    val rec: type.TypeId = unwrap_ok[type.TypeId, str](
+        type.intern_nominal(?ti, intern.STR_NIL, 2::sess.ModuleId, 4::id.DeclId, type.TYPE_REC));
+    val ptr: type.TypeId = unwrap_ok[type.TypeId, str](type.intern_pointer(?ti, rec));
+
+    val no: Option[Nominal] = nominal_of(?ti, ptr);
+    var fail: bool = false;
+    if (is_none[Nominal](no)) { fail = true; }
+    or {
+        val n: Nominal = unwrap[Nominal](no);
+        if (n.origin != 2::sess.ModuleId) { fail = true; }
+        if (n.decl   != 4::id.DeclId)     { fail = true; }
+        if (n.kind   != type.TYPE_REC)    { fail = true; }
+    }
+
+    type.dnit(?ti);
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+test "types: nominal_of maps a generic instance to its template" {
+    var pa: Allocator;
+    page.make(?pa);
+    var ti: type.TypeInterner = unwrap_ok[type.TypeInterner, str](type.init(?pa));
+
+    val i32t: type.TypeId = unwrap[type.TypeId](type.prim(?ti, type.TYPE_I32));
+    var args: [1]type.TypeId;
+    args[0] = i32t;
+    val inst: type.TypeId = unwrap_ok[type.TypeId, str](
+        type.intern_instance(?ti, 5::sess.ModuleId, 8::id.DeclId, ?args[0], 1));
+
+    val no: Option[Nominal] = nominal_of(?ti, inst);
+    var fail: bool = false;
+    if (is_none[Nominal](no)) { fail = true; }
+    or {
+        val n: Nominal = unwrap[Nominal](no);
+        if (n.origin != 5::sess.ModuleId)  { fail = true; }
+        if (n.decl   != 8::id.DeclId)      { fail = true; }
+        if (n.kind   != type.TYPE_INSTANCE) { fail = true; }
+    }
+
+    type.dnit(?ti);
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+test "types: nominal_of returns none for a primitive type" {
+    var pa: Allocator;
+    page.make(?pa);
+    var ti: type.TypeInterner = unwrap_ok[type.TypeInterner, str](type.init(?pa));
+    val i32t: type.TypeId = unwrap[type.TypeId](type.prim(?ti, type.TYPE_I32));
+
+    val ok: bool = is_none[Nominal](nominal_of(?ti, i32t));
+    type.dnit(?ti);
+    if (!ok) { ret 1; }
+    ret 0;
+}
+
+test "types: nominal_of returns none for sentinel TypeIds" {
+    var pa: Allocator;
+    page.make(?pa);
+    var ti: type.TypeInterner = unwrap_ok[type.TypeInterner, str](type.init(?pa));
+
+    var fail: bool = false;
+    if (!is_none[Nominal](nominal_of(?ti, type.TYPE_NIL)))   { fail = true; }
+    if (!is_none[Nominal](nominal_of(?ti, type.TYPE_ERROR))) { fail = true; }
+    type.dnit(?ti);
+    if (fail) { ret 1; }
+    ret 0;
 }


### PR DESCRIPTION
Minor: record/union field navigation (go-to-def, references) and docstring-aware rename, plus first-class & field hover docs, on a new in-LSP sema foundation. Deps at mach 2.5.4 / mach-std 0.14.1.