### PR TITLE
release: v0.8.2

### DIFF
--- a/mach.lock
+++ b/mach.lock
@@ -8,4 +8,4 @@ commit = "eb940a5b48020c18ac73464377d2ba5471241306"
 [deps.mach]
 url = "https://github.com/octalide/mach"
 ref = "branch/main"
-commit = "f3fe2037bcefd0aad1e00472fa6041fa531a0177"
+commit = "cd3cf02b49edaaa30d8047c678ce71df5b0a6932"

--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,7 @@
 [project]
 id      = "mls"
 name    = "Mach Language Server"
-version = "0.8.1"
+version = "0.8.2"
 src     = "src"
 dep     = "dep"
 target  = "native"


### PR DESCRIPTION
Patch: bump mach to 2.5.7 (incremental name resolution) so the LSP's project rebuilds inherit resolve-level incremental from the driver. Full per-save minimal recompute remains tracked as #117.