### PR TITLE
release: v0.8.1

### DIFF
--- a/mach.lock
+++ b/mach.lock
@@ -8,4 +8,4 @@ commit = "eb940a5b48020c18ac73464377d2ba5471241306"
 [deps.mach]
 url = "https://github.com/octalide/mach"
 ref = "branch/main"
-commit = "2d1ab6fc47aaf1119926704625821babedc73deb"
+commit = "f3fe2037bcefd0aad1e00472fa6041fa531a0177"

--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,7 @@
 [project]
 id      = "mls"
 name    = "Mach Language Server"
-version = "0.8.0"
+version = "0.8.1"
 src     = "src"
 dep     = "dep"
 target  = "native"


### PR DESCRIPTION
Patch: bump mach to 2.5.6 (incremental parse caching) so save-triggered project rebuilds re-parse only the changed module, not the whole closure.