### PR TITLE
release: v0.8.0

### DIFF
--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,7 @@
 [project]
 id      = "mls"
 name    = "Mach Language Server"
-version = "0.7.0"
+version = "0.8.0"
 src     = "src"
 dep     = "dep"
 target  = "native"

--- a/src/diagnostics.mach
+++ b/src/diagnostics.mach
@@ -54,6 +54,15 @@ val MAX_DIAGNOSTICS: usize = 200;
 # or editing a buffer stays instant — the project loads lazily on the first
 # feature request, after which the server re-publishes the now-loaded buffers
 # (#96).
+# semantic (type) diagnostics are layered on when — and only when — the governing
+# root's dep closure has already been sema'd (`project.sema_ready`, a load-free
+# check that never triggers a build or the heavy whole-closure `ensure_sema`).
+# `sema_doc` then types the active buffer against the closure's retained dep typing
+# (bounded — one module) and emits its type diagnostics onto the same session
+# DiagList `diagnose_doc` populated, so parse + resolve + type diagnostics publish
+# together. a loaded-but-un-sema'd root publishes parse + resolve only (instant);
+# the server re-publishes with types once a feature request sema's the closure (the
+# sema epoch) (#113).
 # ---
 # w:       the workspace, for routing the document to its governing root
 # es:      editor session holding the buffer
@@ -71,6 +80,13 @@ pub fun publish(w: *project.Workspace, es: *editor.EditorSession, sources: *src.
         ret;
     }
     val list: *diag.DiagList = unwrap_ok[*diag.DiagList, str](dr);
+
+    # append the buffer's type diagnostics when the closure is already sema'd. the
+    # gate is load-free (never `ensure_sema`), so this stays off the build/whole-
+    # closure path — `sema_doc`'s internal `ensure_sema` is a no-op on a ready root.
+    # the type diagnostics land on the same session DiagList `list` points into;
+    # `sema_doc`'s returned typing is the feature layer's, discarded here.
+    if (project.sema_ready(root)) { project.sema_doc(w, root, fid); }
 
     val quoted_uri: str = json.quote(uri, alloc);
     if (quoted_uri == nil) { ret; }

--- a/src/project.mach
+++ b/src/project.mach
@@ -217,6 +217,11 @@ pub rec Root {
 # load_epoch:   monotonic counter bumped on every successful root build, so the
 #               server can tell a feature request triggered a lazy load and
 #               re-publish diagnostics for the now-loaded buffers (#96)
+# sema_epoch:   monotonic counter bumped whenever a root's dep closure finishes
+#               sema (ensure_sema), so the server can tell a feature request
+#               triggered the lazy whole-closure typing and re-publish the open
+#               buffers WITH their semantic diagnostics — the type-diagnostics
+#               twin of load_epoch (#113)
 pub rec Workspace {
     s:            *sess.Session;
     es:           *editor.EditorSession;
@@ -229,6 +234,7 @@ pub rec Workspace {
     cache_len:    u32;
     gen_seq:      u32;
     load_epoch:   u32;
+    sema_epoch:   u32;
 }
 
 # init: construct an empty workspace over the server's sessions.
@@ -251,6 +257,7 @@ pub fun init(s: *sess.Session, es: *editor.EditorSession, alloc: *Allocator) Wor
     w.cache_len     = 0;
     w.gen_seq       = 1;
     w.load_epoch    = 0;
+    w.sema_epoch    = 0;
     ret w;
 }
 
@@ -312,6 +319,33 @@ pub fun set_watch_active(w: *Workspace, on: bool) {
 # ret: the current load epoch
 pub fun load_epoch(w: *Workspace) u32 {
     ret w.load_epoch;
+}
+
+# sema_epoch: the workspace's current sema epoch — a counter bumped whenever a
+# root's dep closure finishes typing (ensure_sema). the server snapshots it around
+# a feature request alongside the load epoch; a change means a type-aware feature
+# lazily sema'd a closure, so the open buffers it governs can be re-published with
+# their semantic diagnostics — which the load-free publish path could not produce
+# while the closure was still un-sema'd — without waiting for an edit (#113).
+# ---
+# w:   the workspace
+# ret: the current sema epoch
+pub fun sema_epoch(w: *Workspace) u32 {
+    ret w.sema_epoch;
+}
+
+# sema_ready: whether `root`'s loaded dep closure has already been sema'd, so its
+# retained per-module typing exists. a load-free check: it never triggers a build
+# or ensure_sema. the diagnostics publish path gates buffer sema on this — only on
+# a ready root is sema_doc cheap and correct (one module against retained dep
+# typing); a loaded-but-un-sema'd root publishes parse + resolve only, keeping
+# open/edit instant (#96). false for a nil, unloaded, or un-sema'd root.
+# ---
+# root: the candidate governing root, or nil
+# ret:  true when sema has run over root's current build
+pub fun sema_ready(root: *Root) bool {
+    if (root == nil) { ret false; }
+    ret root.loaded && root.sema_loaded;
 }
 
 # dnit: release the resolve cache and every loaded root.
@@ -1627,15 +1661,18 @@ fun free_deps(w: *Workspace, deps: *res.ResolveDeps) {
 # resolve is skipped, leaving a zeroed SemaResult that types to TYPE_NIL. the pass
 # is heavy (it walks the whole dep closure), so it runs only when a feature first
 # demands typing — never on the diagnostics publish hot path — and is cached until
-# the build reloads. allocation failure leaves the root un-sema'd (typing simply
-# stays unavailable) rather than aborting the request.
+# the build reloads. on completion it bumps the workspace sema epoch, the signal
+# the server uses to re-publish the open buffers with semantic diagnostics now
+# that the closure's retained typing exists (#113). allocation failure leaves the
+# root un-sema'd (typing simply stays unavailable, no epoch bump) rather than
+# aborting the request.
 # ---
 # w:    the workspace
 # root: the loaded root whose graph to type-check
 pub fun ensure_sema(w: *Workspace, root: *Root) {
     if (root == nil || !root.loaded || root.sema_loaded) { ret; }
     val n: u32 = root.p.module_len;
-    if (n == 0) { root.sema_loaded = true; ret; }
+    if (n == 0) { root.sema_loaded = true; w.sema_epoch = w.sema_epoch + 1; ret; }
 
     val arr_r: Result[*sema.SemaResult, str] = allocate[sema.SemaResult](w.alloc, n::usize);
     if (is_err[*sema.SemaResult, str](arr_r)) { ret; }
@@ -1661,6 +1698,7 @@ pub fun ensure_sema(w: *Workspace, root: *Root) {
 
     deallocate[bool](w.alloc, ready, n::usize);
     root.sema_loaded = true;
+    w.sema_epoch = w.sema_epoch + 1;
 }
 
 # run_module_sema: type-check one loaded module against the modules already sema'd
@@ -2004,4 +2042,33 @@ fun append(buf: *u8, offset: usize, s: str) usize {
     val n: usize = str_len(s);
     if (n > 0) { mem.raw_copy((buf::usize + offset)::ptr, s::ptr, n); }
     ret offset + n;
+}
+
+test "project: sema_ready is false for a nil root" {
+    if (sema_ready(nil)) { ret 1; }
+    ret 0;
+}
+
+test "project: sema_ready is false for a loaded but un-sema'd root" {
+    var r: Root;
+    r.loaded      = true;
+    r.sema_loaded = false;
+    if (sema_ready(?r)) { ret 1; }
+    ret 0;
+}
+
+test "project: sema_ready is false for an unloaded root even if sema_loaded" {
+    var r: Root;
+    r.loaded      = false;
+    r.sema_loaded = true;
+    if (sema_ready(?r)) { ret 1; }
+    ret 0;
+}
+
+test "project: sema_ready is true only when loaded and sema'd" {
+    var r: Root;
+    r.loaded      = true;
+    r.sema_loaded = true;
+    if (!sema_ready(?r)) { ret 1; }
+    ret 0;
 }

--- a/src/server.mach
+++ b/src/server.mach
@@ -352,9 +352,12 @@ fun handle_feature(srv: *Server, body: str, which: i64) {
     val uri: str = json.extract_after(body, "\"textDocument\"", "\"uri\"", srv.alloc);
 
     # a feature request resolves dep-aware via project.root_for, which loads the
-    # governing project lazily on first use. snapshot the load epoch so a load
-    # triggered here re-publishes the now-loaded buffers' diagnostics (#96).
+    # governing project lazily on first use; a type-aware feature additionally
+    # sema's the closure lazily (ensure_sema). snapshot both the load epoch and the
+    # sema epoch so a load (#96) or a first sema (#113) triggered here re-publishes
+    # the now-loaded / now-typed buffers' diagnostics.
     val epoch_before: u32 = project.load_epoch(?srv.ws);
+    val sema_before:  u32 = project.sema_epoch(?srv.ws);
 
     if (which == 0) { language.hover(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, body, uri); }
     or (which == 1) { language.definition(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, body, uri); }
@@ -366,16 +369,18 @@ fun handle_feature(srv: *Server, body: str, which: i64) {
 
     if (uri != nil) { json.free_str(uri, srv.alloc); }
 
-    if (project.load_epoch(?srv.ws) != epoch_before) { republish_loaded(srv); }
+    if (project.load_epoch(?srv.ws) != epoch_before || project.sema_epoch(?srv.ws) != sema_before) { republish_loaded(srv); }
 }
 
 # republish_loaded: re-publish diagnostics for every open document now governed
-# by a loaded project root. run after a feature request triggers a lazy load
-# (#96): the buffers under the freshly-loaded root were published parse-only on
-# open, so this upgrades them to dep-aware semantic diagnostics — including any
-# out-of-closure import the load now flags — without the user touching the file.
-# the publish path is load-free, so a buffer under no loaded root simply
-# re-publishes its parse-only diagnostics (unchanged), and nothing new is built.
+# by a loaded project root. run after a feature request triggers a lazy load (#96)
+# or the first whole-closure sema (#113): the buffers under the freshly-loaded root
+# were published parse-only on open, so a load upgrades them to dep-aware
+# resolution diagnostics — including any out-of-closure import the load now flags —
+# and a completed sema further layers their type diagnostics, all without the user
+# touching the file. the publish path is load-free, so a buffer under no loaded
+# root simply re-publishes its parse-only diagnostics (unchanged), and nothing new
+# is built.
 fun republish_loaded(srv: *Server) {
     val n: usize = documents.slot_count(?srv.docs);
     var i: usize = 0;


### PR DESCRIPTION
Minor: semantic (type) diagnostics published alongside parse + name-resolution, gated load-free to preserve instant open/edit (#113).