### PR TITLE
chore: format cleanup to mach skill

### DIFF
--- a/src/diagnostics.mach
+++ b/src/diagnostics.mach
@@ -1,4 +1,4 @@
-# mls.diagnostics: run the editor diagnostics slice and publish LSP diagnostics.
+# run the editor diagnostics slice and publish LSP diagnostics
 #
 # the diagnostics vertical slice end-to-end: feed a document's buffer to the
 # editor surface (`editor.diagnostics`), translate every reported
@@ -33,16 +33,16 @@ use json:      mls.json;
 use positions: mls.positions;
 use project:   mls.project;
 
-# LSP diagnostic severities (1 = Error … 4 = Hint).
+# LSP diagnostic severities (1 = Error … 4 = Hint)
 val LSP_ERROR:   i64 = 1;
 val LSP_WARNING: i64 = 2;
 val LSP_INFO:    i64 = 3;
 val LSP_HINT:    i64 = 4;
 
-# MAX_DIAGNOSTICS: cap on diagnostics published per document, to bound message size.
+# cap on diagnostics published per document, to bound message size
 val MAX_DIAGNOSTICS: usize = 200;
 
-# publish: analyze `uri`'s buffer and send its current diagnostics. a document
+# analyze `uri`'s buffer and send its current diagnostics. a document
 # governed by an already-loaded project root is analyzed dep-aware
 # (`project.diagnose_doc`) so its name-resolution diagnostics — including an
 # import of a module outside the project's dep closure — are surfaced, keeping
@@ -62,7 +62,7 @@ val MAX_DIAGNOSTICS: usize = 200;
 # DiagList `diagnose_doc` populated, so parse + resolve + type diagnostics publish
 # together. a loaded-but-un-sema'd root publishes parse + resolve only (instant);
 # the server re-publishes with types once a feature request sema's the closure (the
-# sema epoch) (#113).
+# sema epoch) (#113)
 # ---
 # w:       the workspace, for routing the document to its governing root
 # es:      editor session holding the buffer
@@ -153,7 +153,7 @@ pub fun publish(w: *project.Workspace, es: *editor.EditorSession, sources: *src.
     json.free_str(quoted_uri, alloc);
 }
 
-# clear: publish an empty diagnostics array for `uri` (e.g. on close).
+# publish an empty diagnostics array for `uri` (e.g. on close)
 # ---
 # alloc: allocator for the message buffer
 # uri:   document URI to clear
@@ -183,8 +183,8 @@ pub fun clear(alloc: *Allocator, uri: str) {
     json.free_str(quoted_uri, alloc);
 }
 
-# build_entry: render one diagnostic as an LSP Diagnostic JSON object, resolving
-# its span to a 0-based range against the source map.
+# render one diagnostic as an LSP Diagnostic JSON object, resolving
+# its span to a 0-based range against the source map
 fun build_entry(sources: *src.SourceMap, d: *diag.Diagnostic, alloc: *Allocator) str {
     var start_line: usize = 0;
     var start_char: usize = 0;
@@ -205,7 +205,7 @@ fun build_entry(sources: *src.SourceMap, d: *diag.Diagnostic, alloc: *Allocator)
     ret build_diagnostic_json(start_line, start_char, end_line, end_char, severity, d.message, alloc);
 }
 
-# map_severity: translate a compiler Severity to the LSP severity scale.
+# translate a compiler Severity to the LSP severity scale
 fun map_severity(sev: diag.Severity) i64 {
     if (sev == diag.SEVERITY_ERROR)   { ret LSP_ERROR; }
     if (sev == diag.SEVERITY_WARNING) { ret LSP_WARNING; }
@@ -213,8 +213,8 @@ fun map_severity(sev: diag.Severity) i64 {
     ret LSP_HINT;
 }
 
-# build_diagnostic_json: assemble one `{ range, severity, source, message }`
-# object from its parts.
+# assemble one `{ range, severity, source, message }`
+# object from its parts
 fun build_diagnostic_json(
     start_line: usize, start_char: usize,
     end_line: usize, end_char: usize,
@@ -265,13 +265,13 @@ fun build_diagnostic_json(
     ret buf::str;
 }
 
-# slen: length of `s`, treating nil as 0.
+# length of `s`, treating nil as 0
 fun slen(s: str) usize {
     if (s == nil) { ret 0; }
     ret str_len(s);
 }
 
-# append: copy `s` into `buf` at `offset`, returning the new offset.
+# copy `s` into `buf` at `offset`, returning the new offset
 fun append(buf: *u8, offset: usize, s: str) usize {
     if (s == nil) { ret offset; }
     val n: usize = str_len(s);
@@ -279,7 +279,7 @@ fun append(buf: *u8, offset: usize, s: str) usize {
     ret offset + n;
 }
 
-# free_entries: free an array of owned diagnostic JSON strings and the array.
+# free an array of owned diagnostic JSON strings and the array
 fun free_entries(entries: *str, count: usize, alloc: *Allocator) {
     if (entries == nil) { ret; }
     var i: usize = 0;
@@ -290,7 +290,7 @@ fun free_entries(entries: *str, count: usize, alloc: *Allocator) {
     deallocate[str](alloc, entries, count);
 }
 
-# free_parts: free the six fragment strings of one diagnostic object.
+# free the six fragment strings of one diagnostic object
 fun free_parts(sl: str, sc: str, el: str, ec: str, sev: str, qmsg: str, alloc: *Allocator) {
     json.free_str(sl, alloc);
     json.free_str(sc, alloc);

--- a/src/diagnostics.mach
+++ b/src/diagnostics.mach
@@ -2,9 +2,9 @@
 #
 # the diagnostics vertical slice end-to-end: feed a document's buffer to the
 # editor surface (`editor.diagnostics`), translate every reported
-# `diagnostic.Diagnostic` into an LSP `Diagnostic` — mapping its byte `span`
+# `diagnostic.Diagnostic` into an LSP `Diagnostic` - mapping its byte `span`
 # through `positions.range_of` to a 0-based UTF-16 range and its severity
-# to the LSP scale — and emit a `textDocument/publishDiagnostics` notification.
+# to the LSP scale - and emit a `textDocument/publishDiagnostics` notification.
 # clearing is the same notification with an empty array.
 
 use std.types.bool.bool;
@@ -33,7 +33,7 @@ use json:      mls.json;
 use positions: mls.positions;
 use project:   mls.project;
 
-# LSP diagnostic severities (1 = Error … 4 = Hint)
+# LSP diagnostic severities (1 = Error ... 4 = Hint)
 val LSP_ERROR:   i64 = 1;
 val LSP_WARNING: i64 = 2;
 val LSP_INFO:    i64 = 3;
@@ -44,21 +44,21 @@ val MAX_DIAGNOSTICS: usize = 200;
 
 # analyze `uri`'s buffer and send its current diagnostics. a document
 # governed by an already-loaded project root is analyzed dep-aware
-# (`project.diagnose_doc`) so its name-resolution diagnostics — including an
-# import of a module outside the project's dep closure — are surfaced, keeping
+# (`project.diagnose_doc`) so its name-resolution diagnostics - including an
+# import of a module outside the project's dep closure - are surfaced, keeping
 # the published diagnostics consistent with what go-to-definition can resolve
 # (#78). a document under no loaded project resolves single-file
 # (`editor.diagnostics`, parse-only), so its cross-module `use`s are not flagged
 # against an empty dep set. the governing-root lookup is load-free
 # (`root_for_loaded`): publishing must never trigger a project build, so opening
-# or editing a buffer stays instant — the project loads lazily on the first
+# or editing a buffer stays instant - the project loads lazily on the first
 # feature request, after which the server re-publishes the now-loaded buffers
 # (#96).
-# semantic (type) diagnostics are layered on when — and only when — the governing
+# semantic (type) diagnostics are layered on when - and only when - the governing
 # root's dep closure has already been sema'd (`project.sema_ready`, a load-free
 # check that never triggers a build or the heavy whole-closure `ensure_sema`).
 # `sema_doc` then types the active buffer against the closure's retained dep typing
-# (bounded — one module) and emits its type diagnostics onto the same session
+# (bounded - one module) and emits its type diagnostics onto the same session
 # DiagList `diagnose_doc` populated, so parse + resolve + type diagnostics publish
 # together. a loaded-but-un-sema'd root publishes parse + resolve only (instant);
 # the server re-publishes with types once a feature request sema's the closure (the
@@ -83,7 +83,7 @@ pub fun publish(w: *project.Workspace, es: *editor.EditorSession, sources: *src.
 
     # append the buffer's type diagnostics when the closure is already sema'd. the
     # gate is load-free (never `ensure_sema`), so this stays off the build/whole-
-    # closure path — `sema_doc`'s internal `ensure_sema` is a no-op on a ready root.
+    # closure path - `sema_doc`'s internal `ensure_sema` is a no-op on a ready root.
     # the type diagnostics land on the same session DiagList `list` points into;
     # `sema_doc`'s returned typing is the feature layer's, discarded here.
     if (project.sema_ready(root)) { project.sema_doc(w, root, fid); }

--- a/src/documents.mach
+++ b/src/documents.mach
@@ -6,7 +6,7 @@
 # replaces the buffer text in place; `didClose` retires the entry. each entry
 # keeps its own owned URI copy so it survives the request that created it.
 #
-# the editor session is borrowed from the server and reused across documents —
+# the editor session is borrowed from the server and reused across documents -
 # it owns the per-buffer analysis and the underlying session owns the source
 # text, so this registry stores only the URI/FileId association.
 
@@ -149,7 +149,7 @@ pub fun close(st: *Store, uri: str) {
 }
 
 # the number of Document slots in the store. paired with `at` to
-# walk every live document — the re-publish-after-load sweep iterates
+# walk every live document - the re-publish-after-load sweep iterates
 # [0, slot_count) and skips slots whose `in_use` is false
 # ---
 # st:  the store
@@ -159,7 +159,7 @@ pub fun slot_count(st: *Store) usize {
 }
 
 # the Document in slot `idx`, or nil when out of range. the slot may be
-# retired (`in_use` false) — callers check that. for the open-document sweep
+# retired (`in_use` false) - callers check that. for the open-document sweep
 # that re-publishes diagnostics once a project finishes loading
 # ---
 # st:  the store

--- a/src/documents.mach
+++ b/src/documents.mach
@@ -1,4 +1,4 @@
-# mls.documents: the open-document registry bridging LSP URIs to editor buffers.
+# the open-document registry bridging LSP URIs to editor buffers
 #
 # the LSP identifies documents by URI; the editor surface identifies buffers by
 # `source.FileId`. this module owns that mapping. `didOpen` registers a URI's
@@ -33,7 +33,7 @@ use strutil: std.text.string;
 use src:    mach.lang.source;
 use editor: mach.lang.editor;
 
-# Document: one tracked open document.
+# one tracked open document
 # ---
 # uri:     owned document URI
 # file_id: editor FileId the buffer is registered under
@@ -44,7 +44,7 @@ pub rec Document {
     in_use:  bool;
 }
 
-# Store: the registry of tracked documents over a borrowed editor session.
+# the registry of tracked documents over a borrowed editor session
 # ---
 # es:    borrowed editor session that owns buffer analysis
 # alloc: allocator for the entry array and owned URIs
@@ -57,7 +57,7 @@ pub rec Store {
     len:   usize;
 }
 
-# init: construct an empty document store over an editor session.
+# construct an empty document store over an editor session
 # ---
 # es:    editor session the store registers buffers with
 # alloc: allocator for the store's own storage
@@ -71,8 +71,8 @@ pub fun init(es: *editor.EditorSession, alloc: *Allocator) Store {
     ret st;
 }
 
-# dnit: release every owned URI and the entry array. the borrowed editor
-# session is left untouched.
+# release every owned URI and the entry array. the borrowed editor
+# session is left untouched
 # ---
 # st: the store to tear down; all owned fields are zeroed
 pub fun dnit(st: *Store) {
@@ -89,8 +89,8 @@ pub fun dnit(st: *Store) {
     st.len = 0;
 }
 
-# open: register a document's text as an editor buffer, returning its entry.
-# a re-open of an already-tracked URI replaces the buffer text in place.
+# register a document's text as an editor buffer, returning its entry.
+# a re-open of an already-tracked URI replaces the buffer text in place
 # ---
 # st:   the store
 # uri:  document URI
@@ -120,7 +120,7 @@ pub fun open(st: *Store, uri: str, text: str) Result[*Document, str] {
     ret ok[*Document, str](d);
 }
 
-# change: replace the text of an already-open document.
+# replace the text of an already-open document
 # ---
 # st:   the store
 # uri:  document URI; must already be open
@@ -134,9 +134,9 @@ pub fun change(st: *Store, uri: str, text: str) Result[*Document, str] {
     ret ok[*Document, str](d);
 }
 
-# close: retire a tracked document, freeing its URI. the editor buffer's
+# retire a tracked document, freeing its URI. the editor buffer's
 # cached analysis is dropped on the next reuse of its FileId. a no-op for an
-# untracked URI.
+# untracked URI
 # ---
 # st:  the store
 # uri: document URI to close
@@ -148,9 +148,9 @@ pub fun close(st: *Store, uri: str) {
     d.in_use = false;
 }
 
-# slot_count: the number of Document slots in the store. paired with `at` to
+# the number of Document slots in the store. paired with `at` to
 # walk every live document — the re-publish-after-load sweep iterates
-# [0, slot_count) and skips slots whose `in_use` is false.
+# [0, slot_count) and skips slots whose `in_use` is false
 # ---
 # st:  the store
 # ret: the slot-array length
@@ -158,9 +158,9 @@ pub fun slot_count(st: *Store) usize {
     ret st.len;
 }
 
-# at: the Document in slot `idx`, or nil when out of range. the slot may be
+# the Document in slot `idx`, or nil when out of range. the slot may be
 # retired (`in_use` false) — callers check that. for the open-document sweep
-# that re-publishes diagnostics once a project finishes loading.
+# that re-publishes diagnostics once a project finishes loading
 # ---
 # st:  the store
 # idx: slot index in [0, slot_count)
@@ -170,7 +170,7 @@ pub fun at(st: *Store, idx: usize) *Document {
     ret ?st.docs[idx];
 }
 
-# find: the tracked Document for `uri`, or nil when not open.
+# the tracked Document for `uri`, or nil when not open
 # ---
 # st:  the store
 # uri: document URI to look up
@@ -186,7 +186,7 @@ pub fun find(st: *Store, uri: str) *Document {
     ret nil;
 }
 
-# ensure_slot: return a free Document slot, growing the array if needed.
+# return a free Document slot, growing the array if needed
 fun ensure_slot(st: *Store) Result[*Document, str] {
     var i: usize = 0;
     for (i < st.len) {

--- a/src/features.mach
+++ b/src/features.mach
@@ -11,7 +11,7 @@
 #
 # scope: resolution is single-file (the editor resolves a buffer in isolation
 # with an empty dep set), so a reference to a locally declared symbol binds
-# fully — its decl is in this same Ast — while a reference imported through a
+# fully - its decl is in this same Ast - while a reference imported through a
 # `use` resolves to a symbol whose `decl` lives in a dependency Ast this server
 # never loaded. those are reported as cross-module: hover still renders the
 # name and kind, but definition / references that need the decl span are
@@ -102,7 +102,7 @@ pub fun ref_at(a: *ast.Ast, rr: *res.ResolveResult, own: sess.ModuleId, offset: 
     }
 
     # the cursor may sit on a declaration's own name (the binding site), which
-    # is not an expr or type node — resolve it through the decl_symbol table
+    # is not an expr or type node - resolve it through the decl_symbol table
     # when the offset falls inside the decl's name span
     val did: id.DeclId = ast.offset_to_decl(a, offset);
     if (did != id.DECL_NIL) {
@@ -122,7 +122,7 @@ pub fun ref_at(a: *ast.Ast, rr: *res.ResolveResult, own: sess.ModuleId, offset: 
             }
         }
 
-        # a function's parameter and generic binding names are not decls — they
+        # a function's parameter and generic binding names are not decls - they
         # bind SYM_PARAM / SYM_GENERIC symbols carrying (decl, slot). resolve a
         # cursor on one of those binding names through the symbol table
         val bo: Option[SymbolRef] = binding_ref_in_decl(a, rr, own, did, offset);
@@ -134,7 +134,7 @@ pub fun ref_at(a: *ast.Ast, rr: *res.ResolveResult, own: sess.ModuleId, offset: 
 
 # a SymbolRef when `offset` falls on a function
 # parameter or generic binding name within decl `did`, or none. params and
-# generics carry no Decl node — their symbol is found by matching (decl, slot)
+# generics carry no Decl node - their symbol is found by matching (decl, slot)
 # in the symbol table
 fun binding_ref_in_decl(a: *ast.Ast, rr: *res.ResolveResult, own: sess.ModuleId, did: id.DeclId, offset: usize) Option[SymbolRef] {
     val d_opt: Option[*decl.Decl] = ast.get_decl(a, did);
@@ -242,7 +242,7 @@ pub fun symbol_is_local(rr: *res.ResolveResult, own: sess.ModuleId, sid: res.Sym
 }
 
 # the SymbolId in `rr` whose declaration is the module-scoped
-# pair (origin, decl) — the identity the same logical symbol shares across every
+# pair (origin, decl) - the identity the same logical symbol shares across every
 # module's resolve result, since an imported reference copies its referent's
 # origin ModuleId and DeclId. lets the workspace-wide references / rename walk
 # find a module's own id for a symbol declared elsewhere. param / generic
@@ -288,7 +288,7 @@ pub fun export_decl_of(rr: *res.ResolveResult, name: intern.StrId, kind: res.Sym
     ret id.DECL_NIL;
 }
 
-# the number of declarations at the buffer's module scope —
+# the number of declarations at the buffer's module scope -
 # the count documentSymbol enumerates. zero when the Ast has no root module
 # ---
 # a:   the buffer's parsed Ast
@@ -354,7 +354,7 @@ pub fun decl_name_span_of(a: *ast.Ast, sym: *res.Symbol) Option[token.Span] {
 }
 
 # the span go-to-definition should land on for a local
-# symbol — the binding name. for a param / generic this is its binding site in
+# symbol - the binding name. for a param / generic this is its binding site in
 # the function signature; for every other symbol it is the decl's name. none
 # when the symbol has no addressable binding in this Ast
 # ---
@@ -380,7 +380,7 @@ pub fun decl_name_span(d: *decl.Decl) Option[token.Span] {
     ret none[token.Span]();
 }
 
-# the byte span of a local symbol's declaration header — the
+# the byte span of a local symbol's declaration header - the
 # text to render on hover. for a function with a body it runs from the decl
 # start up to (not into) the body block, so the parameter list and return type
 # show without the body; for every other decl it is the whole decl span. none
@@ -413,8 +413,8 @@ pub fun signature_span(a: *ast.Ast, sym: *res.Symbol) Option[token.Span] {
     ret some[token.Span](d.span);
 }
 
-# the `name: type` span of a parameter symbol — from its
-# binding name through the end of its type annotation — for hover. falls back
+# the `name: type` span of a parameter symbol - from its
+# binding name through the end of its type annotation - for hover. falls back
 # to just the name span when the type node is unavailable. none for a non-param
 fun param_signature_span(a: *ast.Ast, sym: *res.Symbol) Option[token.Span] {
     val no: Option[token.Span] = binding_name_span(a, sym);
@@ -441,7 +441,7 @@ fun param_signature_span(a: *ast.Ast, sym: *res.Symbol) Option[token.Span] {
 }
 
 # the first-class doc-block span the parser attached to a local
-# symbol's declaration (`Decl.doc`) — the `#`-comment run directly above the
+# symbol's declaration (`Decl.doc`) - the `#`-comment run directly above the
 # decl with its `#[...]` attribute lines excluded, or none. the attribute-aware
 # replacement for the old source line-scan: it carries no `#[attr]` bytes, so the
 # rendered doc never folds in attribute syntax. none for a param / generic (which
@@ -462,7 +462,7 @@ pub fun doc_span_of(a: *ast.Ast, sym: *res.Symbol) Option[token.Span] {
 }
 
 # the description span of the component in the record / union doc
-# block `doc` whose component name matches the field name `field_name` — scanned
+# block `doc` whose component name matches the field name `field_name` - scanned
 # through `fe/doc.mach`'s component cursor, comparing each component's `name_span`
 # bytes against the field-name bytes. both spans index into the declaring module's
 # `source`, since the doc block and the field declaration share that file. none
@@ -595,7 +595,7 @@ pub fun type_ref_span(a: *ast.Ast, rr: *res.ResolveResult, tid: id.TypeId, targe
 # completion, i.e. a name a statement/expression position could reference. the
 # editor resolves a single file with no exposed scope chain, so completion
 # offers the file's module-level declarations, its `use` aliases and imports,
-# and the primitive type names — not lexically scoped locals, which need the
+# and the primitive type names - not lexically scoped locals, which need the
 # resolver's scope stack. duplicate-name symbols are deduped by the caller
 # ---
 # rr:  the ResolveResult holding the symbol table
@@ -681,8 +681,8 @@ pub fun import_ref_span(a: *ast.Ast, rr: *res.ResolveResult, did: id.DeclId, tar
 
 # true when the bytes of `span` in `file` exactly equal the
 # identifier `name`. the rename walk guards body references with it so a symbol
-# bound under an alias — whose references are spelled with the alias, not the
-# declared name — is not rewritten when the declaration is renamed
+# bound under an alias - whose references are spelled with the alias, not the
+# declared name - is not rewritten when the declaration is renamed
 # ---
 # file: the source file backing the span
 # span: byte span to compare
@@ -724,7 +724,7 @@ fun type_name_span(a: *ast.Ast, tid: id.TypeId) Option[token.Span] {
 # is SYMBOL_NIL for a MEMBER node), so this is the type-driven parallel to
 # `SymbolRef`: the feature layer resolves it to a field declaration through a
 # TypeId rather than the symbol table. `host` is the expression whose semantic
-# type names the record / union the field belongs to — the receiver for a member
+# type names the record / union the field belongs to - the receiver for a member
 # access `foo.bar`, the struct literal itself for `T{ bar: ... }` (whose inferred
 # type is the record). the caller types `host`, peels it to a record site, then
 # matches `name_span` against the site's fields
@@ -742,7 +742,7 @@ pub rec FieldRef {
 # this recovers the field name and the expression whose type names the field's
 # record directly from the syntax. it is consulted only when the symbol-table
 # pivot (`ref_at`) finds nothing, so an ordinary symbol still wins. pure over the
-# Ast — the actual field-decl lookup needs types and runs in the caller via
+# Ast - the actual field-decl lookup needs types and runs in the caller via
 # `field_decl_span`
 # ---
 # a:      the buffer's parsed Ast
@@ -785,7 +785,7 @@ pub fun field_ref_at(a: *ast.Ast, offset: usize) Option[FieldRef] {
 # the name span of the field declared in `decl_a` (its rec / uni
 # field range `[fields_start, fields_start + fields_len)` in `decl_a.typed_names`)
 # whose name bytes equal the referencing token `query` in `query_file`, or none
-# when no field matches. pure and session-free — the field-decl locator the
+# when no field matches. pure and session-free - the field-decl locator the
 # go-to-definition path drives once a value's type has been resolved to its record
 # site. comparing bytes across the two files lets the receiver and the declaration
 # live in different modules
@@ -831,7 +831,7 @@ pub fun field_decl_self_at(decl_a: *ast.Ast, fields_start: u32, fields_len: u32,
     ret none[token.Span]();
 }
 
-# the cross-module identity of a record / union field — the nominal
+# the cross-module identity of a record / union field - the nominal
 # declaration site of its record (`origin`, `decl`) paired with the field name as
 # bytes in the declaring module's source. the field-reference / field-rename walk
 # carries it across every loaded module: a member access or struct-literal init
@@ -862,7 +862,7 @@ pub rec FieldKey {
 #     peels to the keyed record, yields the matching init-name span.
 # the host type is read from `sr` (the module's SemaResult) and peeled through the
 # session type interner `ti`, so a field reached through `*T` or a generic instance
-# of the record matches the same key. pure over (`a`, `sr`, `ti`) — the caller
+# of the record matches the same key. pure over (`a`, `sr`, `ti`) - the caller
 # walks `[0, a.expr_len)` feeding the spans this returns to a sink
 # ---
 # a:    the module's parsed Ast
@@ -916,8 +916,8 @@ fun host_matches(sr: *sema.SemaResult, ti: *type.TypeInterner, eid: id.ExprId, k
 # write into `out` (up to `cap` spans) every site naming the
 # keyed field in module (`a`, `sr`) and return the count. the spans are, in walk
 # order: every member-access / struct-literal init whose host type peels to the
-# keyed record (`field_ref_span_at` over `[0, a.expr_len)`), and — when `declaring`
-# (this module declares the record) — the field declaration's own name span, then
+# keyed record (`field_ref_span_at` over `[0, a.expr_len)`), and - when `declaring`
+# (this module declares the record) - the field declaration's own name span, then
 # (when `want_doc` and the record's `doc` block carries a matching component) that
 # component's name token. this is the complete edit set a field rename applies to
 # one module and the location set references reports; it is pulled out of the JSON
@@ -956,12 +956,12 @@ pub fun collect_field_sites(a: *ast.Ast, sr: *sema.SemaResult, ti: *type.TypeInt
 }
 
 # the byte span to rewrite when a doc component's name is
-# renamed — the component in doc block `doc` (within `source`) whose name matches
+# renamed - the component in doc block `doc` (within `source`) whose name matches
 # the binding `query` (in `qf`), narrowed to the exact identifier token a rename
 # replaces. for a field or value parameter the component head is `# <name>:` and
 # the whole component `name_span` is the identifier, so it is returned as-is. for a
 # generic the component head keeps its syntactic `# [T]:` bracket form (see
-# `mach.lang.fe.doc`), so the returned span is the inner `T` only — the brackets
+# `mach.lang.fe.doc`), so the returned span is the inner `T` only - the brackets
 # are preserved. none when no component matches, or (for a generic) the matched
 # component carries no bracketed identifier. matching compares the inner identifier
 # against `query` so a `# [T]:` head matches the generic named `T`
@@ -984,7 +984,7 @@ pub fun doc_component_name_span(source: str, doc: token.Span, qf: *src.SourceFil
     ret none[token.Span]();
 }
 
-# the identifier token within a component name span — the whole
+# the identifier token within a component name span - the whole
 # span for a plain `name`, or the bracketed inner identifier for a generic's `[T]`
 # head. an empty span when a generic head has no `[...]` enclosed single-word
 # identifier. the narrowing `doc_component_name_span` applies so a generic rename
@@ -1012,7 +1012,7 @@ fun empty_span() token.Span {
 # true when span `sa` in `source` and span `sb` in `fb` cover
 # identical bytes. a cross-source compare where one side is a raw `str` (a doc
 # block lives in the declaring module's source) and the other a SourceFile (the
-# binding name) — bridging `same_source_span_equal` and `span_bytes_equal`
+# binding name) - bridging `same_source_span_equal` and `span_bytes_equal`
 fun span_bytes_equal_2(source: str, sa: token.Span, fb: *src.SourceFile, sb: token.Span) bool {
     if (sa.len != sb.len) { ret false; }
     val b: *u8 = fb.text::*u8;
@@ -1026,7 +1026,7 @@ fun span_bytes_equal_2(source: str, sa: token.Span, fb: *src.SourceFile, sb: tok
 
 # true when the bytes of `sa` in `fa` exactly equal the bytes of
 # `sb` in `fb`. the cross-file identifier compare the field-decl locator matches a
-# field name against the referencing token with — the two may sit in different
+# field name against the referencing token with - the two may sit in different
 # source files (a field declared in a dependency, referenced in the buffer)
 # ---
 # fa: source file backing span `sa`
@@ -1282,7 +1282,7 @@ test "features: doc_span_of returns none for a param symbol" {
 
 test "features: field_doc_desc finds the matching component's description" {
     # the doc block and the rec body share one source, so the field-name query
-    # span and the component name span both point into `src` — the same-file
+    # span and the component name span both point into `src` - the same-file
     # match field_doc_desc performs in `field_hover_markdown`.
     #             0         1         2         3         4         5         6         7         8         9
     #             0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456
@@ -1317,7 +1317,7 @@ test "features: field_doc_desc returns none when no component matches" {
     var doc: token.Span;
     doc.offset = 0;
     doc.len    = 46;
-    # "z" field name at offset 55 — no matching component
+    # "z" field name at offset 55 - no matching component
     val ok: bool = is_none[token.Span](field_doc_desc(src, doc, name_span_in(55, 1)));
     if (!ok) { ret 1; }
     ret 0;
@@ -1328,7 +1328,7 @@ test "features: field_doc_desc returns none for a summary-only doc block" {
     var doc: token.Span;
     doc.offset = 0;
     doc.len    = 31;
-    # "x" field name at offset 40 — the block has no component lines
+    # "x" field name at offset 40 - the block has no component lines
     val ok: bool = is_none[token.Span](field_doc_desc(src, doc, name_span_in(40, 1)));
     if (!ok) { ret 1; }
     ret 0;
@@ -1465,7 +1465,7 @@ test "features: field_ref_span_at matches a member access of the keyed record" {
         val sp: token.Span = unwrap[token.Span](o);
         if (sp.offset != 2 || sp.len != 1) { fail = true; }
     }
-    # the receiver IDENT itself is not a member access — no field span.
+    # the receiver IDENT itself is not a member access - no field span.
     if (is_some[token.Span](field_ref_span_at(?a, ?sr, ?ti, recv, ?buf, key))) { fail = true; }
 
     free_sema(?pa, ?sr);
@@ -1683,7 +1683,7 @@ test "features: collect_field_sites in a non-declaring module yields only body s
 
     val key: FieldKey = fk(0, 4, ?declf, 8, 1);
     var out: [4]token.Span;
-    # declaring=false: no decl span, no doc — just the body site
+    # declaring=false: no decl span, no doc - just the body site
     val n: usize = collect_field_sites(?a, ?sr, ?ti, ?buf, key, false, true, "", empty_doc(), ?out[0], 4);
 
     free_sema(?pa, ?sr);

--- a/src/features.mach
+++ b/src/features.mach
@@ -1,4 +1,4 @@
-# mls.features: offset -> id -> symbol queries over the editor resolve tables.
+# offset -> id -> symbol queries over the editor resolve tables
 #
 # the shared core of the language features (hover, definition, references,
 # rename, documentSymbol, completion). each starts from an `editor` buffer's
@@ -56,8 +56,8 @@ use sema:   mach.lang.fe.sema;
 
 use mtypes: mls.types;
 
-# SymbolRef: a symbol a position references, joined with the location of the
-# name token that referenced it.
+# a symbol a position references, joined with the location of the
+# name token that referenced it
 # ---
 # sym_id:    SymbolId into the ResolveResult symbol table
 # name_span: byte span of the referencing name token (the IDENT / type name)
@@ -69,9 +69,9 @@ pub rec SymbolRef {
     local:     bool;
 }
 
-# ref_at: the symbol referenced at a byte offset, or none when no resolved
+# the symbol referenced at a byte offset, or none when no resolved
 # expression or type name covers it. prefers the tightest expression; falls
-# back to a type-name position (a type annotation, return type, field type).
+# back to a type-name position (a type annotation, return type, field type)
 # ---
 # a:      the buffer's parsed Ast
 # rr:     the buffer's ResolveResult side tables
@@ -103,7 +103,7 @@ pub fun ref_at(a: *ast.Ast, rr: *res.ResolveResult, own: sess.ModuleId, offset: 
 
     # the cursor may sit on a declaration's own name (the binding site), which
     # is not an expr or type node — resolve it through the decl_symbol table
-    # when the offset falls inside the decl's name span.
+    # when the offset falls inside the decl's name span
     val did: id.DeclId = ast.offset_to_decl(a, offset);
     if (did != id.DECL_NIL) {
         if (rr.decl_symbol != nil && did::u32 < rr.decl_count) {
@@ -124,7 +124,7 @@ pub fun ref_at(a: *ast.Ast, rr: *res.ResolveResult, own: sess.ModuleId, offset: 
 
         # a function's parameter and generic binding names are not decls — they
         # bind SYM_PARAM / SYM_GENERIC symbols carrying (decl, slot). resolve a
-        # cursor on one of those binding names through the symbol table.
+        # cursor on one of those binding names through the symbol table
         val bo: Option[SymbolRef] = binding_ref_in_decl(a, rr, own, did, offset);
         if (is_some[SymbolRef](bo)) { ret bo; }
     }
@@ -132,10 +132,10 @@ pub fun ref_at(a: *ast.Ast, rr: *res.ResolveResult, own: sess.ModuleId, offset: 
     ret none[SymbolRef]();
 }
 
-# binding_ref_in_decl: a SymbolRef when `offset` falls on a function
+# a SymbolRef when `offset` falls on a function
 # parameter or generic binding name within decl `did`, or none. params and
 # generics carry no Decl node — their symbol is found by matching (decl, slot)
-# in the symbol table.
+# in the symbol table
 fun binding_ref_in_decl(a: *ast.Ast, rr: *res.ResolveResult, own: sess.ModuleId, did: id.DeclId, offset: usize) Option[SymbolRef] {
     val d_opt: Option[*decl.Decl] = ast.get_decl(a, did);
     if (!is_some[*decl.Decl](d_opt)) { ret none[SymbolRef](); }
@@ -170,7 +170,7 @@ fun binding_ref_in_decl(a: *ast.Ast, rr: *res.ResolveResult, own: sess.ModuleId,
 }
 
 # generics_start_of / generics_len_of: the generic-name pool slice of a decl
-# that may declare generics (fun / rec / uni), or 0 otherwise.
+# that may declare generics (fun / rec / uni), or 0 otherwise
 fun generics_start_of(d: *decl.Decl) u32 {
     if (d.kind == decl.DECL_KIND_FUN) { ret d.data.fun_.generics_start; }
     if (d.kind == decl.DECL_KIND_REC) { ret d.data.rec_.generics_start; }
@@ -184,8 +184,8 @@ fun generics_len_of(d: *decl.Decl) u32 {
     ret 0;
 }
 
-# find_binding_symbol: the SymbolId of the `kind` symbol declared by decl
-# `did` at `slot` (the param / generic index), or SYMBOL_NIL.
+# the SymbolId of the `kind` symbol declared by decl
+# `did` at `slot` (the param / generic index), or SYMBOL_NIL
 fun find_binding_symbol(rr: *res.ResolveResult, kind: res.SymKind, did: id.DeclId, slot: u32) res.SymbolId {
     var i: u32 = 0;
     for (i < rr.symbol_count) {
@@ -196,11 +196,11 @@ fun find_binding_symbol(rr: *res.ResolveResult, kind: res.SymKind, did: id.DeclI
     ret res.SYMBOL_NIL;
 }
 
-# binding_name_span: the binding name span of a SYM_PARAM / SYM_GENERIC symbol
+# the binding name span of a SYM_PARAM / SYM_GENERIC symbol
 # (looked up by its (decl, slot) in the owning decl), or none. lets the
 # references / rename walk include a param / generic's binding site, which the
 # expr / type / decl side tables never record. value parameters belong to a
-# function; generics may belong to a function, record, or union.
+# function; generics may belong to a function, record, or union
 # ---
 # a:   the Ast holding the declaration
 # sym: the param / generic symbol whose binding span is wanted
@@ -220,8 +220,8 @@ pub fun binding_name_span(a: *ast.Ast, sym: *res.Symbol) Option[token.Span] {
     ret some[token.Span]((?a.typed_names[d.data.fun_.params_start + sym.slot]).name);
 }
 
-# make_ref: build a SymbolRef, flagging whether the symbol is local to this
-# buffer's module.
+# build a SymbolRef, flagging whether the symbol is local to this
+# buffer's module
 fun make_ref(rr: *res.ResolveResult, own: sess.ModuleId, sid: res.SymbolId, name_span: token.Span) SymbolRef {
     var sr: SymbolRef;
     sr.sym_id    = sid;
@@ -230,9 +230,9 @@ fun make_ref(rr: *res.ResolveResult, own: sess.ModuleId, sid: res.SymbolId, name
     ret sr;
 }
 
-# symbol_is_local: whether `sid`'s decl is owned by `own` (this buffer's
+# whether `sid`'s decl is owned by `own` (this buffer's
 # module) and so addressable in this Ast. primitives and imported / used
-# symbols originate elsewhere.
+# symbols originate elsewhere
 pub fun symbol_is_local(rr: *res.ResolveResult, own: sess.ModuleId, sid: res.SymbolId) bool {
     if (sid >= rr.symbol_count) { ret false; }
     val sym: *res.Symbol = ?rr.symbols[sid];
@@ -241,14 +241,14 @@ pub fun symbol_is_local(rr: *res.ResolveResult, own: sess.ModuleId, sid: res.Sym
     ret sym.origin == own;
 }
 
-# symbol_by_decl: the SymbolId in `rr` whose declaration is the module-scoped
+# the SymbolId in `rr` whose declaration is the module-scoped
 # pair (origin, decl) — the identity the same logical symbol shares across every
 # module's resolve result, since an imported reference copies its referent's
 # origin ModuleId and DeclId. lets the workspace-wide references / rename walk
 # find a module's own id for a symbol declared elsewhere. param / generic
 # bindings (whose decl is their owning function) are skipped so a module-scope
 # decl resolves to its declaration, not one of its parameters. SYMBOL_NIL when
-# no symbol in `rr` resolves to that declaration.
+# no symbol in `rr` resolves to that declaration
 # ---
 # rr:     the module's resolve side tables
 # origin: ModuleId owning the declaration
@@ -266,12 +266,12 @@ pub fun symbol_by_decl(rr: *res.ResolveResult, origin: sess.ModuleId, decl: id.D
     ret res.SYMBOL_NIL;
 }
 
-# export_decl_of: the DeclId of the pub symbol in `rr` named `name` with kind
+# the DeclId of the pub symbol in `rr` named `name` with kind
 # `kind`, or DECL_NIL. translates a buffer-local pub declaration to the canonical
 # (origin, decl) identity in the on-disk module the buffer mirrors, so the
 # workspace walk can locate importers of that symbol. pub symbols occupy the
 # front of the table ([0, pub_count)); a non-pub symbol has no cross-file
-# use-sites and yields DECL_NIL.
+# use-sites and yields DECL_NIL
 # ---
 # rr:   the on-disk module's resolve side tables
 # name: interned identifier of the declaration
@@ -288,8 +288,8 @@ pub fun export_decl_of(rr: *res.ResolveResult, name: intern.StrId, kind: res.Sym
     ret id.DECL_NIL;
 }
 
-# top_level_count: the number of declarations at the buffer's module scope —
-# the count documentSymbol enumerates. zero when the Ast has no root module.
+# the number of declarations at the buffer's module scope —
+# the count documentSymbol enumerates. zero when the Ast has no root module
 # ---
 # a:   the buffer's parsed Ast
 # ret: the module-scope decl count
@@ -299,10 +299,10 @@ pub fun top_level_count(a: *ast.Ast) u32 {
     ret unwrap[*module.Module](mo).decls_len;
 }
 
-# top_level_decl: the DeclId of the `i`-th module-scope declaration, or DECL_NIL
+# the DeclId of the `i`-th module-scope declaration, or DECL_NIL
 # when out of range. resolves through the module's decl-id list rather than the
 # flat `Ast.decls` array, so nested declarations (a `val` inside a function
-# body) are excluded.
+# body) are excluded
 # ---
 # a: the buffer's parsed Ast
 # i: index into the module's top-level decl list
@@ -315,7 +315,7 @@ pub fun top_level_decl(a: *ast.Ast, i: u32) id.DeclId {
     ret a.decl_ids[m.decls_start + i];
 }
 
-# symbol: the Symbol for a SymbolId, or none when out of range.
+# the Symbol for a SymbolId, or none when out of range
 # ---
 # rr:  the ResolveResult holding the symbol table
 # sid: symbol id to look up
@@ -325,8 +325,8 @@ pub fun symbol(rr: *res.ResolveResult, sid: res.SymbolId) Option[*res.Symbol] {
     ret some[*res.Symbol](?rr.symbols[sid]);
 }
 
-# decl_span_of: the full declaration span of a local symbol's decl, or none
-# when the decl id is absent / out of range. drives go-to-definition.
+# the full declaration span of a local symbol's decl, or none
+# when the decl id is absent / out of range. drives go-to-definition
 # ---
 # a:   the Ast owning the decl
 # sym: the symbol whose decl span is wanted
@@ -338,10 +338,10 @@ pub fun decl_span_of(a: *ast.Ast, sym: *res.Symbol) Option[token.Span] {
     ret some[token.Span](unwrap[*decl.Decl](d_opt).span);
 }
 
-# decl_name_span_of: the span of a local symbol's declared name identifier (the
+# the span of a local symbol's declared name identifier (the
 # selection range for go-to-definition / documentSymbol), or none. for a decl
 # the resolver attached the symbol to, the symbol's name lives at a known span
-# within the decl node.
+# within the decl node
 # ---
 # a:   the Ast owning the decl
 # sym: the symbol whose name span is wanted
@@ -353,10 +353,10 @@ pub fun decl_name_span_of(a: *ast.Ast, sym: *res.Symbol) Option[token.Span] {
     ret decl_name_span(unwrap[*decl.Decl](d_opt));
 }
 
-# definition_name_span: the span go-to-definition should land on for a local
+# the span go-to-definition should land on for a local
 # symbol — the binding name. for a param / generic this is its binding site in
 # the function signature; for every other symbol it is the decl's name. none
-# when the symbol has no addressable binding in this Ast.
+# when the symbol has no addressable binding in this Ast
 # ---
 # a:   the Ast owning the symbol's declaration
 # sym: the symbol whose definition span is wanted
@@ -368,8 +368,8 @@ pub fun definition_name_span(a: *ast.Ast, sym: *res.Symbol) Option[token.Span] {
     ret decl_name_span_of(a, sym);
 }
 
-# decl_name_span: the name identifier span of a decl node, or none for a decl
-# without a single name (use / fwd / test / comptime / error).
+# the name identifier span of a decl node, or none for a decl
+# without a single name (use / fwd / test / comptime / error)
 pub fun decl_name_span(d: *decl.Decl) Option[token.Span] {
     if (d.kind == decl.DECL_KIND_FUN) { ret some[token.Span](d.data.fun_.name); }
     if (d.kind == decl.DECL_KIND_REC) { ret some[token.Span](d.data.rec_.name); }
@@ -380,11 +380,11 @@ pub fun decl_name_span(d: *decl.Decl) Option[token.Span] {
     ret none[token.Span]();
 }
 
-# signature_span: the byte span of a local symbol's declaration header — the
+# the byte span of a local symbol's declaration header — the
 # text to render on hover. for a function with a body it runs from the decl
 # start up to (not into) the body block, so the parameter list and return type
 # show without the body; for every other decl it is the whole decl span. none
-# when the decl id is absent / out of range.
+# when the decl id is absent / out of range
 # ---
 # a:   the Ast owning the decl
 # sym: the symbol whose signature span is wanted
@@ -413,9 +413,9 @@ pub fun signature_span(a: *ast.Ast, sym: *res.Symbol) Option[token.Span] {
     ret some[token.Span](d.span);
 }
 
-# param_signature_span: the `name: type` span of a parameter symbol — from its
+# the `name: type` span of a parameter symbol — from its
 # binding name through the end of its type annotation — for hover. falls back
-# to just the name span when the type node is unavailable. none for a non-param.
+# to just the name span when the type node is unavailable. none for a non-param
 fun param_signature_span(a: *ast.Ast, sym: *res.Symbol) Option[token.Span] {
     val no: Option[token.Span] = binding_name_span(a, sym);
     if (!is_some[token.Span](no)) { ret none[token.Span](); }
@@ -440,13 +440,13 @@ fun param_signature_span(a: *ast.Ast, sym: *res.Symbol) Option[token.Span] {
     ret some[token.Span](sp);
 }
 
-# doc_span_of: the first-class doc-block span the parser attached to a local
+# the first-class doc-block span the parser attached to a local
 # symbol's declaration (`Decl.doc`) — the `#`-comment run directly above the
 # decl with its `#[...]` attribute lines excluded, or none. the attribute-aware
 # replacement for the old source line-scan: it carries no `#[attr]` bytes, so the
 # rendered doc never folds in attribute syntax. none for a param / generic (which
 # carry no Decl node), a decl with no docstring (empty `doc` span), or an absent /
-# out-of-range decl.
+# out-of-range decl
 # ---
 # a:   the Ast owning the decl
 # sym: the symbol whose doc block is wanted
@@ -461,13 +461,13 @@ pub fun doc_span_of(a: *ast.Ast, sym: *res.Symbol) Option[token.Span] {
     ret some[token.Span](d.doc);
 }
 
-# field_doc_desc: the description span of the component in the record / union doc
+# the description span of the component in the record / union doc
 # block `doc` whose component name matches the field name `field_name` — scanned
 # through `fe/doc.mach`'s component cursor, comparing each component's `name_span`
 # bytes against the field-name bytes. both spans index into the declaring module's
 # `source`, since the doc block and the field declaration share that file. none
 # when the doc block has no matching component, no component block at all, or an
-# empty matching description.
+# empty matching description
 # ---
 # source:     the declaring module's source text (both spans point into it)
 # doc:        the record / union declaration's `Decl.doc` span
@@ -486,10 +486,10 @@ pub fun field_doc_desc(source: str, doc: token.Span, field_name: token.Span) Opt
     ret none[token.Span]();
 }
 
-# same_source_span_equal: true when spans `a` and `b` cover identical bytes within
+# true when spans `a` and `b` cover identical bytes within
 # the single source text `source`. the same-file analogue of `span_bytes_equal`,
 # used to match a doc component's name against a field name (both spans into the
-# declaring module's source).
+# declaring module's source)
 fun same_source_span_equal(source: str, a: token.Span, b: token.Span) bool {
     if (a.len != b.len) { ret false; }
     var i: usize = 0;
@@ -500,7 +500,7 @@ fun same_source_span_equal(source: str, a: token.Span, b: token.Span) bool {
     ret true;
 }
 
-# kind_label: a human-readable label for a symbol kind, for hover rendering.
+# a human-readable label for a symbol kind, for hover rendering
 # ---
 # kind: a res.SYM_* value
 # ret:  a short lowercase keyword-like label
@@ -520,9 +520,9 @@ pub fun kind_label(kind: res.SymKind) str {
     ret "symbol";
 }
 
-# lsp_symbol_kind: the LSP SymbolKind number for a symbol kind (documentSymbol).
+# the LSP SymbolKind number for a symbol kind (documentSymbol).
 # 12 = Function, 23 = Struct, 10 = Enum, 13 = Variable, 14 = Constant,
-# 26 = TypeParameter, 5 = Method, 8 = Field, 2 = Module, 6 = Property.
+# 26 = TypeParameter, 5 = Method, 8 = Field, 2 = Module, 6 = Property
 # ---
 # kind: a res.SYM_* value
 # ret:  the LSP SymbolKind code
@@ -539,9 +539,9 @@ pub fun lsp_symbol_kind(kind: res.SymKind) i64 {
     ret 13;
 }
 
-# lsp_completion_kind: the LSP CompletionItemKind number for a symbol kind.
+# the LSP CompletionItemKind number for a symbol kind.
 # 3 = Function, 22 = Struct, 13 = Enum, 6 = Variable, 21 = Constant,
-# 25 = TypeParameter, 9 = Module, 5 = Field.
+# 25 = TypeParameter, 9 = Module, 5 = Field
 # ---
 # kind: a res.SYM_* value
 # ret:  the LSP CompletionItemKind code
@@ -560,9 +560,9 @@ pub fun lsp_completion_kind(kind: res.SymKind) i64 {
     ret 6;
 }
 
-# expr_ref_span: the name span of expr `eid` when it resolves to `target`, or
+# the name span of expr `eid` when it resolves to `target`, or
 # none. used to enumerate every reference to a symbol (references / rename):
-# the server walks all expr ids and collects the spans this returns.
+# the server walks all expr ids and collects the spans this returns
 # ---
 # a:      the Ast holding the expr
 # rr:     the ResolveResult side tables
@@ -577,8 +577,8 @@ pub fun expr_ref_span(a: *ast.Ast, rr: *res.ResolveResult, eid: id.ExprId, targe
     ret some[token.Span](name_span_of_expr(unwrap[*expr.Expr](eo)));
 }
 
-# type_ref_span: the name span of type `tid` when it resolves to `target`, or
-# none. the type-position analogue of expr_ref_span.
+# the name span of type `tid` when it resolves to `target`, or
+# none. the type-position analogue of expr_ref_span
 # ---
 # a:      the Ast holding the type
 # rr:     the ResolveResult side tables
@@ -591,12 +591,12 @@ pub fun type_ref_span(a: *ast.Ast, rr: *res.ResolveResult, tid: id.TypeId, targe
     ret type_name_span(a, tid);
 }
 
-# completion_candidate: whether symbol `sid` should be offered as a top-level
+# whether symbol `sid` should be offered as a top-level
 # completion, i.e. a name a statement/expression position could reference. the
 # editor resolves a single file with no exposed scope chain, so completion
 # offers the file's module-level declarations, its `use` aliases and imports,
 # and the primitive type names — not lexically scoped locals, which need the
-# resolver's scope stack. duplicate-name symbols are deduped by the caller.
+# resolver's scope stack. duplicate-name symbols are deduped by the caller
 # ---
 # rr:  the ResolveResult holding the symbol table
 # sid: symbol id to test
@@ -611,10 +611,10 @@ pub fun completion_candidate(rr: *res.ResolveResult, sid: res.SymbolId) bool {
     ret true;
 }
 
-# decl_ref_span: the name span of decl `did` when its declared symbol is
+# the name span of decl `did` when its declared symbol is
 # `target`, or none. lets the references / rename walk include the declaration
 # site itself, which the expr / type side tables never record (a decl binds its
-# name through `decl_symbol`, not `expr_resolved`).
+# name through `decl_symbol`, not `expr_resolved`)
 # ---
 # a:      the Ast holding the decl
 # rr:     the ResolveResult side tables
@@ -629,11 +629,11 @@ pub fun decl_ref_span(a: *ast.Ast, rr: *res.ResolveResult, did: id.DeclId, targe
     ret decl_name_span(unwrap[*decl.Decl](d_opt));
 }
 
-# import_leaf_span: the byte span of the final dotted segment of import `path`
+# the byte span of the final dotted segment of import `path`
 # (the leaf component that names the imported symbol), or the whole span for a
 # single-segment path. mirrors the resolver's own leaf computation so a
 # cross-file rename can rewrite an imported name inside a `use` / `fwd` path
-# without touching its module prefix or an alias.
+# without touching its module prefix or an alias
 # ---
 # file: the source file backing the path span
 # path: byte span covering the dotted import path
@@ -656,11 +656,11 @@ pub fun import_leaf_span(file: *src.SourceFile, path: token.Span) token.Span {
     ret out;
 }
 
-# import_ref_span: the leaf-name span of import decl `did` (a `use` or `fwd`)
+# the leaf-name span of import decl `did` (a `use` or `fwd`)
 # when it imports `target`, or none. the resolver binds a single-symbol import
 # under the path's leaf and records the imported symbol in `decl_symbol`, but
 # `decl_name_span` has no name for an import decl, so this recovers the leaf the
-# references / rename walk must include to keep an importer compiling.
+# references / rename walk must include to keep an importer compiling
 # ---
 # a:      the Ast holding the decl
 # rr:     the ResolveResult side tables
@@ -679,10 +679,10 @@ pub fun import_ref_span(a: *ast.Ast, rr: *res.ResolveResult, did: id.DeclId, tar
     ret none[token.Span]();
 }
 
-# span_text_equals: true when the bytes of `span` in `file` exactly equal the
+# true when the bytes of `span` in `file` exactly equal the
 # identifier `name`. the rename walk guards body references with it so a symbol
 # bound under an alias — whose references are spelled with the alias, not the
-# declared name — is not rewritten when the declaration is renamed.
+# declared name — is not rewritten when the declaration is renamed
 # ---
 # file: the source file backing the span
 # span: byte span to compare
@@ -701,16 +701,16 @@ pub fun span_text_equals(file: *src.SourceFile, span: token.Span, name: str) boo
     ret true;
 }
 
-# name_span_of_expr: the span identifying an expression's referenced name. for
+# the span identifying an expression's referenced name. for
 # an IDENT the whole expr span is the name; for a member access the name is the
-# leaf after the dot. other expressions fall back to their own span.
+# leaf after the dot. other expressions fall back to their own span
 fun name_span_of_expr(e: *expr.Expr) token.Span {
     if (e.kind == expr.EXPR_KIND_MEMBER) { ret e.data.member.name; }
     ret e.span;
 }
 
-# type_name_span: the name span of a named type node, or none when the type at
-# `tid` is not a named reference (a pointer / array / fun type wrapping it).
+# the name span of a named type node, or none when the type at
+# `tid` is not a named reference (a pointer / array / fun type wrapping it)
 fun type_name_span(a: *ast.Ast, tid: id.TypeId) Option[token.Span] {
     val t_opt: Option[*atype.Type] = ast.get_type(a, tid);
     if (!is_some[*atype.Type](t_opt)) { ret none[token.Span](); }
@@ -719,7 +719,7 @@ fun type_name_span(a: *ast.Ast, tid: id.TypeId) Option[token.Span] {
     ret none[token.Span]();
 }
 
-# FieldRef: a record / union field a cursor position references, before the field
+# a record / union field a cursor position references, before the field
 # is typed. name resolution leaves a value-field access unbound (`expr_resolved`
 # is SYMBOL_NIL for a MEMBER node), so this is the type-driven parallel to
 # `SymbolRef`: the feature layer resolves it to a field declaration through a
@@ -727,7 +727,7 @@ fun type_name_span(a: *ast.Ast, tid: id.TypeId) Option[token.Span] {
 # type names the record / union the field belongs to — the receiver for a member
 # access `foo.bar`, the struct literal itself for `T{ bar: ... }` (whose inferred
 # type is the record). the caller types `host`, peels it to a record site, then
-# matches `name_span` against the site's fields.
+# matches `name_span` against the site's fields
 # ---
 # host:      expression id to type (member receiver, or the struct literal itself)
 # name_span: byte span of the referenced field-name token (`.bar` / `bar`)
@@ -736,14 +736,14 @@ pub rec FieldRef {
     name_span: token.Span;
 }
 
-# field_ref_at: the record / union field a byte offset references through a member
+# the record / union field a byte offset references through a member
 # access or a struct-literal field name, or none. the type-driven pivot for
 # go-to-definition on fields: `expr_resolved` never binds a value-field access, so
 # this recovers the field name and the expression whose type names the field's
 # record directly from the syntax. it is consulted only when the symbol-table
 # pivot (`ref_at`) finds nothing, so an ordinary symbol still wins. pure over the
 # Ast — the actual field-decl lookup needs types and runs in the caller via
-# `field_decl_span`.
+# `field_decl_span`
 # ---
 # a:      the buffer's parsed Ast
 # offset: byte offset into the buffer
@@ -782,13 +782,13 @@ pub fun field_ref_at(a: *ast.Ast, offset: usize) Option[FieldRef] {
     ret none[FieldRef]();
 }
 
-# field_decl_span: the name span of the field declared in `decl_a` (its rec / uni
+# the name span of the field declared in `decl_a` (its rec / uni
 # field range `[fields_start, fields_start + fields_len)` in `decl_a.typed_names`)
 # whose name bytes equal the referencing token `query` in `query_file`, or none
 # when no field matches. pure and session-free — the field-decl locator the
 # go-to-definition path drives once a value's type has been resolved to its record
 # site. comparing bytes across the two files lets the receiver and the declaration
-# live in different modules.
+# live in different modules
 # ---
 # decl_a:       the declaring module's Ast (its typed_names hold the fields)
 # decl_file:    the SourceFile backing `decl_a` (field-name bytes)
@@ -810,10 +810,10 @@ pub fun field_decl_span(decl_a: *ast.Ast, decl_file: *src.SourceFile, fields_sta
     ret none[token.Span]();
 }
 
-# field_decl_self_at: the name span of the rec / uni field whose own declaration
+# the name span of the rec / uni field whose own declaration
 # name covers `offset` in `decl_file`, or none. resolves the field's declaration
 # site to itself (go-to-definition on a field where it is declared). scans the
-# field range `[fields_start, fields_start + fields_len)` in `decl_a.typed_names`.
+# field range `[fields_start, fields_start + fields_len)` in `decl_a.typed_names`
 # ---
 # decl_a:       the Ast holding the field declarations
 # decl_file:    the SourceFile backing `decl_a`
@@ -831,13 +831,13 @@ pub fun field_decl_self_at(decl_a: *ast.Ast, fields_start: u32, fields_len: u32,
     ret none[token.Span]();
 }
 
-# FieldKey: the cross-module identity of a record / union field — the nominal
+# the cross-module identity of a record / union field — the nominal
 # declaration site of its record (`origin`, `decl`) paired with the field name as
 # bytes in the declaring module's source. the field-reference / field-rename walk
 # carries it across every loaded module: a member access or struct-literal init
 # names this field iff its host expression's type peels to the keyed record and the
 # referenced name bytes equal the keyed field name. the name is held as a file +
-# span (not interned) because a field has no Symbol and so no StrId.
+# span (not interned) because a field has no Symbol and so no StrId
 # ---
 # origin:     ModuleId of the module declaring the record / union
 # decl:       DeclId of the rec / uni declaration in `origin`'s Ast
@@ -850,7 +850,7 @@ pub rec FieldKey {
     field_name: token.Span;
 }
 
-# field_ref_span_at: the field-name span of expr `eid` in module (`a`, `sr`) when
+# the field-name span of expr `eid` in module (`a`, `sr`) when
 # it references the keyed field, or none. the field analogue of `expr_ref_span`:
 # resolution never binds a value-field access, so a field reference is recovered
 # by typing the host expression and peeling it to its record's nominal site rather
@@ -863,7 +863,7 @@ pub rec FieldKey {
 # the host type is read from `sr` (the module's SemaResult) and peeled through the
 # session type interner `ti`, so a field reached through `*T` or a generic instance
 # of the record matches the same key. pure over (`a`, `sr`, `ti`) — the caller
-# walks `[0, a.expr_len)` feeding the spans this returns to a sink.
+# walks `[0, a.expr_len)` feeding the spans this returns to a sink
 # ---
 # a:    the module's parsed Ast
 # sr:   the module's SemaResult (per-expr typing)
@@ -900,11 +900,11 @@ pub fun field_ref_span_at(a: *ast.Ast, sr: *sema.SemaResult, ti: *type.TypeInter
     ret none[token.Span]();
 }
 
-# host_matches: whether host expression `eid`'s type peels to the keyed record's
+# whether host expression `eid`'s type peels to the keyed record's
 # nominal declaration site. the type-identity half of `field_ref_span_at`: a
 # member receiver or a struct literal whose `(origin, decl)` equals the key names
 # the same record across modules, regardless of pointer / generic-instance wrapping
-# (peeled by `nominal_of`).
+# (peeled by `nominal_of`)
 fun host_matches(sr: *sema.SemaResult, ti: *type.TypeInterner, eid: id.ExprId, key: FieldKey) bool {
     val tid: type.TypeId = mtypes.type_of(sr, eid);
     val no: Option[mtypes.Nominal] = mtypes.nominal_of(ti, tid);
@@ -913,7 +913,7 @@ fun host_matches(sr: *sema.SemaResult, ti: *type.TypeInterner, eid: id.ExprId, k
     ret n.origin == key.origin && n.decl == key.decl;
 }
 
-# collect_field_sites: write into `out` (up to `cap` spans) every site naming the
+# write into `out` (up to `cap` spans) every site naming the
 # keyed field in module (`a`, `sr`) and return the count. the spans are, in walk
 # order: every member-access / struct-literal init whose host type peels to the
 # keyed record (`field_ref_span_at` over `[0, a.expr_len)`), and — when `declaring`
@@ -922,7 +922,7 @@ fun host_matches(sr: *sema.SemaResult, ti: *type.TypeInterner, eid: id.ExprId, k
 # component's name token. this is the complete edit set a field rename applies to
 # one module and the location set references reports; it is pulled out of the JSON
 # emission so it can be asserted directly. the doc block is read from the declaring
-# module's source (`decl_src`), the same file `key.field_name` indexes into.
+# module's source (`decl_src`), the same file `key.field_name` indexes into
 # ---
 # a:         the module's Ast
 # sr:        the module's SemaResult
@@ -955,7 +955,7 @@ pub fun collect_field_sites(a: *ast.Ast, sr: *sema.SemaResult, ti: *type.TypeInt
     ret n;
 }
 
-# doc_component_name_span: the byte span to rewrite when a doc component's name is
+# the byte span to rewrite when a doc component's name is
 # renamed — the component in doc block `doc` (within `source`) whose name matches
 # the binding `query` (in `qf`), narrowed to the exact identifier token a rename
 # replaces. for a field or value parameter the component head is `# <name>:` and
@@ -964,7 +964,7 @@ pub fun collect_field_sites(a: *ast.Ast, sr: *sema.SemaResult, ti: *type.TypeInt
 # `mach.lang.fe.doc`), so the returned span is the inner `T` only — the brackets
 # are preserved. none when no component matches, or (for a generic) the matched
 # component carries no bracketed identifier. matching compares the inner identifier
-# against `query` so a `# [T]:` head matches the generic named `T`.
+# against `query` so a `# [T]:` head matches the generic named `T`
 # ---
 # source:      the declaring module's source text (the doc block points into it)
 # doc:         the owning decl's `Decl.doc` span
@@ -984,11 +984,11 @@ pub fun doc_component_name_span(source: str, doc: token.Span, qf: *src.SourceFil
     ret none[token.Span]();
 }
 
-# component_ident: the identifier token within a component name span — the whole
+# the identifier token within a component name span — the whole
 # span for a plain `name`, or the bracketed inner identifier for a generic's `[T]`
 # head. an empty span when a generic head has no `[...]` enclosed single-word
 # identifier. the narrowing `doc_component_name_span` applies so a generic rename
-# rewrites `T` inside `[T]` without disturbing the brackets.
+# rewrites `T` inside `[T]` without disturbing the brackets
 fun component_ident(source: str, name: token.Span, is_generic: bool) token.Span {
     if (!is_generic) { ret name; }
     if (name.len < 3) { ret empty_span(); }
@@ -1001,7 +1001,7 @@ fun component_ident(source: str, name: token.Span, is_generic: bool) token.Span 
     ret sp;
 }
 
-# empty_span: a zero-length span, the "absent" marker for component_ident.
+# a zero-length span, the "absent" marker for component_ident
 fun empty_span() token.Span {
     var s: token.Span;
     s.offset = 0;
@@ -1009,10 +1009,10 @@ fun empty_span() token.Span {
     ret s;
 }
 
-# span_bytes_equal_2: true when span `sa` in `source` and span `sb` in `fb` cover
+# true when span `sa` in `source` and span `sb` in `fb` cover
 # identical bytes. a cross-source compare where one side is a raw `str` (a doc
 # block lives in the declaring module's source) and the other a SourceFile (the
-# binding name) — bridging `same_source_span_equal` and `span_bytes_equal`.
+# binding name) — bridging `same_source_span_equal` and `span_bytes_equal`
 fun span_bytes_equal_2(source: str, sa: token.Span, fb: *src.SourceFile, sb: token.Span) bool {
     if (sa.len != sb.len) { ret false; }
     val b: *u8 = fb.text::*u8;
@@ -1024,10 +1024,10 @@ fun span_bytes_equal_2(source: str, sa: token.Span, fb: *src.SourceFile, sb: tok
     ret true;
 }
 
-# span_bytes_equal: true when the bytes of `sa` in `fa` exactly equal the bytes of
+# true when the bytes of `sa` in `fa` exactly equal the bytes of
 # `sb` in `fb`. the cross-file identifier compare the field-decl locator matches a
 # field name against the referencing token with — the two may sit in different
-# source files (a field declared in a dependency, referenced in the buffer).
+# source files (a field declared in a dependency, referenced in the buffer)
 # ---
 # fa: source file backing span `sa`
 # sa: byte span in `fa`
@@ -1046,8 +1046,8 @@ pub fun span_bytes_equal(fa: *src.SourceFile, sa: token.Span, fb: *src.SourceFil
     ret true;
 }
 
-# span_at: a Span over `[offset, offset + len)`. the test builder for field-name /
-# query spans into a stub SourceFile.
+# a Span over `[offset, offset + len)`. the test builder for field-name /
+# query spans into a stub SourceFile
 fun span_at(offset: usize, len: usize) token.Span {
     var sp: token.Span;
     sp.offset = offset;
@@ -1055,8 +1055,8 @@ fun span_at(offset: usize, len: usize) token.Span {
     ret sp;
 }
 
-# stub_file: a SourceFile carrying just `text`, enough for the byte-level field-name
-# compares the pure locator does (it reads `file.text` only).
+# a SourceFile carrying just `text`, enough for the byte-level field-name
+# compares the pure locator does (it reads `file.text` only)
 fun stub_file(text: str) src.SourceFile {
     var f: src.SourceFile;
     f.path        = nil;
@@ -1066,8 +1066,8 @@ fun stub_file(text: str) src.SourceFile {
     ret f;
 }
 
-# add_field: append a field TypedName named over `[offset, offset + len)` to `a`,
-# returning its index into `a.typed_names`.
+# append a field TypedName named over `[offset, offset + len)` to `a`,
+# returning its index into `a.typed_names`
 fun add_field(a: *ast.Ast, offset: usize, len: usize) u32 {
     var tn: decl.TypedName;
     tn.name     = span_at(offset, len);
@@ -1088,7 +1088,7 @@ test "features: field_decl_span matches a field in the same source" {
     var f: src.SourceFile = stub_file("xyzz");
 
     var fail: bool = false;
-    # query "y" (the byte at offset 1) resolves to field "y" at offset 1.
+    # query "y" (the byte at offset 1) resolves to field "y" at offset 1
     val o: Option[token.Span] = field_decl_span(?a, ?f, start, 3, ?f, span_at(1, 1));
     if (is_none[token.Span](o)) { fail = true; }
     or {
@@ -1104,12 +1104,12 @@ test "features: field_decl_span matches a field in the same source" {
 test "features: field_decl_span matches a field across two sources (dependency)" {
     var pa: Allocator;
     page.make(?pa);
-    # the declaring "module" file holds the record fields.
+    # the declaring "module" file holds the record fields
     var da: ast.Ast = ast.init(?pa, 0::src.FileId);
     val start: u32 = add_field(?da, 0, 4);   # "name"
     add_field(?da, 5, 3);                     # "age"
     var df: src.SourceFile = stub_file("name age");
-    # the referencing buffer file holds a member access "p.age".
+    # the referencing buffer file holds a member access "p.age"
     var qf: src.SourceFile = stub_file("p.age");
 
     var fail: bool = false;
@@ -1184,7 +1184,7 @@ test "features: field_decl_self_at hits a field name and misses elsewhere" {
     add_field(?a, 10, 3);                    # "foo" at offset 10
 
     var fail: bool = false;
-    # offset 11 sits inside "foo".
+    # offset 11 sits inside "foo"
     val hit: Option[token.Span] = field_decl_self_at(?a, start, 2, 11);
     if (is_none[token.Span](hit)) { fail = true; }
     or {
@@ -1199,9 +1199,9 @@ test "features: field_decl_self_at hits a field name and misses elsewhere" {
     ret 0;
 }
 
-# add_doc_fun: append a function decl carrying the doc-block span `[doc_off,
+# append a function decl carrying the doc-block span `[doc_off,
 # doc_off + doc_len)` to `a`, returning its DeclId. the function payload is left
-# zeroed; only `kind` and `doc` matter for the doc-retrieval tests.
+# zeroed; only `kind` and `doc` matter for the doc-retrieval tests
 fun add_doc_fun(a: *ast.Ast, doc_off: usize, doc_len: usize) id.DeclId {
     var d: decl.Decl;
     d.kind             = decl.DECL_KIND_FUN;
@@ -1222,7 +1222,7 @@ fun add_doc_fun(a: *ast.Ast, doc_off: usize, doc_len: usize) id.DeclId {
     ret unwrap_ok[id.DeclId, str](r);
 }
 
-# fun_sym: a SYM_FUN symbol whose decl is `did`, for the doc-retrieval tests.
+# a SYM_FUN symbol whose decl is `did`, for the doc-retrieval tests
 fun fun_sym(did: id.DeclId) res.Symbol {
     var s: res.Symbol;
     s.kind   = res.SYM_FUN;
@@ -1293,14 +1293,14 @@ test "features: field_doc_desc finds the matching component's description" {
     # the rec-body field names: "x" at offset 84, "y" at offset 92.
 
     var fail: bool = false;
-    # "y" field -> the "y" component description.
+    # "y" field -> the "y" component description
     val oy: Option[token.Span] = field_doc_desc(src, doc, name_span_in(92, 1));
     if (is_none[token.Span](oy)) { fail = true; }
     or {
         val sp: token.Span = unwrap[token.Span](oy);
         if (!region_eq(src, sp, "the vertical coordinate")) { fail = true; }
     }
-    # "x" field -> the "x" component description.
+    # "x" field -> the "x" component description
     val ox: Option[token.Span] = field_doc_desc(src, doc, name_span_in(84, 1));
     if (is_none[token.Span](ox)) { fail = true; }
     or {
@@ -1317,7 +1317,7 @@ test "features: field_doc_desc returns none when no component matches" {
     var doc: token.Span;
     doc.offset = 0;
     doc.len    = 46;
-    # "z" field name at offset 55 — no matching component.
+    # "z" field name at offset 55 — no matching component
     val ok: bool = is_none[token.Span](field_doc_desc(src, doc, name_span_in(55, 1)));
     if (!ok) { ret 1; }
     ret 0;
@@ -1328,14 +1328,14 @@ test "features: field_doc_desc returns none for a summary-only doc block" {
     var doc: token.Span;
     doc.offset = 0;
     doc.len    = 31;
-    # "x" field name at offset 40 — the block has no component lines.
+    # "x" field name at offset 40 — the block has no component lines
     val ok: bool = is_none[token.Span](field_doc_desc(src, doc, name_span_in(40, 1)));
     if (!ok) { ret 1; }
     ret 0;
 }
 
-# name_span_in: a span over `[offset, offset + len)`, the test builder for a
-# field-name query into the shared doc/body source.
+# a span over `[offset, offset + len)`, the test builder for a
+# field-name query into the shared doc/body source
 fun name_span_in(offset: usize, len: usize) token.Span {
     var sp: token.Span;
     sp.offset = offset;
@@ -1343,7 +1343,7 @@ fun name_span_in(offset: usize, len: usize) token.Span {
     ret sp;
 }
 
-# region_eq: true when `span` of `source` equals the byte content of `expect`.
+# true when `span` of `source` equals the byte content of `expect`
 fun region_eq(source: str, span: token.Span, expect: str) bool {
     val n: usize = str_len(expect);
     if (span.len != n) { ret false; }
@@ -1355,8 +1355,8 @@ fun region_eq(source: str, span: token.Span, expect: str) bool {
     ret true;
 }
 
-# fk: a FieldKey naming the field at `[off, off + len)` in `decl_file` of the
-# record (`origin`, `decl`), the test builder for the field-reference matcher.
+# a FieldKey naming the field at `[off, off + len)` in `decl_file` of the
+# record (`origin`, `decl`), the test builder for the field-reference matcher
 fun fk(origin: u32, decl: u32, decl_file: *src.SourceFile, off: usize, len: usize) FieldKey {
     var k: FieldKey;
     k.origin     = origin::sess.ModuleId;
@@ -1366,9 +1366,9 @@ fun fk(origin: u32, decl: u32, decl_file: *src.SourceFile, off: usize, len: usiz
     ret k;
 }
 
-# mk_sema: a standalone SemaResult with an `expr_type` array of `n` slots, every
+# a standalone SemaResult with an `expr_type` array of `n` slots, every
 # slot TYPE_NIL. the test stand-in for sema's own typing output, so the field
-# matcher can be driven without a whole analysis. released with `free_sema`.
+# matcher can be driven without a whole analysis. released with `free_sema`
 fun mk_sema(pa: *Allocator, n: u32) sema.SemaResult {
     var sr: sema.SemaResult;
     sr.alloc            = pa;
@@ -1396,8 +1396,8 @@ fun free_sema(pa: *Allocator, sr: *sema.SemaResult) {
     }
 }
 
-# add_ident: append an IDENT expr spanning `[off, off + len)`, returning its id.
-# the receiver of a member access is an IDENT whose type the SemaResult carries.
+# append an IDENT expr spanning `[off, off + len)`, returning its id.
+# the receiver of a member access is an IDENT whose type the SemaResult carries
 fun add_ident(a: *ast.Ast, off: usize, len: usize) id.ExprId {
     var e: expr.Expr;
     e.span = span_at(off, len);
@@ -1406,9 +1406,9 @@ fun add_ident(a: *ast.Ast, off: usize, len: usize) id.ExprId {
     ret unwrap_ok[id.ExprId, str](r);
 }
 
-# add_member: append a member access `obj.<name>` where `obj` is expr `object`
+# append a member access `obj.<name>` where `obj` is expr `object`
 # and the field-name token spans `[name_off, name_off + name_len)`, returning the
-# member expr id.
+# member expr id
 fun add_member(a: *ast.Ast, object: id.ExprId, name_off: usize, name_len: usize) id.ExprId {
     var e: expr.Expr;
     e.span = span_at(name_off, name_len);
@@ -1419,8 +1419,8 @@ fun add_member(a: *ast.Ast, object: id.ExprId, name_off: usize, name_len: usize)
     ret unwrap_ok[id.ExprId, str](r);
 }
 
-# add_struct_lit: append a struct literal with a single field init named over
-# `[name_off, name_off + name_len)`, returning the struct-lit expr id.
+# append a struct literal with a single field init named over
+# `[name_off, name_off + name_len)`, returning the struct-lit expr id
 fun add_struct_lit(a: *ast.Ast, name_off: usize, name_len: usize) id.ExprId {
     var fi: expr.FieldInit;
     fi.name  = span_at(name_off, name_len);
@@ -1445,13 +1445,13 @@ test "features: field_ref_span_at matches a member access of the keyed record" {
     var ti: type.TypeInterner;
     if (is_some[str](type.init(?ti, ?pa))) { ret 1; }
     # the record P is declared in module 2, decl 4; its field "x" lives at offset
-    # 8 of the declaring source. the buffer text "p.x" carries the member access.
+    # 8 of the declaring source. the buffer text "p.x" carries the member access
     val recp: type.TypeId = unwrap_ok[type.TypeId, str](
         type.intern_nominal(?ti, intern.STR_NIL, 2::sess.ModuleId, 4::id.DeclId, type.TYPE_REC));
     var declf: src.SourceFile = stub_file("rec P { x: i32; }");   # "x" at offset 8
     var buf:   src.SourceFile = stub_file("p.x");
 
-    # expr 0 = receiver "p" (typed P); expr 1 = member access "p.x" (name "x"@2).
+    # expr 0 = receiver "p" (typed P); expr 1 = member access "p.x" (name "x"@2)
     val recv: id.ExprId = add_ident(?a, 0, 1);
     val mem:  id.ExprId = add_member(?a, recv, 2, 1);
     var sr: sema.SemaResult = mk_sema(?pa, 2);
@@ -1513,7 +1513,7 @@ test "features: field_ref_span_at matches a struct-literal field init" {
     var declf: src.SourceFile = stub_file("rec P { x: i32; }");   # "x" at offset 8
     var buf:   src.SourceFile = stub_file("P{ x: 1 }");           # init "x" at offset 3
 
-    # expr 0 = the struct literal itself, typed P; its single init names "x"@3.
+    # expr 0 = the struct literal itself, typed P; its single init names "x"@3
     val lit: id.ExprId = add_struct_lit(?a, 3, 1);
     var sr: sema.SemaResult = mk_sema(?pa, 1);
     sr.expr_type[lit] = recp;
@@ -1551,7 +1551,7 @@ test "features: field_ref_span_at rejects a different record and a different fie
     sr.expr_type[recv] = recp;
 
     var fail: bool = false;
-    # right record, wrong field name ("y" vs the access "x"): no match.
+    # right record, wrong field name ("y" vs the access "x"): no match
     var decly: src.SourceFile = stub_file("y");
     if (is_some[token.Span](field_ref_span_at(?a, ?sr, ?ti, mem, ?buf, fk(2, 4, ?decly, 0, 1)))) { fail = true; }
     # right field name, wrong record identity (decl 9): no match.
@@ -1567,7 +1567,7 @@ test "features: field_ref_span_at rejects a different record and a different fie
     ret 0;
 }
 
-# empty_doc: a zero-length doc span, for the no-doc test cases.
+# a zero-length doc span, for the no-doc test cases
 fun empty_doc() token.Span {
     var d: token.Span;
     d.offset = 0;
@@ -1585,16 +1585,16 @@ test "features: collect_field_sites gathers every site, the decl, and the doc co
         type.intern_nominal(?ti, intern.STR_NIL, 0::sess.ModuleId, 4::id.DeclId, type.TYPE_REC));
 
     # the declaring module's source: the doc block then `rec P { x: i32; y: i32; }`.
-    # the doc `# x:` component name is at offset 18 (after "# a point\n# ---\n# ").
+    # the doc `# x:` component name is at offset 18 (after "# a point\n# ---\n# ")
     val declsrc: str = "# a point\n# ---\n# x: the abscissa\nrec P { x: i32; y: i32; }";
     var declf: src.SourceFile = stub_file(declsrc);
     var doc: token.Span;
     doc.offset = 0;
     doc.len    = 33;   # through the `# x: ...` component, before the rec body
-    # the field "x" name in the rec body sits at offset 42 (within `rec P { x`).
+    # the field "x" name in the rec body sits at offset 42 (within `rec P { x`)
     val xoff: usize = 42;
 
-    # the module under walk also contains two member accesses and a struct lit on x.
+    # the module under walk also contains two member accesses and a struct lit on x
     var buf: src.SourceFile = stub_file("p.x q.x P{ x: 1 }");
     val r1: id.ExprId = add_ident(?a, 0, 1);          # "p"
     val m1: id.ExprId = add_member(?a, r1, 2, 1);     # "p.x" name @2
@@ -1610,7 +1610,7 @@ test "features: collect_field_sites gathers every site, the decl, and the doc co
     var out: [8]token.Span;
 
     var fail: bool = false;
-    # rename over the declaring module: two members, one init, the decl, the doc.
+    # rename over the declaring module: two members, one init, the decl, the doc
     val n: usize = collect_field_sites(?a, ?sr, ?ti, ?buf, key, true, true, declsrc, doc, ?out[0], 8);
     if (n != 5) { fail = true; }
     or {
@@ -1653,7 +1653,7 @@ test "features: collect_field_sites omits the doc component for references (want
 
     val key: FieldKey = fk(0, 4, ?declf, 42, 1);
     var out: [4]token.Span;
-    # references: the one member access + the field decl, but NOT the doc component.
+    # the one member access + the field decl, but NOT the doc component
     val n: usize = collect_field_sites(?a, ?sr, ?ti, ?buf, key, true, false, declsrc, doc, ?out[0], 4);
 
     free_sema(?pa, ?sr);
@@ -1671,7 +1671,7 @@ test "features: collect_field_sites in a non-declaring module yields only body s
     var ti: type.TypeInterner;
     if (is_some[str](type.init(?ti, ?pa))) { ret 1; }
     # the record is declared in module 0; this is a different (importing) module
-    # whose only contribution is a member access on the imported record's value.
+    # whose only contribution is a member access on the imported record's value
     val recp: type.TypeId = unwrap_ok[type.TypeId, str](
         type.intern_nominal(?ti, intern.STR_NIL, 0::sess.ModuleId, 4::id.DeclId, type.TYPE_REC));
     var declf: src.SourceFile = stub_file("rec P { x: i32; }");   # "x" @8
@@ -1683,7 +1683,7 @@ test "features: collect_field_sites in a non-declaring module yields only body s
 
     val key: FieldKey = fk(0, 4, ?declf, 8, 1);
     var out: [4]token.Span;
-    # declaring=false: no decl span, no doc — just the body site.
+    # declaring=false: no decl span, no doc — just the body site
     val n: usize = collect_field_sites(?a, ?sr, ?ti, ?buf, key, false, true, "", empty_doc(), ?out[0], 4);
 
     free_sema(?pa, ?sr);
@@ -1711,7 +1711,7 @@ test "features: collect_field_sites adds the decl but no doc edit when the recor
 
     val key: FieldKey = fk(0, 4, ?declf, 8, 1);
     var out: [4]token.Span;
-    # rename, declaring, but the doc span is empty -> the decl edit, no doc edit.
+    # rename, declaring, but the doc span is empty -> the decl edit, no doc edit
     val n: usize = collect_field_sites(?a, ?sr, ?ti, ?buf, key, true, true, "rec P { x: i32; }", empty_doc(), ?out[0], 4);
 
     free_sema(?pa, ?sr);
@@ -1753,7 +1753,7 @@ test "features: doc_component_name_span rewrites the inner identifier of a gener
     var qf: src.SourceFile = stub_file("T");
 
     var fail: bool = false;
-    # generic match: the inner "T" only, brackets preserved.
+    # generic match: the inner "T" only, brackets preserved
     val o: Option[token.Span] = doc_component_name_span(txt, doc, ?qf, span_at(0, 1), true);
     if (is_none[token.Span](o)) { fail = true; }
     or {
@@ -1774,20 +1774,20 @@ test "features: doc_component_name_span returns none with no doc, no match, summ
     var qf: src.SourceFile = stub_file("x");
     var fail: bool = false;
 
-    # empty doc span -> none.
+    # empty doc span -> none
     var empty: token.Span;
     empty.offset = 0;
     empty.len    = 0;
     if (is_some[token.Span](doc_component_name_span("", empty, ?qf, span_at(0, 1), false))) { fail = true; }
 
-    # a real doc block whose components do not include "x" -> none.
+    # a real doc block whose components do not include "x" -> none
     val txt: str = "# d\n# ---\n# a: one\n# b: two\n";
     var doc: token.Span;
     doc.offset = 0;
     doc.len    = str_len(txt);
     if (is_some[token.Span](doc_component_name_span(txt, doc, ?qf, span_at(0, 1), false))) { fail = true; }
 
-    # a summary-only block (no `# ---`) -> no components -> none.
+    # a summary-only block (no `# ---`) -> no components -> none
     val s2: str = "# just a summary mentioning x\n";
     var d2: token.Span;
     d2.offset = 0;

--- a/src/features.mach
+++ b/src/features.mach
@@ -811,15 +811,14 @@ pub fun field_decl_span(decl_a: *ast.Ast, decl_file: *src.SourceFile, fields_sta
 }
 
 # the name span of the rec / uni field whose own declaration
-# name covers `offset` in `decl_file`, or none. resolves the field's declaration
+# name covers `offset`, or none. resolves the field's declaration
 # site to itself (go-to-definition on a field where it is declared). scans the
 # field range `[fields_start, fields_start + fields_len)` in `decl_a.typed_names`
 # ---
 # decl_a:       the Ast holding the field declarations
-# decl_file:    the SourceFile backing `decl_a`
 # fields_start: start index of the field range in `decl_a.typed_names`
 # fields_len:   number of fields
-# offset:       byte offset into `decl_file`
+# offset:       byte offset into the declaring module's source
 # ret:          some(field name span) when the offset is on a field name, or none
 pub fun field_decl_self_at(decl_a: *ast.Ast, fields_start: u32, fields_len: u32, offset: usize) Option[token.Span] {
     var i: u32 = 0;

--- a/src/json.mach
+++ b/src/json.mach
@@ -1,4 +1,4 @@
-# mls.json: minimal JSON extraction and construction for LSP messages.
+# minimal JSON extraction and construction for LSP messages
 #
 # the server never builds a full JSON tree: requests are small, flat objects
 # and the fields it needs (method, id, uri, text, version, position) are read
@@ -27,8 +27,8 @@ use std.allocator.deallocate;
 
 use mem: std.memory;
 
-# extract_string: read the string value of `key` in `data`, decoding JSON
-# escapes. returns owned text, or nil when the key is absent or not a string.
+# read the string value of `key` in `data`, decoding JSON
+# escapes. returns owned text, or nil when the key is absent or not a string
 # ---
 # data:  JSON text to scan
 # key:   quoted key to find, e.g. `"method"`
@@ -91,8 +91,8 @@ pub fun extract_string(data: str, key: str, alloc: *Allocator) str {
     ret buf::str;
 }
 
-# extract_raw: read the raw token of `key` (a quoted string copied verbatim, or
-# a bare number / literal). returns owned text, or nil on miss.
+# read the raw token of `key` (a quoted string copied verbatim, or
+# a bare number / literal). returns owned text, or nil on miss
 # ---
 # data:  JSON text to scan
 # key:   quoted key to find
@@ -135,7 +135,7 @@ pub fun extract_raw(data: str, key: str, alloc: *Allocator) str {
     ret copy_range(data, start, pos, alloc);
 }
 
-# extract_number_i64: read the integer value of `key`, or 0 when absent.
+# read the integer value of `key`, or 0 when absent
 # ---
 # data:  JSON text to scan
 # key:   quoted key to find
@@ -149,10 +149,10 @@ pub fun extract_number_i64(data: str, key: str, alloc: *Allocator) i64 {
     ret result;
 }
 
-# seek_after: the tail of `data` starting just past the first occurrence of
+# the tail of `data` starting just past the first occurrence of
 # `anchor` as an object key, or nil when the anchor is absent or ends the text.
 # the shared prologue of the *_after accessors; the returned pointer borrows
-# `data`.
+# `data`
 fun seek_after(data: str, anchor: str) str {
     val idx: isize = find_key(data, anchor);
     if (idx < 0) { ret nil; }
@@ -161,8 +161,8 @@ fun seek_after(data: str, anchor: str) str {
     ret (data::usize + offset)::str;
 }
 
-# extract_after: read string `key` that appears after the first occurrence of
-# `anchor` (scopes a key lookup to a nested object whose opening key is known).
+# read string `key` that appears after the first occurrence of
+# `anchor` (scopes a key lookup to a nested object whose opening key is known)
 # ---
 # data:   JSON text to scan
 # anchor: quoted key marking where to start scanning
@@ -175,7 +175,7 @@ pub fun extract_after(data: str, anchor: str, key: str, alloc: *Allocator) str {
     ret extract_string(sub, key, alloc);
 }
 
-# extract_number_after: read integer `key` after `anchor`, or 0 on miss.
+# read integer `key` after `anchor`, or 0 on miss
 # ---
 # data:   JSON text to scan
 # anchor: quoted key marking where to start scanning
@@ -188,10 +188,10 @@ pub fun extract_number_after(data: str, anchor: str, key: str, alloc: *Allocator
     ret extract_number_i64(sub, key, alloc);
 }
 
-# extract_string_seq: decode the string value of the `index`-th occurrence of
+# decode the string value of the `index`-th occurrence of
 # `key` in `data` (0-based), or nil when there are fewer than index+1
 # occurrences. lets a caller iterate a repeated key — e.g. every `"uri"` in a
-# `workspace/didChangeWatchedFiles` changes array — by bumping `index` until nil.
+# `workspace/didChangeWatchedFiles` changes array — by bumping `index` until nil
 # ---
 # data:  JSON text to scan
 # key:   quoted key to find, e.g. `"uri"`
@@ -209,13 +209,13 @@ pub fun extract_string_seq(data: str, key: str, index: u32, alloc: *Allocator) s
     ret extract_string(sub, key, alloc);
 }
 
-# extract_bool_after: whether the boolean `key` inside the object value of
+# whether the boolean `key` inside the object value of
 # `anchor` is the literal `true`. the scan is scoped to the anchor's balanced
 # object, so an equally-named key in a later sibling object is never misread —
 # e.g. another capability's `dynamicRegistration` after an empty
 # `"didChangeWatchedFiles":{}`. false when the anchor is absent, its value is
 # not an object, or the key is absent / non-true, so a missing capability reads
-# as unsupported.
+# as unsupported
 # ---
 # data:   JSON text to scan
 # anchor: quoted key whose object value scopes the lookup
@@ -245,8 +245,8 @@ pub fun extract_bool_after(data: str, anchor: str, key: str, alloc: *Allocator) 
     ret is_true;
 }
 
-# object_end: the index one past the matching `}` of the `{` at `start`,
-# skipping string contents, or 0 when the object is unbalanced.
+# the index one past the matching `}` of the `{` at `start`,
+# skipping string contents, or 0 when the object is unbalanced
 fun object_end(data: str, start: usize) usize {
     val n: usize = str_len(data);
     var depth: usize = 0;
@@ -274,8 +274,8 @@ fun object_end(data: str, start: usize) usize {
     ret 0;
 }
 
-# quote: JSON-encode `s` as a quoted, escaped string literal (including the
-# surrounding quotes). returns owned text, or nil on allocation failure.
+# JSON-encode `s` as a quoted, escaped string literal (including the
+# surrounding quotes). returns owned text, or nil on allocation failure
 # ---
 # s:     raw text to encode
 # alloc: allocator backing the returned string
@@ -322,7 +322,7 @@ pub fun quote(s: str, alloc: *Allocator) str {
     ret buf::str;
 }
 
-# format_usize: render `value` in base 10. returns owned text, or nil on failure.
+# render `value` in base 10. returns owned text, or nil on failure
 # ---
 # value: number to render
 # alloc: allocator backing the returned string
@@ -348,7 +348,7 @@ pub fun format_usize(value: usize, alloc: *Allocator) str {
     ret buf::str;
 }
 
-# format_i64: render `value` in base 10 with a leading sign for negatives.
+# render `value` in base 10 with a leading sign for negatives
 # ---
 # value: number to render
 # alloc: allocator backing the returned string
@@ -377,7 +377,7 @@ pub fun format_i64(value: i64, alloc: *Allocator) str {
     ret buf::str;
 }
 
-# free_str: release a string returned by this module.
+# release a string returned by this module
 # ---
 # s:     string to free; nil is a no-op
 # alloc: allocator the string was allocated from
@@ -387,8 +387,8 @@ pub fun free_str(s: str, alloc: *Allocator) {
     deallocate[u8](alloc, s::*u8, len + 1);
 }
 
-# find_key: byte offset of the opening quote of `key` as an object key in
-# `data` (a `"key"` token outside any string value), or -1 when absent.
+# byte offset of the opening quote of `key` as an object key in
+# `data` (a `"key"` token outside any string value), or -1 when absent
 fun find_key(data: str, key: str) isize {
     val key_len: usize = str_len(key);
     val data_len: usize = str_len(data);
@@ -411,7 +411,7 @@ fun find_key(data: str, key: str) isize {
     ret -1;
 }
 
-# is_escaped: whether the byte at `index` is preceded by an odd run of backslashes.
+# whether the byte at `index` is preceded by an odd run of backslashes
 fun is_escaped(data: str, index: usize) bool {
     if (index == 0) { ret false; }
     var back: usize = index - 1;
@@ -425,7 +425,7 @@ fun is_escaped(data: str, index: usize) bool {
     ret (count & 1) == 1;
 }
 
-# match_at: whether `pattern` occurs verbatim at `offset` in `data`.
+# whether `pattern` occurs verbatim at `offset` in `data`
 fun match_at(data: str, offset: usize, pattern: str) bool {
     val pattern_len: usize = str_len(pattern);
     val data_len: usize = str_len(data);
@@ -438,7 +438,7 @@ fun match_at(data: str, offset: usize, pattern: str) bool {
     ret true;
 }
 
-# skip_ws: advance past JSON whitespace starting at `pos`.
+# advance past JSON whitespace starting at `pos`
 fun skip_ws(data: str, pos: usize) usize {
     val data_len: usize = str_len(data);
     var p: usize = pos;
@@ -450,7 +450,7 @@ fun skip_ws(data: str, pos: usize) usize {
     ret p;
 }
 
-# parse_i64: parse a leading optionally-signed decimal integer from `s`.
+# parse a leading optionally-signed decimal integer from `s`
 fun parse_i64(s: str) i64 {
     if (s == nil) { ret 0; }
     val s_len: usize = str_len(s);
@@ -469,7 +469,7 @@ fun parse_i64(s: str) i64 {
     ret result;
 }
 
-# copy_range: owned copy of `data[start..end)`, nil-terminated.
+# owned copy of `data[start..end)`, nil-terminated
 fun copy_range(data: str, start: usize, end: usize, alloc: *Allocator) str {
     val len: usize = end - start;
     if (len == 0) { ret nil; }

--- a/src/json.mach
+++ b/src/json.mach
@@ -190,8 +190,8 @@ pub fun extract_number_after(data: str, anchor: str, key: str, alloc: *Allocator
 
 # decode the string value of the `index`-th occurrence of
 # `key` in `data` (0-based), or nil when there are fewer than index+1
-# occurrences. lets a caller iterate a repeated key — e.g. every `"uri"` in a
-# `workspace/didChangeWatchedFiles` changes array — by bumping `index` until nil
+# occurrences. lets a caller iterate a repeated key - e.g. every `"uri"` in a
+# `workspace/didChangeWatchedFiles` changes array - by bumping `index` until nil
 # ---
 # data:  JSON text to scan
 # key:   quoted key to find, e.g. `"uri"`
@@ -211,7 +211,7 @@ pub fun extract_string_seq(data: str, key: str, index: u32, alloc: *Allocator) s
 
 # whether the boolean `key` inside the object value of
 # `anchor` is the literal `true`. the scan is scoped to the anchor's balanced
-# object, so an equally-named key in a later sibling object is never misread —
+# object, so an equally-named key in a later sibling object is never misread -
 # e.g. another capability's `dynamicRegistration` after an empty
 # `"didChangeWatchedFiles":{}`. false when the anchor is absent, its value is
 # not an object, or the key is absent / non-true, so a missing capability reads

--- a/src/language.mach
+++ b/src/language.mach
@@ -1,4 +1,4 @@
-# mls.language: the rich language-feature request handlers.
+# the rich language-feature request handlers
 #
 # hover, definition, references, rename, prepareRename, documentSymbol, and
 # completion. every request resolves the document's buffer against the loaded
@@ -63,7 +63,7 @@ use features:  mls.features;
 use positions: mls.positions;
 use project:   mls.project;
 
-# Analyzed: the resolved analysis of one request's target document.
+# the resolved analysis of one request's target document
 # ---
 # interner: the session's string interner, for resolving symbol-name StrIds
 # file:     the document's SourceFile (text + line index for offset/position)
@@ -82,8 +82,8 @@ rec Analyzed {
     root:     *project.Root;
 }
 
-# hover: answer textDocument/hover with the type / declaration of the symbol at
-# the cursor, or null when the position is not on a resolved symbol.
+# answer textDocument/hover with the type / declaration of the symbol at
+# the cursor, or null when the position is not on a resolved symbol
 pub fun hover(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
     val id_raw: str = json.extract_raw(body, "\"id\"", alloc);
     if (id_raw == nil) { ret; }
@@ -113,9 +113,9 @@ pub fun hover(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocat
     reply_hover(alloc, id_raw, an.file, sr.name_span, md);
 }
 
-# reply_hover: send a `textDocument/hover` reply rendering Markdown `md` over the
+# send a `textDocument/hover` reply rendering Markdown `md` over the
 # name span `name_span` in `file`, freeing `md` and `id_raw`. nil-replies when the
-# Markdown cannot be quoted. shared by the symbol and field hover paths.
+# Markdown cannot be quoted. shared by the symbol and field hover paths
 fun reply_hover(alloc: *Allocator, id_raw: str, file: *src.SourceFile, name_span: token.Span, md: str) {
     val qmd: str = json.quote(md, alloc);
     json.free_str(md, alloc);
@@ -135,7 +135,7 @@ fun reply_hover(alloc: *Allocator, id_raw: str, file: *src.SourceFile, name_span
     json.free_str(id_raw, alloc);
 }
 
-# field_hover: the type-driven hover path for a record / union field, consulted
+# the type-driven hover path for a record / union field, consulted
 # when the symbol-table pivot finds nothing at `offset`. types the referencing
 # expression (a member access `foo.bar` or a struct-literal field name
 # `T{ bar: ... }`), peels it to its record site, and renders the field's name,
@@ -144,7 +144,7 @@ fun reply_hover(alloc: *Allocator, id_raw: str, file: *src.SourceFile, name_span
 # may be declared in a dependency module, in which case its Ast / file / doc all
 # come from the loaded module. emits the hover over the cursor's field-name span
 # and returns true when a field was rendered; returns false (without replying) so
-# the caller can fall back to a null reply. requires a loaded project root.
+# the caller can fall back to a null reply. requires a loaded project root
 # ---
 # ws:     the workspace
 # alloc:  request allocator
@@ -175,14 +175,14 @@ fun field_hover(ws: *project.Workspace, alloc: *Allocator, an: *Analyzed, offset
     ret true;
 }
 
-# field_hover_markdown: a fenced `mach` code block rendering a field as
+# a fenced `mach` code block rendering a field as
 # `<name>: <type>`, with the field's matching doc component description following
 # as prose when present. the field is located by matching the cursor's field-name
 # bytes `query` (in `query_file`, the buffer) against the record site's declared
 # field names; name and type spans are read from the declaring module's source so
 # a cross-module field renders. nil when no field matches, the field name cannot
 # be read, or allocation fails. a field with no matching doc component renders the
-# `name: type` block alone (no description, no error).
+# `name: type` block alone (no description, no error)
 fun field_hover_markdown(rs: project.RecordSite, query_file: *src.SourceFile, query: token.Span, alloc: *Allocator) str {
     val i: usize = field_index(rs, query_file, query);
     if (i >= rs.fields_len::usize) { ret nil; }
@@ -207,10 +207,10 @@ fun field_hover_markdown(rs: project.RecordSite, query_file: *src.SourceFile, qu
     ret r;
 }
 
-# field_index: the index into the record site's field range whose declared name
+# the index into the record site's field range whose declared name
 # bytes equal `query` (in `query_file`), or fields_len when no field matches. the
 # cross-source byte compare lets the receiver and the declaration live in
-# different modules.
+# different modules
 fun field_index(rs: project.RecordSite, query_file: *src.SourceFile, query: token.Span) usize {
     if (query.len == 0) { ret rs.fields_len::usize; }
     var i: u32 = 0;
@@ -222,10 +222,10 @@ fun field_index(rs: project.RecordSite, query_file: *src.SourceFile, query: toke
     ret rs.fields_len::usize;
 }
 
-# field_type_text: the declared-type text of a field, read from the declaring
+# the declared-type text of a field, read from the declaring
 # module's source (`TypedName.ty` -> its AST type span), or nil when the field
 # carries no type node. the declaring module's file backs the span, so a
-# cross-module field's type renders.
+# cross-module field's type renders
 fun field_type_text(rs: project.RecordSite, tn: *decl.TypedName, alloc: *Allocator) str {
     if (tn.ty == id.TYPE_NIL) { ret nil; }
     val to: Option[*atype.Type] = ast.get_type(rs.a, tn.ty);
@@ -233,9 +233,9 @@ fun field_type_text(rs: project.RecordSite, tn: *decl.TypedName, alloc: *Allocat
     ret positions.span_text(rs.file, unwrap[*atype.Type](to).span, alloc);
 }
 
-# doc_desc_prose: render a single doc-component description span as prose,
+# render a single doc-component description span as prose,
 # folding its embedded comment-line breaks the way `doc_text` does. nil on an
-# empty span or allocation failure.
+# empty span or allocation failure
 fun doc_desc_prose(file: *src.SourceFile, span: token.Span, alloc: *Allocator) str {
     if (span.len == 0) { ret nil; }
     val source: str = file.text;
@@ -249,9 +249,9 @@ fun doc_desc_prose(file: *src.SourceFile, span: token.Span, alloc: *Allocator) s
     ret buf::str;
 }
 
-# compose_field_hover: assemble the field hover Markdown — a fenced `mach` block
+# assemble the field hover Markdown — a fenced `mach` block
 # of `name: type` (or just `name` when the type is unavailable), followed by the
-# description prose as a paragraph when present. nil on allocation failure.
+# description prose as a paragraph when present. nil on allocation failure
 fun compose_field_hover(name: str, ty: str, doc: str, alloc: *Allocator) str {
     val pre:  str = "```mach\n";
     val post: str = "\n```";
@@ -281,12 +281,12 @@ fun compose_field_hover(name: str, ty: str, doc: str, alloc: *Allocator) str {
     ret buf::str;
 }
 
-# hover_markdown: a fenced `mach` code block rendering the symbol at hover. it
+# a fenced `mach` code block rendering the symbol at hover. it
 # shows the declaration header as written — read from the buffer for a local
 # symbol, from the defining dependency module's file for a cross-module one —
 # falling back to the symbol kind and name when no decl header is available. the
 # decl's doc comment, if any, follows the block as prose, read from the same
-# Site so a cross-module symbol's docs render too.
+# Site so a cross-module symbol's docs render too
 fun hover_markdown(ws: *project.Workspace, an: Analyzed, sym: *res.Symbol, uri: str, alloc: *Allocator) str {
     var sig: str = nil;
     var doc: str = nil;
@@ -330,7 +330,7 @@ fun hover_markdown(ws: *project.Workspace, an: Analyzed, sym: *res.Symbol, uri: 
     ret buf::str;
 }
 
-# doc_prose: render a declaration's first-class doc block (`Decl.doc`) as
+# render a declaration's first-class doc block (`Decl.doc`) as
 # Markdown. the block is read through `fe/doc.mach`: the summary becomes a prose
 # paragraph; when a `# ---` component block follows, a thematic break (`---`
 # fenced by blank lines so CommonMark reads a horizontal rule, not a setext
@@ -339,7 +339,7 @@ fun hover_markdown(ws: *project.Workspace, an: Analyzed, sym: *res.Symbol, uri: 
 # attribute lines, no attribute syntax can leak into the rendering. one
 # `doc_render` walk both sizes and fills the buffer, so the two passes cannot
 # diverge and the allocation is str_len + 1 as `json.free_str` expects. nil on an
-# empty span, a block carrying no rendered text, or allocation failure.
+# empty span, a block carrying no rendered text, or allocation failure
 # ---
 # file:  the source file the doc span points into
 # span:  the declaration's `Decl.doc` span
@@ -362,10 +362,10 @@ fun doc_prose(file: *src.SourceFile, span: token.Span, alloc: *Allocator) str {
     ret buf::str;
 }
 
-# doc_render: walk a doc block once, writing the Markdown rendering into `buf`
+# walk a doc block once, writing the Markdown rendering into `buf`
 # when it is non-nil and only measuring otherwise. both passes share this walk so
 # the sized length and the written bytes stay identical. sets `has_text` when any
-# summary or component byte is rendered. returns the rendered length in bytes.
+# summary or component byte is rendered. returns the rendered length in bytes
 fun doc_render(source: str, span: token.Span, buf: *u8, has_text: *bool) usize {
     @has_text = false;
     var off: usize = 0;
@@ -398,26 +398,26 @@ fun doc_render(source: str, span: token.Span, buf: *u8, has_text: *bool) usize {
     ret off;
 }
 
-# doc_lf: write a single newline into `buf` when non-nil, returning the advanced
-# offset.
+# write a single newline into `buf` when non-nil, returning the advanced
+# offset
 fun doc_lf(buf: *u8, off: usize) usize {
     if (buf != nil) { buf[off] = '\n'; }
     ret off + 1;
 }
 
-# doc_emit: write null-terminated `s` into `buf` at `off` when non-nil, only
-# measuring its length otherwise, returning the advanced offset.
+# write null-terminated `s` into `buf` at `off` when non-nil, only
+# measuring its length otherwise, returning the advanced offset
 fun doc_emit(buf: *u8, off: usize, s: str) usize {
     val n: usize = str_len(s);
     if (buf != nil && n > 0) { mem.raw_copy((buf::usize + off)::ptr, s::ptr, n); }
     ret off + n;
 }
 
-# doc_text: copy a summary / description span into `buf`, folding each embedded
+# copy a summary / description span into `buf`, folding each embedded
 # comment-line break (`\n` then the next line's `#`, whitespace, and an optional
 # single space) into a single rendered space. a span returned by `fe/doc.mach`
 # spans only the first line's leading `#`; continuation lines keep their `#`
-# prefix, so this strips them to leave clean prose. measures when `buf` is nil.
+# prefix, so this strips them to leave clean prose. measures when `buf` is nil
 fun doc_text(buf: *u8, off: usize, source: str, sp: token.Span) usize {
     val s: *u8 = source::*u8;
     val end: usize = sp.offset + sp.len;
@@ -439,8 +439,8 @@ fun doc_text(buf: *u8, off: usize, source: str, sp: token.Span) usize {
     ret off;
 }
 
-# compose_kind_name: a `<kind> <name>` rendering for a symbol with no local
-# decl header (an imported symbol or primitive), or nil.
+# a `<kind> <name>` rendering for a symbol with no local
+# decl header (an imported symbol or primitive), or nil
 fun compose_kind_name(sym: *res.Symbol, interner: *intern.Interner, alloc: *Allocator) str {
     val no: Option[str] = intern.lookup(interner, sym.name);
     if (!is_some[str](no)) { ret nil; }
@@ -459,10 +459,10 @@ fun compose_kind_name(sym: *res.Symbol, interner: *intern.Interner, alloc: *Allo
     ret buf::str;
 }
 
-# definition: answer textDocument/definition with the Location of the resolved
+# answer textDocument/definition with the Location of the resolved
 # symbol's declaration. lands in the buffer for a local symbol and in the
 # defining dependency module's on-disk file for a cross-module one; null when
-# the position is not on a resolved symbol or its declaration cannot be located.
+# the position is not on a resolved symbol or its declaration cannot be located
 pub fun definition(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
     val id_raw: str = json.extract_raw(body, "\"id\"", alloc);
     if (id_raw == nil) { ret; }
@@ -507,7 +507,7 @@ pub fun definition(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Al
     json.free_str(id_raw, alloc);
 }
 
-# field_definition: the type-driven go-to-definition path for a record / union
+# the type-driven go-to-definition path for a record / union
 # field, consulted when the symbol-table pivot finds nothing at `offset`. handles
 # three field positions: a member access `foo.bar`, a struct-literal field name
 # `T{ bar: ... }`, and a field's own declaration site (which resolves to itself).
@@ -515,7 +515,7 @@ pub fun definition(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Al
 # match the field name; the third matches the cursor against the rec / uni decl's
 # own field names. emits the field declaration's Location and returns true when a
 # field is found and replied; returns false (without replying) so the caller can
-# fall back to a null reply otherwise. requires a loaded project root for typing.
+# fall back to a null reply otherwise. requires a loaded project root for typing
 # ---
 # ws:     the workspace
 # alloc:  request allocator
@@ -546,7 +546,7 @@ fun field_definition(ws: *project.Workspace, alloc: *Allocator, an: *Analyzed, u
     }
 
     # the cursor may sit on a field's own declaration name inside a rec / uni;
-    # resolve it to itself by matching the offset against the decl's field names.
+    # resolve it to itself by matching the offset against the decl's field names
     val self_o: Option[FieldSelf] = field_self_at(an, offset);
     if (is_some[FieldSelf](self_o)) {
         val fs: FieldSelf = unwrap[FieldSelf](self_o);
@@ -560,17 +560,17 @@ fun field_definition(ws: *project.Workspace, alloc: *Allocator, an: *Analyzed, u
     ret false;
 }
 
-# FieldSelf: a field declaration the cursor sits on at its own definition site —
-# the field name span resolves to itself for go-to-definition.
+# a field declaration the cursor sits on at its own definition site —
+# the field name span resolves to itself for go-to-definition
 # ---
 # name: byte span of the field name in the buffer
 rec FieldSelf {
     name: token.Span;
 }
 
-# field_self_at: the rec / uni field whose own declaration name covers `offset` in
+# the rec / uni field whose own declaration name covers `offset` in
 # the buffer, or none. enumerates the buffer's record / union declarations and
-# their fields so a cursor on a field's binding name resolves to itself.
+# their fields so a cursor on a field's binding name resolves to itself
 # ---
 # an:     the analyzed request document
 # offset: cursor byte offset into the buffer
@@ -601,10 +601,10 @@ fun field_self_at(an: *Analyzed, offset: usize) Option[FieldSelf] {
     ret some[FieldSelf](fs);
 }
 
-# emit_field_location: send the Location of a field declaration at its record
+# send the Location of a field declaration at its record
 # site. builds the site's `file://` URI (the buffer's own URI when the record is
 # declared in this module, else the defining module's on-disk file) and emits the
-# field name span. true on success; false on a URI / allocation failure.
+# field name span. true on success; false on a URI / allocation failure
 fun emit_field_location(ws: *project.Workspace, alloc: *Allocator, an: *Analyzed, uri: str, rs: project.RecordSite, name: token.Span, id_raw: str) bool {
     var furi: str = uri;
     var owned: bool = false;
@@ -622,8 +622,8 @@ fun emit_field_location(ws: *project.Workspace, alloc: *Allocator, an: *Analyzed
     ret true;
 }
 
-# reply_result: send a JSON-RPC success reply carrying `result` for request
-# `id_raw`. shared by the field-definition replies.
+# send a JSON-RPC success reply carrying `result` for request
+# `id_raw`. shared by the field-definition replies
 fun reply_result(alloc: *Allocator, id_raw: str, result: str) {
     val p1: str = "{\"jsonrpc\":\"2.0\",\"id\":";
     val p2: str = ",\"result\":";
@@ -632,12 +632,12 @@ fun reply_result(alloc: *Allocator, id_raw: str, result: str) {
     json.free_str(id_raw, alloc);
 }
 
-# FieldTarget: a record / union field resolved from a cursor, the type-driven twin
+# a record / union field resolved from a cursor, the type-driven twin
 # of a SymbolRef for the field references / rename / prepareRename paths. carries
 # the field's cross-module identity (`key`), the record's declaring site (`rs`,
 # for the field-declaration span and its doc block), and whether that site is the
 # active buffer (so the declaring module's edits — the field decl name and the doc
-# component — are placed in the buffer's URI rather than a loaded module's).
+# component — are placed in the buffer's URI rather than a loaded module's)
 # ---
 # key:            the field's cross-module identity
 # rs:             the record's declaring site (field range, Ast, file, doc)
@@ -648,14 +648,14 @@ rec FieldTarget {
     decl_in_buffer: bool;
 }
 
-# field_target_at: the record / union field a cursor references, resolved to its
+# the record / union field a cursor references, resolved to its
 # cross-module identity and declaring site, or none. drives the field references /
 # rename / prepareRename paths: pivots the offset through `field_ref_at` (a member
 # access or struct-literal field name) or `field_self_at` (a field's own decl
 # name), types the host expression, peels it to a `RecordSite`, and matches the
 # field name to recover its declaring span. none when the position is not on a
 # field, the host cannot be typed, or no field matches. requires a loaded project
-# root for typing.
+# root for typing
 # ---
 # ws:     the workspace
 # an:     the analyzed request document
@@ -679,7 +679,7 @@ fun field_target_at(ws: *project.Workspace, an: *Analyzed, offset: usize) Option
     }
 
     # the cursor may sit on a field's own declaration name inside a rec / uni in
-    # the buffer; resolve it to itself, then to that record's site for the walk.
+    # the buffer; resolve it to itself, then to that record's site for the walk
     val self_o: Option[FieldSelf] = field_self_at(an, offset);
     if (is_some[FieldSelf](self_o)) {
         val fs: FieldSelf = unwrap[FieldSelf](self_o);
@@ -692,10 +692,10 @@ fun field_target_at(ws: *project.Workspace, an: *Analyzed, offset: usize) Option
     ret none[FieldTarget]();
 }
 
-# make_field_target: assemble a FieldTarget from a resolved record site and the
+# assemble a FieldTarget from a resolved record site and the
 # field's declared-name span. the field name and its source live in the record's
 # declaring module (`rs.file`), which is the cross-module byte identity every
-# other module's references are matched against.
+# other module's references are matched against
 fun make_field_target(an: *Analyzed, rs: project.RecordSite, field_name: token.Span) FieldTarget {
     var t: FieldTarget;
     t.key.origin     = rs.origin;
@@ -707,11 +707,11 @@ fun make_field_target(an: *Analyzed, rs: project.RecordSite, field_name: token.S
     ret t;
 }
 
-# FieldXRef: one module contributing field references — its Ast, SemaResult (for
+# one module contributing field references — its Ast, SemaResult (for
 # typing each host expression), source file, document URI, and whether it is the
 # record's declaring module (so its field-declaration name span and doc component
 # are emitted). the active buffer is always `out[0]`; each other loaded module
-# that types a reference is another (owned `file://` URI freed by free_field_refs).
+# that types a reference is another (owned `file://` URI freed by free_field_refs)
 rec FieldXRef {
     a:        *ast.Ast;
     sr:       *sema.SemaResult;
@@ -720,13 +720,13 @@ rec FieldXRef {
     declaring: bool;
 }
 
-# build_field_refs: populate `out` with the modules that reference the keyed field
+# populate `out` with the modules that reference the keyed field
 # and return the count. `out[0]` is always the active buffer (live SemaResult);
 # each subsequent entry is a loaded module whose SemaResult types at least one
 # reference to the field, skipping the buffer's on-disk twin so its live edits are
 # not double-counted. every module is walked (a field is reachable wherever its
 # record is imported), so this is not gated on project ownership — the rename gate
-# is applied separately by the caller.
+# is applied separately by the caller
 # ---
 # ws:    the workspace
 # an:    the active buffer's analysis
@@ -772,8 +772,8 @@ fun build_field_refs(ws: *project.Workspace, an: Analyzed, uri: str, t: FieldTar
     ret n;
 }
 
-# free_field_refs: release the owned `file://` URIs of the graph-module entries.
-# refs[0] borrows the request URI and is skipped.
+# release the owned `file://` URIs of the graph-module entries.
+# refs[0] borrows the request URI and is skipped
 fun free_field_refs(ws: *project.Workspace, refs: *FieldXRef, n: usize) {
     var i: usize = 1;
     for (i < n) {
@@ -782,13 +782,13 @@ fun free_field_refs(ws: *project.Workspace, refs: *FieldXRef, n: usize) {
     }
 }
 
-# walk_field_sites: feed every site naming the keyed field in module `s` to the
+# feed every site naming the keyed field in module `s` to the
 # sink — every member access / struct-literal init whose host type peels to the
 # keyed record, plus (when `s` is the record's declaring module) the field
 # declaration's own name span and, for rename, the matching `# <field>:` doc
 # component name token. the span set is computed by the pure
 # `features.collect_field_sites` (a module can name a field at most once per expr,
-# so the buffer is sized to the expr count plus the two declaring extras).
+# so the buffer is sized to the expr count plus the two declaring extras)
 fun walk_field_sites(s: *FieldXRef, ti: *type.TypeInterner, t: FieldTarget, want_doc: bool, k: *WalkSink) {
     var doc: token.Span;
     doc.offset = 0;
@@ -809,11 +809,11 @@ fun walk_field_sites(s: *FieldXRef, ti: *type.TypeInterner, t: FieldTarget, want
     deallocate[token.Span](k.alloc, spans, cap);
 }
 
-# field_references: the type-driven references path for a record / union field.
+# the type-driven references path for a record / union field.
 # resolves the field, walks every loaded module's SemaResult collecting its
 # member-access / struct-literal sites plus the field declaration, and emits a
 # Location[]. true when a field was resolved and replied; false (without replying)
-# so the caller falls back to an empty array.
+# so the caller falls back to an empty array
 fun field_references(ws: *project.Workspace, alloc: *Allocator, an: *Analyzed, uri: str, offset: usize, id_raw: str) bool {
     val to: Option[FieldTarget] = field_target_at(ws, an, offset);
     if (!is_some[FieldTarget](to)) { ret false; }
@@ -833,13 +833,13 @@ fun field_references(ws: *project.Workspace, alloc: *Allocator, an: *Analyzed, u
     ret true;
 }
 
-# field_rename: the type-driven rename path for a record / union field. refuses
+# the type-driven rename path for a record / union field. refuses
 # (returns false without replying — the caller emits an empty edit) when the
 # field's record is declared in a vendored dependency: such a declaration is not
 # the editor's to rewrite. otherwise resolves the field, walks every loaded
 # module, and emits a WorkspaceEdit replacing every member-access / struct-literal
 # site, the field declaration, and the record's matching doc component. true when
-# the edit was replied.
+# the edit was replied
 fun field_rename(ws: *project.Workspace, alloc: *Allocator, an: *Analyzed, uri: str, offset: usize, id_raw: str, new_name: str) bool {
     val to: Option[FieldTarget] = field_target_at(ws, an, offset);
     if (!is_some[FieldTarget](to)) { ret false; }
@@ -861,13 +861,13 @@ fun field_rename(ws: *project.Workspace, alloc: *Allocator, an: *Analyzed, uri: 
     ret true;
 }
 
-# field_record_renameable: whether the field's record is the editor's to rewrite —
+# whether the field's record is the editor's to rewrite —
 # the same gate the symbol rename `renameable` applies, keyed on the record's
 # declaring module. a record declared in a loaded module keys directly on
 # `is_project_module`; a record declared in the active buffer keys on the buffer's
 # on-disk twin (a dependency source opened for editing has a loaded twin that is
 # not project-owned), and on the buffer's governing root not being a vendored
-# dependency project when it has no twin.
+# dependency project when it has no twin
 fun field_record_renameable(ws: *project.Workspace, root: *project.Root, uri: str, t: FieldTarget) bool {
     if (!t.decl_in_buffer) { ret project.is_project_module(ws, root, t.key.origin); }
     val twin_o: Option[sess.ModuleId] = project.module_for_uri(ws, root, uri);
@@ -875,16 +875,16 @@ fun field_record_renameable(ws: *project.Workspace, root: *project.Root, uri: st
     ret project.is_project_module(ws, root, unwrap[sess.ModuleId](twin_o));
 }
 
-# field_prepare_span: write the field-name span the cursor sits on into `out` and
+# write the field-name span the cursor sits on into `out` and
 # return true when it resolves to a field of a project-owned record, or false. the
-# prepareRename gate for field positions.
+# prepareRename gate for field positions
 fun field_prepare_span(ws: *project.Workspace, an: *Analyzed, uri: str, offset: usize, out: *token.Span) bool {
     val to: Option[FieldTarget] = field_target_at(ws, an, offset);
     if (!is_some[FieldTarget](to)) { ret false; }
     val t: FieldTarget = unwrap[FieldTarget](to);
     if (!field_record_renameable(ws, an.root, uri, t)) { ret false; }
     # the range reported is the cursor's own field-name token in the buffer; the
-    # decl-site name lives in the record's module, which may not be the buffer.
+    # decl-site name lives in the record's module, which may not be the buffer
     val fo: Option[features.FieldRef] = features.field_ref_at(an.a, offset);
     if (is_some[features.FieldRef](fo)) { @out = unwrap[features.FieldRef](fo).name_span; ret true; }
     val self_o: Option[FieldSelf] = field_self_at(an, offset);
@@ -892,9 +892,9 @@ fun field_prepare_span(ws: *project.Workspace, an: *Analyzed, uri: str, offset: 
     ret false;
 }
 
-# emit_field_locations: send a Location[] of every field site across `refs` (each
+# send a Location[] of every field site across `refs` (each
 # module's member-access / struct-literal sites plus the field declaration). takes
-# ownership of `id_raw` and frees it.
+# ownership of `id_raw` and frees it
 fun emit_field_locations(ws: *project.Workspace, alloc: *Allocator, id_raw: str, refs: *FieldXRef, nref: usize, t: FieldTarget) {
     val ti: *type.TypeInterner = project.type_interner(ws);
     val prefix: str = "{\"jsonrpc\":\"2.0\",\"id\":";
@@ -927,11 +927,11 @@ fun emit_field_locations(ws: *project.Workspace, alloc: *Allocator, id_raw: str,
     json.free_str(id_raw, alloc);
 }
 
-# emit_field_rename: send a WorkspaceEdit renaming the field to `new_name` across
+# send a WorkspaceEdit renaming the field to `new_name` across
 # `refs`, one `changes` entry per module. each entry rewrites that module's
 # member-access / struct-literal sites; the declaring module's entry also rewrites
 # the field declaration and the record's matching doc component. takes ownership of
-# `id_raw` and frees it.
+# `id_raw` and frees it
 fun emit_field_rename(ws: *project.Workspace, alloc: *Allocator, id_raw: str, refs: *FieldXRef, nref: usize, t: FieldTarget, new_name: str) {
     val ti: *type.TypeInterner = project.type_interner(ws);
     val qname: str = json.quote(new_name, alloc);
@@ -988,9 +988,9 @@ fun emit_field_rename(ws: *project.Workspace, alloc: *Allocator, id_raw: str, re
     json.free_str(id_raw, alloc);
 }
 
-# field_rename_group_json: the `changes`-map entry `"<uri>":[<edits>]` for module
+# the `changes`-map entry `"<uri>":[<edits>]` for module
 # `s`, rewriting its field sites (and, for the declaring module, the declaration
-# and doc component) to the quoted `qname`, or nil when `s` contributes no edit.
+# and doc component) to the quoted `qname`, or nil when `s` contributes no edit
 fun field_rename_group_json(s: *FieldXRef, ti: *type.TypeInterner, t: FieldTarget, qname: str, alloc: *Allocator) str {
     val quri: str = json.quote(s.uri, alloc);
     if (quri == nil) { ret nil; }
@@ -1020,10 +1020,10 @@ fun field_rename_group_json(s: *FieldXRef, ti: *type.TypeInterner, t: FieldTarge
     ret buf::str;
 }
 
-# references: answer textDocument/references with every Location resolving to
+# answer textDocument/references with every Location resolving to
 # the symbol at the cursor — its declaration plus every use-site across the
 # loaded project graph (the requesting buffer and every other module that
-# references the symbol). empty when the position is not on a resolved symbol.
+# references the symbol). empty when the position is not on a resolved symbol
 pub fun references(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
     val id_raw: str = json.extract_raw(body, "\"id\"", alloc);
     if (id_raw == nil) { ret; }
@@ -1056,7 +1056,7 @@ pub fun references(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Al
     val refs: *XRef = unwrap_ok[*XRef, str](ra);
 
     # a failed bridge only degrades references to buffer-local results; rename
-    # is where it must refuse (see build_refs / BRIDGE_FAILED).
+    # is where it must refuse (see build_refs / BRIDGE_FAILED)
     var status: i64 = BRIDGE_LOCAL;
     val n: usize = build_refs(ws, an, uri, sym, sr.sym_id, false, refs, cap, ?status);
     emit_locations(alloc, id_raw, refs, n, bind, has_bind);
@@ -1064,7 +1064,7 @@ pub fun references(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Al
     deallocate[XRef](alloc, refs, cap);
 }
 
-# rename: answer textDocument/rename with a WorkspaceEdit replacing every
+# answer textDocument/rename with a WorkspaceEdit replacing every
 # reference to the symbol at the cursor with the requested new name, across the
 # whole project graph — the declaring file plus every module that imports or
 # uses it (including each importer's `use` path leaf). confined to symbols
@@ -1072,7 +1072,7 @@ pub fun references(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Al
 # editor's to rewrite (whether referenced cross-module or opened as the buffer
 # itself), so those yield an empty edit. an empty edit is also returned when a
 # module-scope pub symbol's cross-file identity cannot be recovered from its
-# stale on-disk twin — a buffer-local edit there would be a partial rename.
+# stale on-disk twin — a buffer-local edit there would be a partial rename
 pub fun rename(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
     val id_raw: str = json.extract_raw(body, "\"id\"", alloc);
     if (id_raw == nil) { ret; }
@@ -1100,7 +1100,7 @@ pub fun rename(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Alloca
     if (!renameable(ws, an.root, uri, sym, sr)) { reply_empty_edit(alloc, id_raw); json.free_str(new_name, alloc); ret; }
 
     # the declared name guards the cross-file walk: only occurrences spelled with
-    # it are rewritten, so an aliased import's references are left untouched.
+    # it are rewritten, so an aliased import's references are left untouched
     val no: Option[str] = intern.lookup(an.interner, sym.name);
     if (!is_some[str](no)) { reply_empty_edit(alloc, id_raw); json.free_str(new_name, alloc); ret; }
     val name: str = unwrap[str](no);
@@ -1111,7 +1111,7 @@ pub fun rename(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Alloca
     # a param / generic carries its name in its owning decl's docstring component
     # block too (`# <param>:` / `# [T]:`); rename rewrites that name token in the
     # buffer where the decl lives. a fun / rec / val / etc. summary line no longer
-    # carries the name, so only param / generic bindings contribute a doc edit.
+    # carries the name, so only param / generic bindings contribute a doc edit
     var doc: token.Span;
     val has_doc: bool = param_generic_doc_span(an, sym, name, ?doc);
 
@@ -1137,13 +1137,13 @@ pub fun rename(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Alloca
     json.free_str(new_name, alloc);
 }
 
-# param_generic_doc_span: write the doc-component name token for a param / generic
+# write the doc-component name token for a param / generic
 # symbol's binding into `out` and return true, or false when the symbol is not a
 # param / generic, its owning decl has no docstring, or no component matches its
 # name. the doc block lives in the buffer the decl is declared in, so its name span
 # (`Decl.doc` resolved through `mach.lang.fe.doc`) is a buffer edit. a generic's
 # component head is the bracket form `# [T]:`, so the returned span is the inner
-# identifier only (the brackets stay).
+# identifier only (the brackets stay)
 fun param_generic_doc_span(an: Analyzed, sym: *res.Symbol, name: str, out: *token.Span) bool {
     if (sym.kind != res.SYM_PARAM && sym.kind != res.SYM_GENERIC) { ret false; }
     if (sym.decl == id.DECL_NIL) { ret false; }
@@ -1161,11 +1161,11 @@ fun param_generic_doc_span(an: Analyzed, sym: *res.Symbol, name: str, out: *toke
     ret true;
 }
 
-# prepare_rename: answer textDocument/prepareRename with the range of the name
+# answer textDocument/prepareRename with the range of the name
 # token at the cursor when it is a renameable symbol (a buffer-local symbol, or a
 # project-owned cross-module one) or a field of a known, project-owned record, or
 # null when it is not the editor's to rename (an unresolved position, a dependency
-# symbol, or a field of a vendored record).
+# symbol, or a field of a vendored record)
 pub fun prepare_rename(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
     val id_raw: str = json.extract_raw(body, "\"id\"", alloc);
     if (id_raw == nil) { ret; }
@@ -1178,7 +1178,7 @@ pub fun prepare_rename(ws: *project.Workspace, es: *editor.EditorSession, alloc:
     val ro: Option[features.SymbolRef] = features.ref_at(an.a, an.rr, an.own, offset);
     if (!is_some[features.SymbolRef](ro)) {
         # a cursor on a field name yields no SymbolRef — accept it when it resolves
-        # to a field of a project-owned record (the same gate field rename uses).
+        # to a field of a project-owned record (the same gate field rename uses)
         var name_span: token.Span;
         if (field_prepare_span(ws, ?an, uri, offset, ?name_span)) {
             reply_range(alloc, id_raw, an.file, name_span); ret;
@@ -1194,8 +1194,8 @@ pub fun prepare_rename(ws: *project.Workspace, es: *editor.EditorSession, alloc:
     reply_range(alloc, id_raw, an.file, sr.name_span);
 }
 
-# reply_range: send a prepareRename success reply carrying the range of `span` in
-# `file`, freeing `id_raw`. shared by the symbol and field prepare paths.
+# send a prepareRename success reply carrying the range of `span` in
+# `file`, freeing `id_raw`. shared by the symbol and field prepare paths
 fun reply_range(alloc: *Allocator, id_raw: str, file: *src.SourceFile, span: token.Span) {
     val rng: str = range_json(positions.range_of(file, span), alloc);
     val p1: str = "{\"jsonrpc\":\"2.0\",\"id\":";
@@ -1206,9 +1206,9 @@ fun reply_range(alloc: *Allocator, id_raw: str, file: *src.SourceFile, span: tok
     json.free_str(id_raw, alloc);
 }
 
-# document_symbol: answer textDocument/documentSymbol with a flat list of the
+# answer textDocument/documentSymbol with a flat list of the
 # file's top-level declarations as DocumentSymbol nodes (name, kind, range,
-# selectionRange).
+# selectionRange)
 pub fun document_symbol(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
     val id_raw: str = json.extract_raw(body, "\"id\"", alloc);
     if (id_raw == nil) { ret; }
@@ -1220,8 +1220,8 @@ pub fun document_symbol(ws: *project.Workspace, es: *editor.EditorSession, alloc
     emit_document_symbols(an, alloc, id_raw);
 }
 
-# completion: answer textDocument/completion with the in-scope top-level names
-# (module decls, `use` aliases / imports, primitives) as CompletionItems.
+# answer textDocument/completion with the in-scope top-level names
+# (module decls, `use` aliases / imports, primitives) as CompletionItems
 pub fun completion(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
     val id_raw: str = json.extract_raw(body, "\"id\"", alloc);
     if (id_raw == nil) { ret; }
@@ -1233,10 +1233,10 @@ pub fun completion(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Al
     emit_completions(an, alloc, id_raw);
 }
 
-# binding_span: write the binding name span of a param / generic symbol into
+# write the binding name span of a param / generic symbol into
 # `out` and return true, or false when the symbol binds at a Decl node (whose
 # site the decl walk already covers). lets references / rename include the one
-# binding site a param / generic has, which no side table records.
+# binding site a param / generic has, which no side table records
 fun binding_span(an: Analyzed, sid: res.SymbolId, out: *token.Span) bool {
     val so: Option[*res.Symbol] = features.symbol(an.rr, sid);
     if (!is_some[*res.Symbol](so)) { ret false; }
@@ -1246,7 +1246,7 @@ fun binding_span(an: Analyzed, sid: res.SymbolId, out: *token.Span) bool {
     ret true;
 }
 
-# renameable: whether the symbol at the cursor may be renamed. a cross-module
+# whether the symbol at the cursor may be renamed. a cross-module
 # symbol must be declared in a project-owned module, and a buffer-local symbol
 # is only renameable when the buffer itself is the editor's to rewrite: its
 # on-disk twin (when the buffer is a loaded module's file — e.g. a dependency
@@ -1254,7 +1254,7 @@ fun binding_span(an: Analyzed, sid: res.SymbolId, out: *token.Span) bool {
 # must also be project-owned. a buffer with no twin renames buffer-local — unless
 # its governing root is a vendored dependency project, whose every file is
 # read-only even outside that root's own graph closure (a vendored dep source the
-# outer project never imports still routes to its own vendored root).
+# outer project never imports still routes to its own vendored root)
 fun renameable(ws: *project.Workspace, root: *project.Root, uri: str, sym: *res.Symbol, sr: features.SymbolRef) bool {
     if (!sr.local) { ret project.is_project_module(ws, root, sym.origin); }
     val twin_o: Option[sess.ModuleId] = project.module_for_uri(ws, root, uri);
@@ -1262,11 +1262,11 @@ fun renameable(ws: *project.Workspace, root: *project.Root, uri: str, sym: *res.
     ret project.is_project_module(ws, root, unwrap[sess.ModuleId](twin_o));
 }
 
-# XRef: one file contributing references to a target symbol — its Ast, resolve
+# one file contributing references to a target symbol — its Ast, resolve
 # tables, source file, document URI, and the local SymbolId every reference in
 # it resolves to. the active buffer is always the first XRef (live resolve,
 # borrowed URI); each other loaded module that references the symbol is another
-# (graph snapshot, an owned `file://` URI freed by free_refs). see build_refs.
+# (graph snapshot, an owned `file://` URI freed by free_refs). see build_refs
 rec XRef {
     a:      *ast.Ast;
     rr:     *res.ResolveResult;
@@ -1275,7 +1275,7 @@ rec XRef {
     target: res.SymbolId;
 }
 
-# bridge status of build_refs' buffer -> on-disk-twin identity translation.
+# bridge status of build_refs' buffer -> on-disk-twin identity translation
 # ---
 # BRIDGE_LOCAL:  the symbol has no cross-file identity (block-local, non-pub,
 #                or the buffer has no loaded twin); buffer-local results are
@@ -1291,7 +1291,7 @@ val BRIDGE_LOCAL:  i64 = 0;
 val BRIDGE_OK:     i64 = 1;
 val BRIDGE_FAILED: i64 = 2;
 
-# build_refs: populate `out` with the files that reference the symbol at the
+# populate `out` with the files that reference the symbol at the
 # cursor and return the count. `out[0]` is always the active buffer (resolved
 # live, matched by its own SymbolId). each subsequent entry is a loaded module
 # whose resolve result contains the symbol's canonical (origin, decl) identity,
@@ -1303,7 +1303,7 @@ val BRIDGE_FAILED: i64 = 2;
 # pub declaration — a block-local binding that shadows a pub symbol's name, or a
 # non-pub declaration, has no importers and must not bridge to one. the bridge
 # outcome is reported in `status` (see BRIDGE_*) so rename can refuse on a
-# failed bridge instead of degrading to a partial buffer-local edit.
+# failed bridge instead of degrading to a partial buffer-local edit
 # ---
 # ws:          the workspace
 # an:          the active buffer's analysis
@@ -1367,8 +1367,8 @@ fun build_refs(ws: *project.Workspace, an: Analyzed, uri: str, sym: *res.Symbol,
     ret n;
 }
 
-# free_refs: release the owned `file://` URIs of the graph-module entries in a
-# built XRef array. refs[0] borrows the request's URI and is skipped.
+# release the owned `file://` URIs of the graph-module entries in a
+# built XRef array. refs[0] borrows the request's URI and is skipped
 fun free_refs(ws: *project.Workspace, refs: *XRef, n: usize) {
     var i: usize = 1;
     for (i < n) {
@@ -1377,12 +1377,12 @@ fun free_refs(ws: *project.Workspace, refs: *XRef, n: usize) {
     }
 }
 
-# analyze: resolve the document named by `uri` against the dependency graph of
+# resolve the document named by `uri` against the dependency graph of
 # the project root that governs it and populate `out` with its interner, file,
 # Ast, ResolveResult, governing root, and module id. false when the document is
 # unknown or resolution fails. the module id is the root's synthetic buffer id,
 # matching the one resolution bound local symbols under, so the local /
-# cross-module distinction holds.
+# cross-module distinction holds
 fun analyze(ws: *project.Workspace, es: *editor.EditorSession, docs: *documents.Store, uri: str, out: *Analyzed) bool {
     if (uri == nil) { ret false; }
     val doc: *documents.Document = documents.find(docs, uri);
@@ -1405,9 +1405,9 @@ fun analyze(ws: *project.Workspace, es: *editor.EditorSession, docs: *documents.
     ret true;
 }
 
-# locate: analyze the target document and resolve the request's cursor position
+# analyze the target document and resolve the request's cursor position
 # to a byte offset, or none when the document is unknown / unresolvable or the
-# position is invalid (callers fall back to a null / empty reply).
+# position is invalid (callers fall back to a null / empty reply)
 fun locate(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, body: str, uri: str, out: *Analyzed) Option[usize] {
     if (!analyze(ws, es, docs, uri, out)) { ret none[usize](); }
 
@@ -1418,7 +1418,7 @@ fun locate(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator,
     ret positions.offset_at(out.file, line::usize, ch::usize);
 }
 
-# WalkSink: the size-or-write accumulator behind the shared reference walk.
+# the size-or-write accumulator behind the shared reference walk.
 # one walk (walk_refs) feeds it: with `buf` nil it totals JSON byte lengths
 # into `total`; pointed at the output buffer it writes entries at `off`. the
 # same walk drives both passes, so the sizing and writing can never diverge.
@@ -1426,7 +1426,7 @@ fun locate(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator,
 # each span with that quoted name. `guard`, when non-nil, drops body (expr /
 # type) spans not spelled exactly `guard`, so rename skips alias-spelled
 # references while references reports them. `count` sequences the separating
-# commas across everything fed to the sink.
+# commas across everything fed to the sink
 rec WalkSink {
     alloc: *Allocator;
     buf:   *u8;
@@ -1437,8 +1437,8 @@ rec WalkSink {
     guard: str;
 }
 
-# sink_init: a sizing WalkSink; point `buf` at the output (and reset `count`)
-# to switch it to the write pass.
+# a sizing WalkSink; point `buf` at the output (and reset `count`)
+# to switch it to the write pass
 fun sink_init(alloc: *Allocator, qname: str, guard: str) WalkSink {
     var k: WalkSink;
     k.alloc = alloc;
@@ -1451,9 +1451,9 @@ fun sink_init(alloc: *Allocator, qname: str, guard: str) WalkSink {
     ret k;
 }
 
-# sink_emit: size or write one Location / TextEdit for `span` in `file` (located
+# size or write one Location / TextEdit for `span` in `file` (located
 # at `uri`), per the sink's mode. taking `file` / `uri` rather than a source
-# record lets the symbol walk (XRef) and the field walk (FieldXRef) share it.
+# record lets the symbol walk (XRef) and the field walk (FieldXRef) share it
 fun sink_emit(k: *WalkSink, file: *src.SourceFile, uri: str, span: token.Span) {
     if (k.qname == nil) {
         if (k.buf == nil) { k.total = k.total + loc_len(file, uri, span, k.alloc, k.count); }
@@ -1466,12 +1466,12 @@ fun sink_emit(k: *WalkSink, file: *src.SourceFile, uri: str, span: token.Span) {
     k.count = k.count + 1;
 }
 
-# walk_refs: feed every reference to `s.target` in source `s` to the sink — the
+# feed every reference to `s.target` in source `s` to the sink — the
 # declaration name, `use` / `fwd` import-path leaves, and the body (expr / type)
 # use-sites, plus the active buffer's param / generic binding when `include_bind`
 # and its owning decl's matching doc-component name token when `include_doc`. body
 # spans pass the sink's spelling guard (see WalkSink); declaration, import leaves,
-# binding, and doc-component spans always carry the declared name and are exempt.
+# binding, and doc-component spans always carry the declared name and are exempt
 fun walk_refs(s: *XRef, include_bind: bool, bind: token.Span, include_doc: bool, doc: token.Span, k: *WalkSink) {
     if (s.target == res.SYMBOL_NIL) { ret; }
     if (include_bind) { sink_emit(k, s.file, s.uri, bind); }
@@ -1498,17 +1498,17 @@ fun walk_refs(s: *XRef, include_bind: bool, bind: token.Span, include_doc: bool,
     }
 }
 
-# guard_admits: whether a body span passes the sink's spelling guard.
+# whether a body span passes the sink's spelling guard
 fun guard_admits(s: *XRef, k: *WalkSink, span: token.Span) bool {
     if (k.guard == nil) { ret true; }
     ret features.span_text_equals(s.file, span, k.guard);
 }
 
-# emit_locations: send a Location[] of every reference to the symbol across the
+# send a Location[] of every reference to the symbol across the
 # files in `refs` (declaration, import leaves, body use-sites; see walk_refs).
 # the active buffer's param / generic binding (which has no Decl node) is
 # `refs[0]`'s and is included when `has_bind`. takes ownership of `id_raw` and
-# frees it.
+# frees it
 fun emit_locations(alloc: *Allocator, id_raw: str, refs: *XRef, nref: usize, bind: token.Span, has_bind: bool) {
     val prefix: str = "{\"jsonrpc\":\"2.0\",\"id\":";
     val mid:    str = ",\"result\":[";
@@ -1543,13 +1543,13 @@ fun emit_locations(alloc: *Allocator, id_raw: str, refs: *XRef, nref: usize, bin
     json.free_str(id_raw, alloc);
 }
 
-# emit_rename: send a WorkspaceEdit renaming the symbol to `new_name` across the
+# send a WorkspaceEdit renaming the symbol to `new_name` across the
 # files in `refs`, one `changes` entry per file. each entry renames the
 # declaration, the import-path leaves, and every body reference spelled with the
 # declared name `name` (so an aliased import's references are not rewritten); the
 # active buffer's param / generic binding is included when `has_bind`, and its
 # owning decl's matching doc-component name token when `has_doc`. takes ownership
-# of `id_raw` and frees it.
+# of `id_raw` and frees it
 fun emit_rename(alloc: *Allocator, id_raw: str, refs: *XRef, nref: usize, new_name: str, name: str, bind: token.Span, has_bind: bool, doc: token.Span, has_doc: bool) {
     val qname: str = json.quote(new_name, alloc);
     if (qname == nil) { reply_empty_edit(alloc, id_raw); ret; }
@@ -1605,12 +1605,12 @@ fun emit_rename(alloc: *Allocator, id_raw: str, refs: *XRef, nref: usize, new_na
     json.free_str(id_raw, alloc);
 }
 
-# rename_group_json: the `changes`-map entry `"<uri>":[<edits>]` for source `s`,
+# the `changes`-map entry `"<uri>":[<edits>]` for source `s`,
 # renaming the declaration, import-path leaves, and every body reference spelled
 # `name` to the already-quoted `qname` (via the shared walk; see WalkSink), or
 # nil when `s` contributes no edit. the active buffer's param / generic binding is
 # included when `include_bind` and its owning decl's doc-component name token when
-# `include_doc`.
+# `include_doc`
 fun rename_group_json(s: *XRef, include_bind: bool, bind: token.Span, include_doc: bool, doc: token.Span, name: str, qname: str, alloc: *Allocator) str {
     if (s.target == res.SYMBOL_NIL) { ret nil; }
     val quri: str = json.quote(s.uri, alloc);
@@ -1641,14 +1641,14 @@ fun rename_group_json(s: *XRef, include_bind: bool, bind: token.Span, include_do
     ret buf::str;
 }
 
-# free_groups: free the first `n` owned changes-map entry strings in `groups`.
+# free the first `n` owned changes-map entry strings in `groups`
 fun free_groups(groups: *str, n: usize, alloc: *Allocator) {
     var i: usize = 0;
     for (i < n) { json.free_str(groups[i], alloc); i = i + 1; }
 }
 
-# emit_document_symbols: send a DocumentSymbol[] of the file's top-level decls.
-# takes ownership of `id_raw` and frees it.
+# send a DocumentSymbol[] of the file's top-level decls.
+# takes ownership of `id_raw` and frees it
 fun emit_document_symbols(an: Analyzed, alloc: *Allocator, id_raw: str) {
     val prefix: str = "{\"jsonrpc\":\"2.0\",\"id\":";
     val mid:    str = ",\"result\":[";
@@ -1700,8 +1700,8 @@ fun emit_document_symbols(an: Analyzed, alloc: *Allocator, id_raw: str) {
     json.free_str(id_raw, alloc);
 }
 
-# doc_symbol_json: render decl `did` as a DocumentSymbol object, or nil when the
-# decl has no nameable symbol (use / fwd / test / comptime / error).
+# render decl `did` as a DocumentSymbol object, or nil when the
+# decl has no nameable symbol (use / fwd / test / comptime / error)
 fun doc_symbol_json(an: Analyzed, did: id.DeclId, alloc: *Allocator) str {
     val d_opt: Option[*decl.Decl] = ast.get_decl(an.a, did);
     if (!is_some[*decl.Decl](d_opt)) { ret nil; }
@@ -1755,7 +1755,7 @@ fun doc_symbol_json(an: Analyzed, did: id.DeclId, alloc: *Allocator) str {
     ret buf::str;
 }
 
-# decl_lsp_kind: the LSP SymbolKind for a decl kind (documentSymbol).
+# the LSP SymbolKind for a decl kind (documentSymbol)
 fun decl_lsp_kind(kind: decl.DeclKind) i64 {
     if (kind == decl.DECL_KIND_FUN) { ret 12; }
     if (kind == decl.DECL_KIND_REC) { ret 23; }
@@ -1766,9 +1766,9 @@ fun decl_lsp_kind(kind: decl.DeclKind) i64 {
     ret 13;
 }
 
-# emit_completions: send a CompletionItem[] of the file's top-level names, each
+# send a CompletionItem[] of the file's top-level names, each
 # deduped by spelling so a name declared once appears once. takes ownership of
-# `id_raw` and frees it.
+# `id_raw` and frees it
 fun emit_completions(an: Analyzed, alloc: *Allocator, id_raw: str) {
     val prefix: str = "{\"jsonrpc\":\"2.0\",\"id\":";
     val mid:    str = ",\"result\":{\"isIncomplete\":false,\"items\":[";
@@ -1822,8 +1822,8 @@ fun emit_completions(an: Analyzed, alloc: *Allocator, id_raw: str) {
     json.free_str(id_raw, alloc);
 }
 
-# completion_first: whether symbol `sid` is a completion candidate AND the first
-# symbol with its name, so a name bound more than once is offered only once.
+# whether symbol `sid` is a completion candidate AND the first
+# symbol with its name, so a name bound more than once is offered only once
 fun completion_first(an: Analyzed, sid: res.SymbolId) bool {
     if (!features.completion_candidate(an.rr, sid)) { ret false; }
     val name: intern.StrId = an.rr.symbols[sid].name;
@@ -1835,7 +1835,7 @@ fun completion_first(an: Analyzed, sid: res.SymbolId) bool {
     ret true;
 }
 
-# completion_json: render symbol `sid` as a CompletionItem, or nil.
+# render symbol `sid` as a CompletionItem, or nil
 fun completion_json(an: Analyzed, sid: res.SymbolId, alloc: *Allocator) str {
     val sym: *res.Symbol = ?an.rr.symbols[sid];
     val no: Option[str] = intern.lookup(an.interner, sym.name);
@@ -1875,7 +1875,7 @@ fun completion_json(an: Analyzed, sid: res.SymbolId, alloc: *Allocator) str {
     ret buf::str;
 }
 
-# location_json: a Location object `{ uri, range }` for a span, or nil.
+# a Location object `{ uri, range }` for a span, or nil
 fun location_json(file: *src.SourceFile, uri: str, span: token.Span, alloc: *Allocator) str {
     val quri: str = json.quote(uri, alloc);
     if (quri == nil) { ret nil; }
@@ -1902,7 +1902,7 @@ fun location_json(file: *src.SourceFile, uri: str, span: token.Span, alloc: *All
     ret buf::str;
 }
 
-# range_json: a `{ start: {...}, end: {...} }` range object, or nil.
+# a `{ start: {...}, end: {...} }` range object, or nil
 fun range_json(range: positions.LspRange, alloc: *Allocator) str {
     val sl: str = json.format_usize(range.start_line, alloc);
     val sc: str = json.format_usize(range.start_char, alloc);
@@ -1935,8 +1935,8 @@ fun range_json(range: positions.LspRange, alloc: *Allocator) str {
     ret buf::str;
 }
 
-# loc_len: the JSON length one Location entry adds (plus a separating comma when
-# it is not the first), without retaining the rendering.
+# the JSON length one Location entry adds (plus a separating comma when
+# it is not the first), without retaining the rendering
 fun loc_len(file: *src.SourceFile, uri: str, span: token.Span, alloc: *Allocator, index: usize) usize {
     val loc: str = location_json(file, uri, span, alloc);
     if (loc == nil) { ret 0; }
@@ -1946,8 +1946,8 @@ fun loc_len(file: *src.SourceFile, uri: str, span: token.Span, alloc: *Allocator
     ret n;
 }
 
-# put_loc: write one Location entry (comma-separated) into `buf`, returning the
-# new offset.
+# write one Location entry (comma-separated) into `buf`, returning the
+# new offset
 fun put_loc(buf: *u8, off: usize, file: *src.SourceFile, uri: str, span: token.Span, alloc: *Allocator, index: usize) usize {
     val loc: str = location_json(file, uri, span, alloc);
     if (loc == nil) { ret off; }
@@ -1958,8 +1958,8 @@ fun put_loc(buf: *u8, off: usize, file: *src.SourceFile, uri: str, span: token.S
     ret o;
 }
 
-# edit_len: the JSON length one TextEdit adds (plus a separating comma when not
-# first), without retaining the rendering.
+# the JSON length one TextEdit adds (plus a separating comma when not
+# first), without retaining the rendering
 fun edit_len(file: *src.SourceFile, span: token.Span, qname: str, alloc: *Allocator, index: usize) usize {
     val ed: str = text_edit_json(file, span, qname, alloc);
     if (ed == nil) { ret 0; }
@@ -1969,7 +1969,7 @@ fun edit_len(file: *src.SourceFile, span: token.Span, qname: str, alloc: *Alloca
     ret n;
 }
 
-# put_edit: write one TextEdit entry (comma-separated) into `buf`.
+# write one TextEdit entry (comma-separated) into `buf`
 fun put_edit(buf: *u8, off: usize, file: *src.SourceFile, span: token.Span, qname: str, alloc: *Allocator, index: usize) usize {
     val ed: str = text_edit_json(file, span, qname, alloc);
     if (ed == nil) { ret off; }
@@ -1980,8 +1980,8 @@ fun put_edit(buf: *u8, off: usize, file: *src.SourceFile, span: token.Span, qnam
     ret o;
 }
 
-# text_edit_json: a `{ range, newText }` TextEdit replacing a span's range with
-# the already-quoted `qname`, or nil.
+# a `{ range, newText }` TextEdit replacing a span's range with
+# the already-quoted `qname`, or nil
 fun text_edit_json(file: *src.SourceFile, span: token.Span, qname: str, alloc: *Allocator) str {
     val rng: str = range_json(positions.range_of(file, span), alloc);
     if (rng == nil) { ret nil; }
@@ -2006,7 +2006,7 @@ fun text_edit_json(file: *src.SourceFile, span: token.Span, qname: str, alloc: *
     ret buf::str;
 }
 
-# reply_null: send a `result: null` response for the request id.
+# send a `result: null` response for the request id
 fun reply_null(alloc: *Allocator, id_raw: str) {
     val p1: str = "{\"jsonrpc\":\"2.0\",\"id\":";
     val p2: str = ",\"result\":null}";
@@ -2014,7 +2014,7 @@ fun reply_null(alloc: *Allocator, id_raw: str) {
     json.free_str(id_raw, alloc);
 }
 
-# reply_empty_array: send a `result: []` response for the request id.
+# send a `result: []` response for the request id
 fun reply_empty_array(alloc: *Allocator, id_raw: str) {
     val p1: str = "{\"jsonrpc\":\"2.0\",\"id\":";
     val p2: str = ",\"result\":[]}";
@@ -2022,7 +2022,7 @@ fun reply_empty_array(alloc: *Allocator, id_raw: str) {
     json.free_str(id_raw, alloc);
 }
 
-# reply_empty_edit: send an empty WorkspaceEdit (`changes: {}`) for the id.
+# send an empty WorkspaceEdit (`changes: {}`) for the id
 fun reply_empty_edit(alloc: *Allocator, id_raw: str) {
     val p1: str = "{\"jsonrpc\":\"2.0\",\"id\":";
     val p2: str = ",\"result\":{\"changes\":{}}}";
@@ -2030,7 +2030,7 @@ fun reply_empty_edit(alloc: *Allocator, id_raw: str) {
     json.free_str(id_raw, alloc);
 }
 
-# send6: frame and send the concatenation of up to six fragments (nil skipped).
+# frame and send the concatenation of up to six fragments (nil skipped)
 fun send6(alloc: *Allocator, a: str, b: str, c: str, d: str, e: str, f: str, g: str) {
     val total: usize = slen(a) + slen(b) + slen(c) + slen(d) + slen(e) + slen(f) + slen(g);
     val r: Result[*u8, str] = allocate[u8](alloc, total + 1);
@@ -2049,13 +2049,13 @@ fun send6(alloc: *Allocator, a: str, b: str, c: str, d: str, e: str, f: str, g: 
     deallocate[u8](alloc, buf, total + 1);
 }
 
-# slen: length of `s`, treating nil as 0.
+# length of `s`, treating nil as 0
 fun slen(s: str) usize {
     if (s == nil) { ret 0; }
     ret str_len(s);
 }
 
-# append: copy `s` into `buf` at `offset`, returning the new offset.
+# copy `s` into `buf` at `offset`, returning the new offset
 fun append(buf: *u8, offset: usize, s: str) usize {
     if (s == nil) { ret offset; }
     val n: usize = str_len(s);
@@ -2063,7 +2063,7 @@ fun append(buf: *u8, offset: usize, s: str) usize {
     ret offset + n;
 }
 
-# free4: free four owned strings.
+# free four owned strings
 fun free4(a: str, b: str, c: str, d: str, alloc: *Allocator) {
     json.free_str(a, alloc);
     json.free_str(b, alloc);

--- a/src/language.mach
+++ b/src/language.mach
@@ -15,7 +15,7 @@
 # through a shared use-site index (`build_refs` over `project.module_view`):
 # references reports every use-site across all modules; rename rewrites the
 # declaration plus every importer (body references and `use` path leaves), but
-# only for symbols declared in the user's own project — a dependency's
+# only for symbols declared in the user's own project - a dependency's
 # declaration is not the editor's to rewrite. completion offers the file's
 # module-level names, `use` aliases, and the primitive types (see
 # `features.completion_candidate`).
@@ -96,7 +96,7 @@ pub fun hover(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocat
     val ro: Option[features.SymbolRef] = features.ref_at(an.a, an.rr, an.own, offset);
     if (!is_some[features.SymbolRef](ro)) {
         # name resolution leaves a value-field access unbound, so a cursor on a
-        # field name yields no SymbolRef — fall through to the type-driven field
+        # field name yields no SymbolRef - fall through to the type-driven field
         # hover before giving up.
         if (field_hover(ws, alloc, ?an, offset, id_raw)) { ret; }
         reply_null(alloc, id_raw); ret;
@@ -139,8 +139,8 @@ fun reply_hover(alloc: *Allocator, id_raw: str, file: *src.SourceFile, name_span
 # when the symbol-table pivot finds nothing at `offset`. types the referencing
 # expression (a member access `foo.bar` or a struct-literal field name
 # `T{ bar: ... }`), peels it to its record site, and renders the field's name,
-# its declared type, and — when the record's doc block carries a matching
-# `# <name>: <desc>` component — that description. cross-module aware: the record
+# its declared type, and - when the record's doc block carries a matching
+# `# <name>: <desc>` component - that description. cross-module aware: the record
 # may be declared in a dependency module, in which case its Ast / file / doc all
 # come from the loaded module. emits the hover over the cursor's field-name span
 # and returns true when a field was rendered; returns false (without replying) so
@@ -249,7 +249,7 @@ fun doc_desc_prose(file: *src.SourceFile, span: token.Span, alloc: *Allocator) s
     ret buf::str;
 }
 
-# assemble the field hover Markdown — a fenced `mach` block
+# assemble the field hover Markdown - a fenced `mach` block
 # of `name: type` (or just `name` when the type is unavailable), followed by the
 # description prose as a paragraph when present. nil on allocation failure
 fun compose_field_hover(name: str, ty: str, doc: str, alloc: *Allocator) str {
@@ -282,8 +282,8 @@ fun compose_field_hover(name: str, ty: str, doc: str, alloc: *Allocator) str {
 }
 
 # a fenced `mach` code block rendering the symbol at hover. it
-# shows the declaration header as written — read from the buffer for a local
-# symbol, from the defining dependency module's file for a cross-module one —
+# shows the declaration header as written - read from the buffer for a local
+# symbol, from the defining dependency module's file for a cross-module one -
 # falling back to the symbol kind and name when no decl header is available. the
 # decl's doc comment, if any, follows the block as prose, read from the same
 # Site so a cross-module symbol's docs render too
@@ -335,7 +335,7 @@ fun hover_markdown(ws: *project.Workspace, an: Analyzed, sym: *res.Symbol, uri: 
 # paragraph; when a `# ---` component block follows, a thematic break (`---`
 # fenced by blank lines so CommonMark reads a horizontal rule, not a setext
 # heading) precedes each `# <name>: <desc>` component rendered as a
-# `- **name** — desc` list item. because `Decl.doc` excludes the decl's `#[...]`
+# `- **name** - desc` list item. because `Decl.doc` excludes the decl's `#[...]`
 # attribute lines, no attribute syntax can leak into the rendering. one
 # `doc_render` walk both sizes and fills the buffer, so the two passes cannot
 # diverge and the allocation is str_len + 1 as `json.free_str` expects. nil on an
@@ -475,7 +475,7 @@ pub fun definition(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Al
     val ro: Option[features.SymbolRef] = features.ref_at(an.a, an.rr, an.own, offset);
     if (!is_some[features.SymbolRef](ro)) {
         # name resolution leaves a value-field access unbound, so a cursor on a
-        # field name yields no SymbolRef — fall through to the type-driven field
+        # field name yields no SymbolRef - fall through to the type-driven field
         # path before giving up.
         if (field_definition(ws, alloc, ?an, uri, offset, id_raw)) { ret; }
         reply_null(alloc, id_raw); ret;
@@ -560,7 +560,7 @@ fun field_definition(ws: *project.Workspace, alloc: *Allocator, an: *Analyzed, u
     ret false;
 }
 
-# a field declaration the cursor sits on at its own definition site —
+# a field declaration the cursor sits on at its own definition site -
 # the field name span resolves to itself for go-to-definition
 # ---
 # name: byte span of the field name in the buffer
@@ -636,8 +636,8 @@ fun reply_result(alloc: *Allocator, id_raw: str, result: str) {
 # of a SymbolRef for the field references / rename / prepareRename paths. carries
 # the field's cross-module identity (`key`), the record's declaring site (`rs`,
 # for the field-declaration span and its doc block), and whether that site is the
-# active buffer (so the declaring module's edits — the field decl name and the doc
-# component — are placed in the buffer's URI rather than a loaded module's)
+# active buffer (so the declaring module's edits - the field decl name and the doc
+# component - are placed in the buffer's URI rather than a loaded module's)
 # ---
 # key:            the field's cross-module identity
 # rs:             the record's declaring site (field range, Ast, file, doc)
@@ -707,7 +707,7 @@ fun make_field_target(an: *Analyzed, rs: project.RecordSite, field_name: token.S
     ret t;
 }
 
-# one module contributing field references — its Ast, SemaResult (for
+# one module contributing field references - its Ast, SemaResult (for
 # typing each host expression), source file, document URI, and whether it is the
 # record's declaring module (so its field-declaration name span and doc component
 # are emitted). the active buffer is always `out[0]`; each other loaded module
@@ -725,7 +725,7 @@ rec FieldXRef {
 # each subsequent entry is a loaded module whose SemaResult types at least one
 # reference to the field, skipping the buffer's on-disk twin so its live edits are
 # not double-counted. every module is walked (a field is reachable wherever its
-# record is imported), so this is not gated on project ownership — the rename gate
+# record is imported), so this is not gated on project ownership - the rename gate
 # is applied separately by the caller
 # ---
 # ws:    the workspace
@@ -783,7 +783,7 @@ fun free_field_refs(ws: *project.Workspace, refs: *FieldXRef, n: usize) {
 }
 
 # feed every site naming the keyed field in module `s` to the
-# sink — every member access / struct-literal init whose host type peels to the
+# sink - every member access / struct-literal init whose host type peels to the
 # keyed record, plus (when `s` is the record's declaring module) the field
 # declaration's own name span and, for rename, the matching `# <field>:` doc
 # component name token. the span set is computed by the pure
@@ -834,7 +834,7 @@ fun field_references(ws: *project.Workspace, alloc: *Allocator, an: *Analyzed, u
 }
 
 # the type-driven rename path for a record / union field. refuses
-# (returns false without replying — the caller emits an empty edit) when the
+# (returns false without replying - the caller emits an empty edit) when the
 # field's record is declared in a vendored dependency: such a declaration is not
 # the editor's to rewrite. otherwise resolves the field, walks every loaded
 # module, and emits a WorkspaceEdit replacing every member-access / struct-literal
@@ -861,7 +861,7 @@ fun field_rename(ws: *project.Workspace, alloc: *Allocator, an: *Analyzed, uri: 
     ret true;
 }
 
-# whether the field's record is the editor's to rewrite —
+# whether the field's record is the editor's to rewrite -
 # the same gate the symbol rename `renameable` applies, keyed on the record's
 # declaring module. a record declared in a loaded module keys directly on
 # `is_project_module`; a record declared in the active buffer keys on the buffer's
@@ -1021,7 +1021,7 @@ fun field_rename_group_json(s: *FieldXRef, ti: *type.TypeInterner, t: FieldTarge
 }
 
 # answer textDocument/references with every Location resolving to
-# the symbol at the cursor — its declaration plus every use-site across the
+# the symbol at the cursor - its declaration plus every use-site across the
 # loaded project graph (the requesting buffer and every other module that
 # references the symbol). empty when the position is not on a resolved symbol
 pub fun references(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
@@ -1036,7 +1036,7 @@ pub fun references(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Al
     val ro: Option[features.SymbolRef] = features.ref_at(an.a, an.rr, an.own, offset);
     if (!is_some[features.SymbolRef](ro)) {
         # name resolution leaves a value-field access unbound, so a cursor on a
-        # field name yields no SymbolRef — fall through to the type-driven field
+        # field name yields no SymbolRef - fall through to the type-driven field
         # references before giving up.
         if (field_references(ws, alloc, ?an, uri, offset, id_raw)) { ret; }
         reply_empty_array(alloc, id_raw); ret;
@@ -1066,13 +1066,13 @@ pub fun references(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Al
 
 # answer textDocument/rename with a WorkspaceEdit replacing every
 # reference to the symbol at the cursor with the requested new name, across the
-# whole project graph — the declaring file plus every module that imports or
+# whole project graph - the declaring file plus every module that imports or
 # uses it (including each importer's `use` path leaf). confined to symbols
 # declared in the user's own project: a dependency's declaration is not the
 # editor's to rewrite (whether referenced cross-module or opened as the buffer
 # itself), so those yield an empty edit. an empty edit is also returned when a
 # module-scope pub symbol's cross-file identity cannot be recovered from its
-# stale on-disk twin — a buffer-local edit there would be a partial rename
+# stale on-disk twin - a buffer-local edit there would be a partial rename
 pub fun rename(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
     val id_raw: str = json.extract_raw(body, "\"id\"", alloc);
     if (id_raw == nil) { ret; }
@@ -1087,7 +1087,7 @@ pub fun rename(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Alloca
 
     val ro: Option[features.SymbolRef] = features.ref_at(an.a, an.rr, an.own, offset);
     if (!is_some[features.SymbolRef](ro)) {
-        # a cursor on a field name yields no SymbolRef — fall through to the
+        # a cursor on a field name yields no SymbolRef - fall through to the
         # type-driven field rename, which gates on the record's ownership.
         if (field_rename(ws, alloc, ?an, uri, offset, id_raw, new_name)) { json.free_str(new_name, alloc); ret; }
         reply_empty_edit(alloc, id_raw); json.free_str(new_name, alloc); ret;
@@ -1177,7 +1177,7 @@ pub fun prepare_rename(ws: *project.Workspace, es: *editor.EditorSession, alloc:
 
     val ro: Option[features.SymbolRef] = features.ref_at(an.a, an.rr, an.own, offset);
     if (!is_some[features.SymbolRef](ro)) {
-        # a cursor on a field name yields no SymbolRef — accept it when it resolves
+        # a cursor on a field name yields no SymbolRef - accept it when it resolves
         # to a field of a project-owned record (the same gate field rename uses)
         var name_span: token.Span;
         if (field_prepare_span(ws, ?an, uri, offset, ?name_span)) {
@@ -1249,9 +1249,9 @@ fun binding_span(an: Analyzed, sid: res.SymbolId, out: *token.Span) bool {
 # whether the symbol at the cursor may be renamed. a cross-module
 # symbol must be declared in a project-owned module, and a buffer-local symbol
 # is only renameable when the buffer itself is the editor's to rewrite: its
-# on-disk twin (when the buffer is a loaded module's file — e.g. a dependency
+# on-disk twin (when the buffer is a loaded module's file - e.g. a dependency
 # source opened via go-to-definition, whose symbols all resolve buffer-locally)
-# must also be project-owned. a buffer with no twin renames buffer-local — unless
+# must also be project-owned. a buffer with no twin renames buffer-local - unless
 # its governing root is a vendored dependency project, whose every file is
 # read-only even outside that root's own graph closure (a vendored dep source the
 # outer project never imports still routes to its own vendored root)
@@ -1262,7 +1262,7 @@ fun renameable(ws: *project.Workspace, root: *project.Root, uri: str, sym: *res.
     ret project.is_project_module(ws, root, unwrap[sess.ModuleId](twin_o));
 }
 
-# one file contributing references to a target symbol — its Ast, resolve
+# one file contributing references to a target symbol - its Ast, resolve
 # tables, source file, document URI, and the local SymbolId every reference in
 # it resolves to. the active buffer is always the first XRef (live resolve,
 # borrowed URI); each other loaded module that references the symbol is another
@@ -1283,7 +1283,7 @@ rec XRef {
 # BRIDGE_OK:     a canonical (origin, decl) identity resolved; the graph walk
 #                ran and cross-file results are included.
 # BRIDGE_FAILED: the symbol is a module-scope pub declaration but its identity
-#                could not be recovered from the on-disk twin — e.g. unsaved
+#                could not be recovered from the on-disk twin - e.g. unsaved
 #                edits renamed the declaration, so the stale twin does not
 #                export the name. rename must refuse rather than emit the
 #                compile-breaking partial edit a buffer-local fallback would be.
@@ -1300,7 +1300,7 @@ val BRIDGE_FAILED: i64 = 2;
 # passes false to include dependency modules. the canonical identity is read
 # directly for a cross-module reference; for a buffer-local symbol it is bridged
 # through the buffer's on-disk twin, but only when the symbol is a module-scope
-# pub declaration — a block-local binding that shadows a pub symbol's name, or a
+# pub declaration - a block-local binding that shadows a pub symbol's name, or a
 # non-pub declaration, has no importers and must not bridge to one. the bridge
 # outcome is reported in `status` (see BRIDGE_*) so rename can refuse on a
 # failed bridge instead of degrading to a partial buffer-local edit
@@ -1466,7 +1466,7 @@ fun sink_emit(k: *WalkSink, file: *src.SourceFile, uri: str, span: token.Span) {
     k.count = k.count + 1;
 }
 
-# feed every reference to `s.target` in source `s` to the sink — the
+# feed every reference to `s.target` in source `s` to the sink - the
 # declaration name, `use` / `fwd` import-path leaves, and the body (expr / type)
 # use-sites, plus the active buffer's param / generic binding when `include_bind`
 # and its owning decl's matching doc-component name token when `include_doc`. body

--- a/src/language.mach
+++ b/src/language.mach
@@ -253,9 +253,9 @@ fun doc_desc_prose(file: *src.SourceFile, span: token.Span, alloc: *Allocator) s
 # of `name: type` (or just `name` when the type is unavailable), followed by the
 # description prose as a paragraph when present. nil on allocation failure
 fun compose_field_hover(name: str, ty: str, doc: str, alloc: *Allocator) str {
-    val pre:  str = "```mach\n";
-    val post: str = "\n```";
-    val sep:  str = "\n\n";
+    val pre:   str = "```mach\n";
+    val post:  str = "\n```";
+    val sep:   str = "\n\n";
     val colon: str = ": ";
 
     var total: usize = str_len(pre) + str_len(name) + str_len(post);
@@ -713,10 +713,10 @@ fun make_field_target(an: *Analyzed, rs: project.RecordSite, field_name: token.S
 # are emitted). the active buffer is always `out[0]`; each other loaded module
 # that types a reference is another (owned `file://` URI freed by free_field_refs)
 rec FieldXRef {
-    a:        *ast.Ast;
-    sr:       *sema.SemaResult;
-    file:     *src.SourceFile;
-    uri:      str;
+    a:         *ast.Ast;
+    sr:        *sema.SemaResult;
+    file:      *src.SourceFile;
+    uri:       str;
     declaring: bool;
 }
 

--- a/src/main.mach
+++ b/src/main.mach
@@ -1,4 +1,4 @@
-# mls.main: mach language server entry point.
+# mach language server entry point
 #
 # initializes the server over a page-backed allocator and runs the JSON-RPC
 # message loop over stdin/stdout until the client shuts the server down. all

--- a/src/positions.mach
+++ b/src/positions.mach
@@ -2,8 +2,8 @@
 #
 # the LSP addresses text by 0-based (line, character); the compiler addresses
 # it by byte offset (and reports 1-based line/col via `source.position`). the
-# language features pivot on byte offset — `ast.offset_to_*` takes an offset
-# and the resolve side tables index by node id — so every request first maps
+# language features pivot on byte offset - `ast.offset_to_*` takes an offset
+# and the resolve side tables index by node id - so every request first maps
 # the incoming LSP position to an offset, and every response maps a `token.Span`
 # back to an LSP range. these helpers are the single conversion point.
 #
@@ -162,7 +162,7 @@ fun u8_seq_len(b: u8) usize {
     ret 4;
 }
 
-# the UTF-16 code units the codepoint led by `b` encodes to — 2 for a
+# the UTF-16 code units the codepoint led by `b` encodes to - 2 for a
 # 4-byte sequence (a surrogate pair), 1 otherwise
 fun u16_units(b: u8) usize {
     if (b >= 0xF0) { ret 2; }

--- a/src/positions.mach
+++ b/src/positions.mach
@@ -1,4 +1,4 @@
-# mls.positions: byte-offset <-> LSP position conversions and span helpers.
+# byte-offset <-> LSP position conversions and span helpers
 #
 # the LSP addresses text by 0-based (line, character); the compiler addresses
 # it by byte offset (and reports 1-based line/col via `source.position`). the
@@ -36,7 +36,7 @@ use mem: std.memory;
 use src:   mach.lang.source;
 use token: mach.lang.fe.token;
 
-# LspRange: a 0-based LSP range, the form a `Location` / hover range needs.
+# a 0-based LSP range, the form a `Location` / hover range needs
 # ---
 # start_line: 0-based start line
 # start_char: 0-based start character (UTF-16 code-unit column)
@@ -49,9 +49,9 @@ pub rec LspRange {
     end_char:   usize;
 }
 
-# offset_at: the byte offset of a 0-based LSP (line, character) in `file`, or
+# the byte offset of a 0-based LSP (line, character) in `file`, or
 # none when the line is out of range. the UTF-16 character column is resolved
-# to a byte offset by walking the line's UTF-8, clamped to the line's end.
+# to a byte offset by walking the line's UTF-8, clamped to the line's end
 # ---
 # file: the source file the position addresses
 # line: 0-based LSP line
@@ -68,9 +68,9 @@ pub fun offset_at(file: *src.SourceFile, line: usize, ch: usize) Option[usize] {
     ret some[usize](u16_col_to_byte(file, ls_off, le_off, ch));
 }
 
-# range_of: the LSP range covering a byte span in `file`. a zero-length span
+# the LSP range covering a byte span in `file`. a zero-length span
 # yields an empty range at its offset. columns are reported as UTF-16 code-unit
-# offsets within their line.
+# offsets within their line
 # ---
 # file: the source file the span addresses
 # span: the byte range to convert
@@ -90,9 +90,9 @@ pub fun range_of(file: *src.SourceFile, span: token.Span) LspRange {
     ret r;
 }
 
-# span_text: an owned copy of the source text a span covers, nil-terminated, or
+# an owned copy of the source text a span covers, nil-terminated, or
 # nil on an empty span / allocation failure. used to render the spelling of a
-# decl name or type as written.
+# decl name or type as written
 # ---
 # file:  the source file the span addresses
 # span:  the byte range to copy
@@ -113,8 +113,8 @@ pub fun span_text(file: *src.SourceFile, span: token.Span, alloc: *Allocator) st
     ret buf::str;
 }
 
-# u16_col: the 0-based UTF-16 code-unit column of a byte `offset` on its
-# 1-based `line`, measured by walking the line prefix's UTF-8.
+# the 0-based UTF-16 code-unit column of a byte `offset` on its
+# 1-based `line`, measured by walking the line prefix's UTF-8
 # ---
 # file:   the source file the offset addresses
 # line:   1-based line the offset falls on (as `source.position` reports)
@@ -131,9 +131,9 @@ fun u16_col(file: *src.SourceFile, line: usize, offset: usize) usize {
     ret units;
 }
 
-# u16_col_to_byte: the byte offset of a 0-based UTF-16 code-unit column on the
+# the byte offset of a 0-based UTF-16 code-unit column on the
 # line spanning [start, end), or `end` when the column runs past the line. a
-# column landing inside a codepoint snaps to that codepoint's start.
+# column landing inside a codepoint snaps to that codepoint's start
 # ---
 # file:  the source file
 # start: byte offset of the line's first byte
@@ -153,8 +153,8 @@ fun u16_col_to_byte(file: *src.SourceFile, start: usize, end: usize, col: usize)
     ret o;
 }
 
-# u8_seq_len: the byte length of the UTF-8 sequence led by `b`; a stray
-# continuation byte counts as 1 so malformed input still advances.
+# the byte length of the UTF-8 sequence led by `b`; a stray
+# continuation byte counts as 1 so malformed input still advances
 fun u8_seq_len(b: u8) usize {
     if (b < 0xC0) { ret 1; }
     if (b < 0xE0) { ret 2; }
@@ -162,14 +162,14 @@ fun u8_seq_len(b: u8) usize {
     ret 4;
 }
 
-# u16_units: the UTF-16 code units the codepoint led by `b` encodes to — 2 for a
-# 4-byte sequence (a surrogate pair), 1 otherwise.
+# the UTF-16 code units the codepoint led by `b` encodes to — 2 for a
+# 4-byte sequence (a surrogate pair), 1 otherwise
 fun u16_units(b: u8) usize {
     if (b >= 0xF0) { ret 2; }
     ret 1;
 }
 
-# dec: clamp `n - 1` at 0 (1-based compiler position -> 0-based LSP position).
+# clamp `n - 1` at 0 (1-based compiler position -> 0-based LSP position)
 fun dec(n: usize) usize {
     if (n == 0) { ret 0; }
     ret n - 1;

--- a/src/project.mach
+++ b/src/project.mach
@@ -1,4 +1,4 @@
-# mls.project: the per-root workspace graphs that power cross-module analysis.
+# the per-root workspace graphs that power cross-module analysis
 #
 # the editor surface (`mach.lang.editor`) resolves one buffer in isolation with
 # an empty dependency set, so any symbol imported through a `use` binds to
@@ -123,10 +123,10 @@ use json:      mls.json;
 use trace:     mls.trace;
 use mtypes:    mls.types;
 
-# Site: where a resolved symbol's declaration lives — the Ast and SourceFile to
+# where a resolved symbol's declaration lives — the Ast and SourceFile to
 # read its spans from, and the document URI to report. for a buffer-local symbol
 # this is the request's own buffer; for a cross-module symbol it is the defining
-# dependency module's on-disk file.
+# dependency module's on-disk file
 # ---
 # a:     Ast owning the symbol's decl (spans are decl-ids into this tree)
 # file:  SourceFile backing `a` (byte offset <-> position, span text)
@@ -139,7 +139,7 @@ pub rec Site {
     owned: bool;
 }
 
-# Cached: one buffer's dep-aware resolve result — and, lazily, its sema result —
+# one buffer's dep-aware resolve result — and, lazily, its sema result —
 # stamped with the Ast it was resolved from and the generation of the root build
 # it resolved against. the editor replaces a buffer's `*ast.Ast` on every text
 # update (`drop_analysis`), so Ast pointer identity catches a text edit — the same
@@ -147,7 +147,7 @@ pub rec Site {
 # cross-root or post-reload staleness, since a result resolved against one build
 # never matches a different build's stamp. the resolve result is populated on every
 # resolve; the sema result is populated only when a type-aware feature first asks
-# for it (`sema_doc`), so the diagnostics publish path never pays for sema.
+# for it (`sema_doc`), so the diagnostics publish path never pays for sema
 # ---
 # rr:   the cached dep-aware ResolveResult, owned by the cache
 # sr:   the cached SemaResult for the same Ast / gen, or nil until first demanded
@@ -160,9 +160,9 @@ rec Cached {
     gen: u32;
 }
 
-# Root: one project root open in the session and the dependency graph built from
+# one project root open in the session and the dependency graph built from
 # its manifest's default-target import closure. a slot with a nil path is dead
-# and reusable.
+# and reusable
 # ---
 # path:           owned absolute project-root path (the dir holding `mach.toml`)
 # loaded:         whether the graph built; a tracked !loaded slot is a remembered
@@ -213,7 +213,7 @@ pub rec Root {
     sema_loaded:    bool;
 }
 
-# Workspace: the session's project roots plus the per-buffer resolve cache.
+# the session's project roots plus the per-buffer resolve cache
 # ---
 # s:            the compiler session. feature code must reach its safe services
 #               through `interner` / `sources` and never read this field: its
@@ -255,7 +255,7 @@ pub rec Workspace {
     sema_epoch:   u32;
 }
 
-# init: construct an empty workspace over the server's sessions.
+# construct an empty workspace over the server's sessions
 # ---
 # s:     compiler session the graphs load into
 # es:    editor session whose buffers are re-resolved against the graphs
@@ -279,7 +279,7 @@ pub fun init(s: *sess.Session, es: *editor.EditorSession, alloc: *Allocator) Wor
     ret w;
 }
 
-# interner: the session's shared string interner — the append-only symbol-name
+# the session's shared string interner — the append-only symbol-name
 # registry feature code resolves StrIds through. handed out instead of the whole
 # session so no feature signature carries one: the session's per-build module
 # registries are clobbered on every project load, and the interner and source
@@ -293,10 +293,10 @@ pub fun interner(w: *Workspace) *intern.Interner {
     ret ?w.s.interner;
 }
 
-# sources: the session's source-file registry, for resolving a FileId to its
+# the session's source-file registry, for resolving a FileId to its
 # SourceFile (text + line index). the other safe-to-read session service feature
 # and diagnostics code needs; see `interner` for why the whole session is kept
-# out of feature signatures.
+# out of feature signatures
 # ---
 # w:   the workspace
 # ret: the session's source map
@@ -304,11 +304,11 @@ pub fun sources(w: *Workspace) *src.SourceMap {
     ret ?w.s.sources;
 }
 
-# type_interner: the session's type interner, for peeling a record / union TypeId
+# the session's type interner, for peeling a record / union TypeId
 # to its nominal declaration site (the cross-module field-reference walk reads
 # each module's typing and matches the field's host type against its key through
 # it). the narrow read the feature layer makes; see `interner` for why the whole
-# session is kept out of feature signatures.
+# session is kept out of feature signatures
 # ---
 # w:   the workspace
 # ret: the session's type interner
@@ -316,10 +316,10 @@ pub fun type_interner(w: *Workspace) *type.TypeInterner {
     ret ?w.s.types;
 }
 
-# set_watch_active: record that the client delivers
+# record that the client delivers
 # workspace/didChangeWatchedFiles for the registered manifest / lockfile /
 # source globs, so invalidation is event-driven and the per-request
-# manifest-mtime fallback check is skipped.
+# manifest-mtime fallback check is skipped
 # ---
 # w:  the workspace
 # on: whether file watching is active
@@ -327,11 +327,11 @@ pub fun set_watch_active(w: *Workspace, on: bool) {
     w.watch_active = on;
 }
 
-# load_epoch: the workspace's current load epoch — a counter bumped on every
+# the workspace's current load epoch — a counter bumped on every
 # successful root build. the server snapshots it around a feature request; a
 # change means a lazy project load completed, so the open buffers it now governs
 # can have their diagnostics re-published with semantic (dep-aware) results
-# without waiting for an edit (#96).
+# without waiting for an edit (#96)
 # ---
 # w:   the workspace
 # ret: the current load epoch
@@ -339,12 +339,12 @@ pub fun load_epoch(w: *Workspace) u32 {
     ret w.load_epoch;
 }
 
-# sema_epoch: the workspace's current sema epoch — a counter bumped whenever a
+# the workspace's current sema epoch — a counter bumped whenever a
 # root's dep closure finishes typing (ensure_sema). the server snapshots it around
 # a feature request alongside the load epoch; a change means a type-aware feature
 # lazily sema'd a closure, so the open buffers it governs can be re-published with
 # their semantic diagnostics — which the load-free publish path could not produce
-# while the closure was still un-sema'd — without waiting for an edit (#113).
+# while the closure was still un-sema'd — without waiting for an edit (#113)
 # ---
 # w:   the workspace
 # ret: the current sema epoch
@@ -352,12 +352,12 @@ pub fun sema_epoch(w: *Workspace) u32 {
     ret w.sema_epoch;
 }
 
-# sema_ready: whether `root`'s loaded dep closure has already been sema'd, so its
+# whether `root`'s loaded dep closure has already been sema'd, so its
 # retained per-module typing exists. a load-free check: it never triggers a build
 # or ensure_sema. the diagnostics publish path gates buffer sema on this — only on
 # a ready root is sema_doc cheap and correct (one module against retained dep
 # typing); a loaded-but-un-sema'd root publishes parse + resolve only, keeping
-# open/edit instant (#96). false for a nil, unloaded, or un-sema'd root.
+# open/edit instant (#96). false for a nil, unloaded, or un-sema'd root
 # ---
 # root: the candidate governing root, or nil
 # ret:  true when sema has run over root's current build
@@ -366,7 +366,7 @@ pub fun sema_ready(root: *Root) bool {
     ret root.loaded && root.sema_loaded;
 }
 
-# dnit: release the resolve cache and every loaded root.
+# release the resolve cache and every loaded root
 # ---
 # w: workspace to tear down; all owned fields are zeroed
 pub fun dnit(w: *Workspace) {
@@ -388,10 +388,10 @@ pub fun dnit(w: *Workspace) {
     w.root_cap = 0;
 }
 
-# resolve_doc: the buffer's dep-aware ResolveResult under `root` (nil for a
+# the buffer's dep-aware ResolveResult under `root` (nil for a
 # single-file document). returns the cached result when the buffer's Ast is
 # unchanged since the last resolve; otherwise parses if needed and re-resolves
-# with `res.resolve` against the root's dep set (empty when root is nil).
+# with `res.resolve` against the root's dep set (empty when root is nil)
 # ---
 # w:    the workspace
 # root: the root governing the document (from `root_for`), or nil
@@ -411,12 +411,12 @@ pub fun resolve_doc(w: *Workspace, root: *Root, fid: src.FileId) Result[*res.Res
     ret resolve_fresh(w, root, fid, a);
 }
 
-# resolve_fresh: re-resolve buffer `a` (FileId `fid`) against `root`'s dep set
+# re-resolve buffer `a` (FileId `fid`) against `root`'s dep set
 # unconditionally — the cache-miss core shared by `resolve_doc` (after its cache
 # check) and `diagnose_doc` (which forces a fresh parse to repopulate the session
 # DiagList). drops any prior cached result for `fid`, resolves with `res.resolve`,
 # and caches the new result. the resolve's diagnostics land on the session
-# DiagList, which `diagnose_doc` then publishes.
+# DiagList, which `diagnose_doc` then publishes
 # ---
 # w:    the workspace
 # root: the root governing the document, or nil for a single-file document
@@ -428,7 +428,7 @@ fun resolve_fresh(w: *Workspace, root: *Root, fid: src.FileId, a: *ast.Ast) Resu
 
     # resolve under the same comptime environment the project's own modules
     # were resolved under, so target-gated imports ($if on os / arch) fold the
-    # same way; neutral host defaults outside a project.
+    # same way; neutral host defaults outside a project
     var deps: *res.ResolveDeps = ?w.empty;
     var ctx: comptime.ComptimeCtx;
     if (root != nil) {
@@ -463,7 +463,7 @@ fun resolve_fresh(w: *Workspace, root: *Root, fid: src.FileId, a: *ast.Ast) Resu
     ret ok[*res.ResolveResult, str](slot);
 }
 
-# sema_doc: the buffer's SemaResult under `root` — its per-expression typing,
+# the buffer's SemaResult under `root` — its per-expression typing,
 # computed against the root's dep-closure typing. the type-aware twin of
 # `resolve_doc`: it first resolves the buffer (populating the resolve cache entry),
 # then, on a cache miss for the same Ast / build, lazily sema's the whole root
@@ -473,7 +473,7 @@ fun resolve_fresh(w: *Workspace, root: *Root, fid: src.FileId, a: *ast.Ast) Resu
 # unedited buffer reuses it. heavy on a cold root (the first call pays for the whole
 # dep closure), so it is reached only from a type-aware feature, never the
 # diagnostics publish path. `root` must be non-nil: a single-file document has no
-# dep typing to check against. the returned pointer is owned by the cache.
+# dep typing to check against. the returned pointer is owned by the cache
 # ---
 # w:    the workspace
 # root: the loaded root governing the document (non-nil)
@@ -523,13 +523,13 @@ pub fun sema_doc(w: *Workspace, root: *Root, fid: src.FileId) Result[*sema.SemaR
     ret ok[*sema.SemaResult, str](slot);
 }
 
-# build_full_sema_deps: assemble a SemaDeps spanning EVERY sema'd module of
+# assemble a SemaDeps spanning EVERY sema'd module of
 # `root`, for typing the active buffer (which may `use` any loaded module). each
 # entry borrows the module's retained decl_type snapshot; an un-sema'd module
 # contributes a decl-type-less entry (a lookup against it yields TYPE_ERROR, like a
 # miss). writes the deps into `out`, leaving it empty on allocation failure or when
 # the root has no retained sema. the borrowed arrays are owned by the Root's
-# SemaResults, so the result must be released with `free_sema_deps`.
+# SemaResults, so the result must be released with `free_sema_deps`
 fun build_full_sema_deps(w: *Workspace, root: *Root, out: *sema.SemaDeps) {
     out.entries = nil;
     out.count   = 0;
@@ -553,14 +553,14 @@ fun build_full_sema_deps(w: *Workspace, root: *Root, out: *sema.SemaDeps) {
     }
 }
 
-# cache_slot: the Cached entry for `fid`, or nil when out of range. the borrowed
-# slot handle sema_doc uses to attach a buffer's SemaResult to its resolve entry.
+# the Cached entry for `fid`, or nil when out of range. the borrowed
+# slot handle sema_doc uses to attach a buffer's SemaResult to its resolve entry
 fun cache_slot(w: *Workspace, fid: src.FileId) *Cached {
     if (w.cache == nil || fid::u32 >= w.cache_len) { ret nil; }
     ret ?w.cache[fid::u32];
 }
 
-# diagnose_doc: parse and dep-aware-resolve the buffer governed by `root`,
+# parse and dep-aware-resolve the buffer governed by `root`,
 # returning the session DiagList populated with both its syntactic and its
 # name-resolution diagnostics. resolving against `root.deps` — the same dep set
 # go-to-definition uses — is what makes an import of a module outside the
@@ -571,7 +571,7 @@ fun cache_slot(w: *Workspace, fid: src.FileId) *Cached {
 # same unedited buffer reuses it. the fresh parse resets the session DiagList and
 # emits this buffer's lex / parse diagnostics; the resolve appends its own.
 # `root` must be non-nil: a single-file document keeps the editor's parse-only
-# diagnostics so its cross-module `use`s are not flagged against an empty dep set.
+# diagnostics so its cross-module `use`s are not flagged against an empty dep set
 # ---
 # w:    the workspace
 # root: the root governing the document (non-nil)
@@ -589,10 +589,10 @@ pub fun diagnose_doc(w: *Workspace, root: *Root, fid: src.FileId) Result[*diag.D
     ret ok[*diag.DiagList, str](?w.s.diags);
 }
 
-# own_module: the synthetic module id a buffer resolves under for `root`. offset
+# the synthetic module id a buffer resolves under for `root`. offset
 # past every loaded module id so a buffer-local symbol's `origin` never equals a
 # loaded dependency's, keeping the local/cross-module distinction exact. base 0
-# for a single-file document (root nil), whose empty dep set has no module ids.
+# for a single-file document (root nil), whose empty dep set has no module ids
 # ---
 # root: the root governing the buffer, or nil
 # fid:  FileId of the buffer
@@ -603,21 +603,21 @@ pub fun own_module(root: *Root, fid: src.FileId) sess.ModuleId {
     ret (base + fid::u32)::sess.ModuleId;
 }
 
-# root_gen: the generation stamp a buffer's resolve carries under `root` — the
+# the generation stamp a buffer's resolve carries under `root` — the
 # root's current build generation, or the reserved 0 for a single-file document
 # (root nil). the single source of the stamp rule, shared by cache_put's write
-# and cache_hit's check so the two sides cannot drift.
+# and cache_hit's check so the two sides cannot drift
 fun root_gen(root: *Root) u32 {
     if (root == nil) { ret 0; }
     ret root.gen;
 }
 
-# root_for: the root governing the document at `uri`, loading it on first use,
+# the root governing the document at `uri`, loading it on first use,
 # or nil when the document resolves single-file (no ancestor `mach.toml`, or a
 # remembered failed load). a document that is a dependency module of a root
 # rooted elsewhere — whether that root is already loaded, or is an ancestor
 # project loaded here on demand — is routed to that root read-only, rather than
-# spun up as its own project, regardless of document open order.
+# spun up as its own project, regardless of document open order
 # ---
 # w:   the workspace
 # uri: the document's URI
@@ -628,7 +628,7 @@ pub fun root_for(w: *Workspace, uri: str) *Root {
 
     # a loaded root rooted elsewhere that holds the document as one of its
     # modules governs it read-only: a vendored dependency resolves in the
-    # project that depends on it, never as its own project.
+    # project that depends on it, never as its own project
     val twin: *Root = containing_root(w, uri, doc_root);
     if (twin != nil) {
         if (doc_root != nil) { strutil.str_free(w.alloc, doc_root); }
@@ -647,14 +647,14 @@ pub fun root_for(w: *Workspace, uri: str) *Root {
     # fresh root: when an ancestor project declares this root as one of its dep
     # vendor dirs, load that project and prefer it when its graph holds the
     # document — so a dependency source opened before any project document
-    # still routes read-only instead of becoming its own renameable project.
+    # still routes read-only instead of becoming its own renameable project
     val outer: *Root = ancestor_root(w, uri, doc_root, doc_root);
     if (outer != nil) { strutil.str_free(w.alloc, doc_root); ret outer; }
 
     ret load_root(w, doc_root);
 }
 
-# root_for_loaded: the root governing the document at `uri` ONLY when it is
+# the root governing the document at `uri` ONLY when it is
 # already loaded — never triggering a build. unlike `root_for`, this neither
 # loads a fresh root nor speculatively loads a vendoring ancestor nor reloads a
 # stale one; it returns nil when no loaded root holds the document. the
@@ -663,7 +663,7 @@ pub fun root_for(w: *Workspace, uri: str) *Root {
 # (#96); the project still loads lazily on the first feature request, where
 # `root_for` runs. a document already governed by a loaded root resolves
 # dep-aware as before (#78). matches `root_for`'s routing: a loaded twin rooted
-# elsewhere wins, else the document's own root when it is loaded.
+# elsewhere wins, else the document's own root when it is loaded
 # ---
 # w:   the workspace
 # uri: the document's URI
@@ -672,7 +672,7 @@ pub fun root_for_loaded(w: *Workspace, uri: str) *Root {
     if (uri == nil) { ret nil; }
 
     # a loaded root rooted elsewhere holding the document governs it read-only,
-    # exactly as in root_for — checked without reloading.
+    # exactly as in root_for — checked without reloading
     val twin: *Root = containing_root_loaded(w, uri);
     if (twin != nil) { ret twin; }
 
@@ -684,7 +684,7 @@ pub fun root_for_loaded(w: *Workspace, uri: str) *Root {
     ret nil;
 }
 
-# ancestor_root: load-and-prefer the outermost project that vendors the document
+# load-and-prefer the outermost project that vendors the document
 # at `uri` (whose own fresh root is `doc_root`) and whose loaded graph holds it.
 # walks the chain of ancestor manifest dirs strictly above `dir` (`doc_root` on
 # the outer call), outermost first; an ancestor is only considered when its
@@ -697,7 +697,7 @@ pub fun root_for_loaded(w: *Workspace, uri: str) *Root {
 # another dependency's tree reaches the outermost project that actually closes
 # over it, not merely its immediate parent. ancestors already tracked are
 # skipped: a loaded one was already offered by containing_root, and a failed one
-# is not retried here. nil when no ancestor claims the document.
+# is not retried here. nil when no ancestor claims the document
 fun ancestor_root(w: *Workspace, uri: str, doc_root: str, dir: str) *Root {
     val par_r: Result[pathlib.Path, str] = pathlib.parent(w.alloc, dir);
     if (is_err[pathlib.Path, str](par_r)) { ret nil; }
@@ -721,7 +721,7 @@ fun ancestor_root(w: *Workspace, uri: str, doc_root: str, dir: str) *Root {
     ret nil;
 }
 
-# vendors_enclosing: whether the project at `root_path` declares a dependency
+# whether the project at `root_path` declares a dependency
 # whose vendor dir encloses `dir` — i.e. `dir` equals or lies under
 # `<root>/<[project].dep>/<alias>` for some `[deps.<alias>]`, the same layout the
 # driver's dep resolution reads. one small manifest parse answers "could this
@@ -734,7 +734,7 @@ fun ancestor_root(w: *Workspace, uri: str, doc_root: str, dir: str) *Root {
 # vendor dirs enclose nothing the document sits in. a manifest that fails to read
 # or parse vendors nothing. the parsed table is leaked into the server's page
 # allocator — std.data.toml exposes no teardown, the same convention the driver's
-# own manifest reads use.
+# own manifest reads use
 fun vendors_enclosing(w: *Workspace, root_path: str, dir: str) bool {
     val mp_r: Result[pathlib.Path, str] = pathlib.join(w.alloc, root_path, "mach.toml");
     if (is_err[pathlib.Path, str](mp_r)) { ret false; }
@@ -783,7 +783,7 @@ fun vendors_enclosing(w: *Workspace, root_path: str, dir: str) bool {
     ret found;
 }
 
-# find_root: the tracked slot whose path equals `root_path`, or nil.
+# the tracked slot whose path equals `root_path`, or nil
 fun find_root(w: *Workspace, root_path: str) *Root {
     if (w.roots == nil) { ret nil; }
     var i: u32 = 0;
@@ -795,7 +795,7 @@ fun find_root(w: *Workspace, root_path: str) *Root {
     ret nil;
 }
 
-# containing_root: the outermost loaded root whose graph holds the document at
+# the outermost loaded root whose graph holds the document at
 # `uri` as a module (matched on the normalized filesystem path), skipping the
 # document's own root at `doc_root` (which find_root handles, with its
 # outside-the-closure files resolving against its dep set). when several loaded
@@ -805,7 +805,7 @@ fun find_root(w: *Workspace, root_path: str) *Root {
 # module routes to the project that vendors it regardless of which root loaded
 # first. each candidate is reload-checked and its containment re-verified before
 # it is accepted, so a twin-routed document does not bypass the staleness check.
-# nil when no other loaded root holds the document.
+# nil when no other loaded root holds the document
 fun containing_root(w: *Workspace, uri: str, doc_root: str) *Root {
     if (w.roots == nil) { ret nil; }
     val norm: str = uri_to_norm(w.alloc, uri);
@@ -829,13 +829,13 @@ fun containing_root(w: *Workspace, uri: str, doc_root: str) *Root {
     ret found;
 }
 
-# containing_root_loaded: the load-free counterpart of `containing_root` for the
+# the load-free counterpart of `containing_root` for the
 # diagnostics publish path — the outermost already-loaded root whose graph holds
 # the document at `uri`, without the per-candidate `maybe_reload` (which would
 # rebuild a stale root). selection is identical otherwise: the shortest holding
 # root path wins, so a vendored module routes to the project that vendors it. nil
 # when no loaded root holds the document. staleness is reconciled on the feature
-# path's `root_for`, never on publish.
+# path's `root_for`, never on publish
 fun containing_root_loaded(w: *Workspace, uri: str) *Root {
     if (w.roots == nil) { ret nil; }
     val norm: str = uri_to_norm(w.alloc, uri);
@@ -855,12 +855,12 @@ fun containing_root_loaded(w: *Workspace, uri: str) *Root {
     ret found;
 }
 
-# load_root: claim a slot for `root_path` (taking ownership of the string) and
+# claim a slot for `root_path` (taking ownership of the string) and
 # build its graph. the vendored flag is stamped once here — intrinsic to the
 # path, so every root-creating path (root_for's fresh-root load, ancestor_root's
 # speculative loads) gets it correct, and it survives in-place reloads (which keep
 # the slot). on failure the slot is kept as a remembered failed load and nil is
-# returned; on success the loaded Root pointer is returned.
+# returned; on success the loaded Root pointer is returned
 fun load_root(w: *Workspace, root_path: str) *Root {
     val slot: *Root = alloc_slot(w);
     if (slot == nil) { strutil.str_free(w.alloc, root_path); ret nil; }
@@ -870,7 +870,7 @@ fun load_root(w: *Workspace, root_path: str) *Root {
     ret nil;
 }
 
-# vendored_under_ancestor: whether `root_path`'s own directory lies under some
+# whether `root_path`'s own directory lies under some
 # strict-ancestor project's declared vendor dir — i.e. this root is a vendored
 # dependency of an outer project. climbs the chain of ancestor manifest dirs
 # strictly above `root_path` (the same dirs ancestor_root walks), asking
@@ -879,7 +879,7 @@ fun load_root(w: *Workspace, root_path: str) *Root {
 # reached: a root materialized as an outer vendoring project for a deeper dep is
 # still flagged when it itself sits under a grandparent's vendor dir, which is
 # correct — its own sources remain a vendored dependency. a root with no such
-# ancestor (a top-level project, even one that loads dep modules) is not vendored.
+# ancestor (a top-level project, even one that loads dep modules) is not vendored
 fun vendored_under_ancestor(w: *Workspace, root_path: str) bool {
     var cur: str = root_path;
     var result: bool = false;
@@ -900,9 +900,9 @@ fun vendored_under_ancestor(w: *Workspace, root_path: str) bool {
     ret result;
 }
 
-# reset_slot: zero a Root slot's fields, marking it dead and reusable. owned
+# zero a Root slot's fields, marking it dead and reusable. owned
 # storage must already be released (free_root) or never allocated (a fresh
-# slot).
+# slot)
 fun reset_slot(r: *Root) {
     r.path           = nil;
     r.loaded         = false;
@@ -920,8 +920,8 @@ fun reset_slot(r: *Root) {
     r.sema_loaded    = false;
 }
 
-# alloc_slot: a reusable dead slot, growing the array when every slot is
-# tracked. nil on allocation failure.
+# a reusable dead slot, growing the array when every slot is
+# tracked. nil on allocation failure
 fun alloc_slot(w: *Workspace) *Root {
     var i: u32 = 0;
     for (i < w.root_cap) {
@@ -951,7 +951,7 @@ fun alloc_slot(w: *Workspace) *Root {
     ret ?w.roots[old_cap];
 }
 
-# try_load: run build_project_union for `r.path` and snapshot the dep set into
+# run build_project_union for `r.path` and snapshot the dep set into
 # `r` (the union of every declared target's closure, so cross-file features cover
 # modules reachable only via a non-default target).
 # the manifest / lockfile mtimes are recorded at the start of the attempt
@@ -960,7 +960,7 @@ fun alloc_slot(w: *Workspace) *Root {
 # surfaced (trace log + window/showMessage); on success the root claims a fresh
 # generation stamp, so any result resolved before the load (against the empty dep
 # set and the pre-load own_base, stamped a different generation) misses the cache
-# rather than being served stale.
+# rather than being served stale
 fun try_load(w: *Workspace, r: *Root) bool {
     record_mtimes(w, r);
 
@@ -991,10 +991,10 @@ fun try_load(w: *Workspace, r: *Root) bool {
     ret true;
 }
 
-# next_gen: hand out a fresh generation stamp. each successful build claims one,
+# hand out a fresh generation stamp. each successful build claims one,
 # so a cache entry's generation identifies its exact build and a reloaded or
 # freed root's stale entries can never match a later build. 0 is the reserved
-# unloaded / single-file sentinel and is skipped if the sequence ever wraps.
+# unloaded / single-file sentinel and is skipped if the sequence ever wraps
 fun next_gen(w: *Workspace) u32 {
     if (w.gen_seq == 0) { w.gen_seq = 1; }
     val g: u32 = w.gen_seq;
@@ -1002,11 +1002,11 @@ fun next_gen(w: *Workspace) u32 {
     ret g;
 }
 
-# build_mod_paths: snapshot every loaded module's normalized source path into
+# snapshot every loaded module's normalized source path into
 # `r.mod_paths`, indexed by module id, so the per-request uri -> module lookups
 # are allocation-free string compares. a source that cannot be read or
 # normalized leaves a nil entry, making that module unmatchable by uri (the
-# same outcome the per-request normalization had).
+# same outcome the per-request normalization had)
 fun build_mod_paths(w: *Workspace, r: *Root) {
     val n: u32 = r.p.module_len;
     if (n == 0) { ret; }
@@ -1026,7 +1026,7 @@ fun build_mod_paths(w: *Workspace, r: *Root) {
     }
 }
 
-# free_mod_paths: release the per-module normalized path snapshot.
+# release the per-module normalized path snapshot
 fun free_mod_paths(w: *Workspace, r: *Root) {
     if (r.mod_paths == nil) { ret; }
     var i: u32 = 0;
@@ -1039,13 +1039,13 @@ fun free_mod_paths(w: *Workspace, r: *Root) {
     r.mod_path_count = 0;
 }
 
-# maybe_reload: rebuild `r`'s graph when its manifest or lockfile changed on
+# rebuild `r`'s graph when its manifest or lockfile changed on
 # disk since the last load attempt — the conservative fallback for clients that
 # do not deliver `workspace/didChangeWatchedFiles`, and the retry path for a
 # root whose previous load failed (a since-fixed manifest). skipped entirely
 # when file watching is active: the watcher already invalidates on those
 # changes, so the per-request stats would be pure overhead. a no-op when
-# nothing changed.
+# nothing changed
 fun maybe_reload(w: *Workspace, r: *Root) {
     if (w.watch_active) { ret; }
     var man:  i64 = 0;
@@ -1056,11 +1056,11 @@ fun maybe_reload(w: *Workspace, r: *Root) {
     try_load(w, r);
 }
 
-# invalidate_uri: drop every loaded root whose tree contains the changed file, so
+# drop every loaded root whose tree contains the changed file, so
 # the next request rebuilds it from disk. the LSP trigger is
 # `workspace/didChangeWatchedFiles`; a changed `mach.toml` / `mach.lock` or any
 # source under a root (including a vendored dependency under `dep/`) invalidates
-# that root. each dropped root's cached results are evicted per-root by free_root.
+# that root. each dropped root's cached results are evicted per-root by free_root
 # ---
 # w:   the workspace
 # uri: the URI of the changed file
@@ -1080,8 +1080,8 @@ pub fun invalidate_uri(w: *Workspace, uri: str) {
     strutil.str_free(w.alloc, norm);
 }
 
-# root_covers: whether `file_norm` (a normalized absolute path) lies within the
-# project rooted at `root_path` — equal to it or under it.
+# whether `file_norm` (a normalized absolute path) lies within the
+# project rooted at `root_path` — equal to it or under it
 fun root_covers(w: *Workspace, file_norm: str, root_path: str) bool {
     if (root_path == nil) { ret false; }
     val rn: str = normalize_path(w.alloc, root_path);
@@ -1091,7 +1091,7 @@ fun root_covers(w: *Workspace, file_norm: str, root_path: str) bool {
     ret covered;
 }
 
-# is_under: whether `file` equals `dir` or is a path beneath it.
+# whether `file` equals `dir` or is a path beneath it
 fun is_under(file: str, dir: str) bool {
     val dl: usize = str_len(dir);
     val fl: usize = str_len(file);
@@ -1100,19 +1100,19 @@ fun is_under(file: str, dir: str) bool {
     ret file[dl] == '/';
 }
 
-# free_root: release a root's graph, dep snapshot, and owned path, resetting
-# the slot for reuse.
+# release a root's graph, dep snapshot, and owned path, resetting
+# the slot for reuse
 fun free_root(w: *Workspace, r: *Root) {
     free_root_graph(w, r);
     if (r.path != nil) { strutil.str_free(w.alloc, r.path); }
     reset_slot(r);
 }
 
-# free_root_graph: release a root's dep snapshot, module-path snapshot, and
+# release a root's dep snapshot, module-path snapshot, and
 # loaded project, leaving the slot tracked with its path so it can reload in
 # place. the build's cached resolve results are evicted first (so a teardown
 # reclaims them rather than leaving them for the whole-cache sweep), and the
-# generation is cleared so a later build claims a fresh, non-matching one.
+# generation is cleared so a later build claims a fresh, non-matching one
 fun free_root_graph(w: *Workspace, r: *Root) {
     evict_root(w, r);
     free_sema(w, r);
@@ -1125,10 +1125,10 @@ fun free_root_graph(w: *Workspace, r: *Root) {
     r.gen = 0;
 }
 
-# free_sema: tear down the root's retained per-module SemaResults and the array
+# tear down the root's retained per-module SemaResults and the array
 # holding them, resetting the lazy-sema state so a reloaded build re-runs sema on
 # next demand. each SemaResult's parallel TypeId arrays are freed; the interned
-# types they reference live on the session and are not touched here.
+# types they reference live on the session and are not touched here
 fun free_sema(w: *Workspace, r: *Root) {
     if (r.sema == nil) {
         r.sema_count  = 0;
@@ -1146,21 +1146,21 @@ fun free_sema(w: *Workspace, r: *Root) {
     r.sema_loaded = false;
 }
 
-# record_mtimes: snapshot the root's manifest / lockfile mtimes for the
-# conservative reload check.
+# snapshot the root's manifest / lockfile mtimes for the
+# conservative reload check
 fun record_mtimes(w: *Workspace, r: *Root) {
     stat_mtimes(w, r.path, ?r.man_mtime, ?r.lock_mtime);
 }
 
-# stat_mtimes: write the mtimes of `<root_path>/mach.toml` and
-# `<root_path>/mach.lock` (0 when absent) into `man` / `lock`.
+# write the mtimes of `<root_path>/mach.toml` and
+# `<root_path>/mach.lock` (0 when absent) into `man` / `lock`
 fun stat_mtimes(w: *Workspace, root_path: str, man: *i64, lock: *i64) {
     @man  = join_mtime(w.alloc, root_path, "mach.toml");
     @lock = join_mtime(w.alloc, root_path, "mach.lock");
 }
 
-# join_mtime: the mtime of `<dir>/<name>`, or 0 when the file is absent or
-# cannot be joined.
+# the mtime of `<dir>/<name>`, or 0 when the file is absent or
+# cannot be joined
 fun join_mtime(alloc: *Allocator, dir: str, name: str) i64 {
     val jr: Result[pathlib.Path, str] = pathlib.join(alloc, dir, name);
     if (is_err[pathlib.Path, str](jr)) { ret 0; }
@@ -1175,13 +1175,13 @@ fun join_mtime(alloc: *Allocator, dir: str, name: str) i64 {
     ret m;
 }
 
-# site_of: where symbol `sym` is declared, as an Ast / SourceFile / URI triple.
+# where symbol `sym` is declared, as an Ast / SourceFile / URI triple.
 # a buffer-local symbol (origin equals the buffer's module) reports against the
 # request buffer; a cross-module symbol reports against the defining dependency
 # module's on-disk file, read from `root`'s own project module array (whose ids
 # are private to that root), with a freshly built `file://` URI the caller must
 # free (see `free_site`). none when there is no project, or the defining module
-# cannot be located.
+# cannot be located
 # ---
 # w:       the workspace
 # root:    the root the buffer resolved against, or nil
@@ -1217,14 +1217,14 @@ pub fun site_of(w: *Workspace, root: *Root, own: sess.ModuleId, own_a: *ast.Ast,
     ret some[Site](s);
 }
 
-# module_entry: loaded module `mid`'s entry in `root`, or nil when there is no
-# loaded project or the id is out of range.
+# loaded module `mid`'s entry in `root`, or nil when there is no
+# loaded project or the id is out of range
 fun module_entry(root: *Root, mid: sess.ModuleId) *driver.ModuleEntry {
     if (root == nil || !root.loaded || mid::u32 >= root.p.module_len) { ret nil; }
     ret ?root.p.modules[mid::u32];
 }
 
-# free_site: release a Site's URI when it owns one.
+# release a Site's URI when it owns one
 # ---
 # w:    the workspace
 # site: the site to release
@@ -1234,8 +1234,8 @@ pub fun free_site(w: *Workspace, site: *Site) {
     site.owned = false;
 }
 
-# ModuleView: a borrowed view of one loaded module for the workspace-wide
-# use-site walk — its parsed Ast, resolve side tables, and backing source file.
+# a borrowed view of one loaded module for the workspace-wide
+# use-site walk — its parsed Ast, resolve side tables, and backing source file
 # ---
 # a:    the module's parsed Ast (decl / expr / type ids index into it)
 # rr:   the module's ResolveResult side tables
@@ -1246,8 +1246,8 @@ pub rec ModuleView {
     file: *src.SourceFile;
 }
 
-# module_count: the number of loaded modules in `root`, or 0 when root is nil /
-# not loaded. the workspace-wide references / rename walk iterates [0, count).
+# the number of loaded modules in `root`, or 0 when root is nil /
+# not loaded. the workspace-wide references / rename walk iterates [0, count)
 # ---
 # root: the root governing the request, or nil
 # ret:  the loaded module count
@@ -1256,10 +1256,10 @@ pub fun module_count(root: *Root) u32 {
     ret root.p.module_len;
 }
 
-# module_view: a borrowed view of loaded module `mid` in `root` for the use-site
+# a borrowed view of loaded module `mid` in `root` for the use-site
 # walk, or none when there is no project, the id is out of range, the module did
 # not resolve, or its source is missing. the returned pointers are owned by the
-# loaded project / session.
+# loaded project / session
 # ---
 # w:    the workspace
 # root: the root governing the request, or nil
@@ -1277,13 +1277,13 @@ pub fun module_view(w: *Workspace, root: *Root, mid: sess.ModuleId) Option[Modul
     ret some[ModuleView](v);
 }
 
-# module_sema: loaded module `mid`'s SemaResult in `root`, lazily running the
+# loaded module `mid`'s SemaResult in `root`, lazily running the
 # type checker over the whole graph on first demand (ensure_sema) and retaining
 # every module's result on the root. none when there is no project, the id is out
 # of range, or the module did not resolve / could not be typed (its retained slot
 # stays zeroed). this is the type-aware twin of `module_view`: a workspace-wide
 # type query (e.g. a field rename's cross-module walk) reads each module's typing
-# through it. the returned pointer is owned by the root.
+# through it. the returned pointer is owned by the root
 # ---
 # w:    the workspace
 # root: the root governing the request, or nil
@@ -1298,11 +1298,11 @@ pub fun module_sema(w: *Workspace, root: *Root, mid: sess.ModuleId) Option[*sema
     ret some[*sema.SemaResult](sr);
 }
 
-# type_of: the semantic type of expression `eid` in SemaResult `sr`, or TYPE_NIL
+# the semantic type of expression `eid` in SemaResult `sr`, or TYPE_NIL
 # when `sr` is nil or `eid` is out of range. the narrow read the feature layer
 # makes to learn an expression's type — handed a SemaResult (from `sema_doc` or
 # `module_sema`), never the session. delegates to the pure helper so the rule lives
-# in one unit-testable place.
+# in one unit-testable place
 # ---
 # sr:  a buffer's / module's SemaResult, or nil
 # eid: the expression id to type
@@ -1311,8 +1311,8 @@ pub fun type_of(sr: *sema.SemaResult, eid: id.ExprId) type.TypeId {
     ret mtypes.type_of(sr, eid);
 }
 
-# decl_type_of: the declared (or inferred) type of decl `did` in SemaResult `sr`,
-# or TYPE_NIL when unavailable. the decl-keyed twin of `type_of`.
+# the declared (or inferred) type of decl `did` in SemaResult `sr`,
+# or TYPE_NIL when unavailable. the decl-keyed twin of `type_of`
 # ---
 # sr:  a buffer's / module's SemaResult, or nil
 # did: the declaration id to type
@@ -1321,11 +1321,11 @@ pub fun decl_type_of(sr: *sema.SemaResult, did: id.DeclId) type.TypeId {
     ret mtypes.decl_type_of(sr, did);
 }
 
-# RecordSite: the nominal back-link from a record / union TypeId to its declaring
+# the nominal back-link from a record / union TypeId to its declaring
 # site — what a field go-to-def / rename follows from a value's type to the `rec` /
 # `uni` declaration whose fields it must walk. carries the field range (uniform
 # across rec / uni, both being TypedName slices in `a.typed_names`) and the
-# module's Ast / source so field spans can be read directly.
+# module's Ast / source so field spans can be read directly
 # ---
 # origin:       ModuleId of the declaring module
 # decl:         DeclId of the rec / uni declaration in `origin`'s Ast
@@ -1344,7 +1344,7 @@ pub rec RecordSite {
     is_rec:       bool;
 }
 
-# record_decl: the declaring site a record / union TypeId nominally refers to,
+# the declaring site a record / union TypeId nominally refers to,
 # resolved against the session's type interner and the root's loaded module array —
 # the nominal back-link field features follow. peels a pointer to its pointee and
 # maps a generic instance to its template. none when `tid` is not a nominal type,
@@ -1352,7 +1352,7 @@ pub rec RecordSite {
 # rec / uni. the returned Ast / file pointers are owned by the loaded project /
 # session. a record declared in the active buffer (whose synthetic module id is not
 # in the loaded array) is not found here — use `record_decl_in`, which falls back to
-# the buffer's live Ast for that case.
+# the buffer's live Ast for that case
 # ---
 # w:    the workspace
 # root: the root the type was resolved under, or nil
@@ -1370,12 +1370,12 @@ pub fun record_decl(w: *Workspace, root: *Root, tid: type.TypeId) Option[RecordS
     ret record_site_from(n.origin, n.decl, m.a, unwrap[*src.SourceFile](fo));
 }
 
-# record_decl_in: `record_decl` extended to resolve a record / union declared in
+# `record_decl` extended to resolve a record / union declared in
 # the active buffer. a buffer's own nominal type is interned under its synthetic
 # module id (`own`), which is not in the loaded module array, so `record_decl`
 # alone would miss a field access on a record the edited buffer itself declares.
 # when the nominal's origin is `own`, the declaration is read from the buffer's
-# live Ast / file (`own_a` / `own_file`); otherwise it defers to a loaded module.
+# live Ast / file (`own_a` / `own_file`); otherwise it defers to a loaded module
 # ---
 # w:        the workspace
 # root:     the root the type was resolved under, or nil
@@ -1392,12 +1392,12 @@ pub fun record_decl_in(w: *Workspace, root: *Root, own: sess.ModuleId, own_a: *a
     ret record_decl(w, root, tid);
 }
 
-# record_site_at: a RecordSite for the rec / uni declaration `decl` in the active
+# a RecordSite for the rec / uni declaration `decl` in the active
 # buffer (`own` / `own_a` / `own_file`), or none when `decl` is not a rec / uni.
 # the buffer-side entry point for a cursor sitting on a field's own declaration
 # name: the decl is in the buffer being edited, so its Ast / file are the live
 # ones. the resulting site carries the buffer's own module id, the cross-module
-# identity every other module's references are matched against.
+# identity every other module's references are matched against
 # ---
 # w:        the workspace (unused, kept for signature symmetry with record_decl_in)
 # root:     the project root, or nil
@@ -1411,17 +1411,17 @@ pub fun record_site_at(w: *Workspace, root: *Root, own: sess.ModuleId, own_a: *a
     ret record_site_from(own, decl, own_a, own_file);
 }
 
-# nominal_of_tid: the nominal back-link of `tid` against the session type interner,
-# guarded on a loaded root. none when there is no project or `tid` is not nominal.
+# the nominal back-link of `tid` against the session type interner,
+# guarded on a loaded root. none when there is no project or `tid` is not nominal
 fun nominal_of_tid(w: *Workspace, root: *Root, tid: type.TypeId) Option[mtypes.Nominal] {
     if (root == nil || !root.loaded) { ret none[mtypes.Nominal](); }
     ret mtypes.nominal_of(?w.s.types, tid);
 }
 
-# record_site_from: build a RecordSite for the rec / uni decl `decl` in `a` (backed
+# build a RecordSite for the rec / uni decl `decl` in `a` (backed
 # by `file`), or none when the decl is absent or not a rec / uni. the shared core
 # of `record_decl` / `record_decl_in` — both having chosen which Ast / file the
-# declaration lives in.
+# declaration lives in
 fun record_site_from(origin: sess.ModuleId, decl: id.DeclId, a: *ast.Ast, file: *src.SourceFile) Option[RecordSite] {
     val d_opt: Option[*adecl.Decl] = ast.get_decl(a, decl);
     if (is_none[*adecl.Decl](d_opt)) { ret none[RecordSite](); }
@@ -1445,9 +1445,9 @@ fun record_site_from(origin: sess.ModuleId, decl: id.DeclId, a: *ast.Ast, file: 
     ret some[RecordSite](rs);
 }
 
-# module_uri: a freshly built, normalized `file://` URI for loaded module `mid`'s
+# a freshly built, normalized `file://` URI for loaded module `mid`'s
 # source file in `root` (from the root's path snapshot), owned by the caller, or
-# nil when there is no project, the id is out of range, or allocation fails.
+# nil when there is no project, the id is out of range, or allocation fails
 # ---
 # w:    the workspace
 # root: the root governing the request, or nil
@@ -1459,7 +1459,7 @@ pub fun module_uri(w: *Workspace, root: *Root, mid: sess.ModuleId) str {
     ret norm_uri(w.alloc, root.mod_paths[mid::u32]);
 }
 
-# module_for_uri: the loaded module in `root` whose source file is the document
+# the loaded module in `root` whose source file is the document
 # at `uri` (matched on the normalized filesystem path), or none. lets the
 # workspace walk skip the active buffer's on-disk twin, whose live edits the
 # buffer's own resolve already covers, so its references are not counted twice.
@@ -1467,7 +1467,7 @@ pub fun module_uri(w: *Workspace, root: *Root, mid: sess.ModuleId) str {
 # neither realpath nor inode identity, so a buffer opened through a symlinked or
 # differently-cased path does not match its twin and that file is walked as a
 # separate module — yielding duplicate locations / a duplicate WorkspaceEdit key
-# for the same physical file.
+# for the same physical file
 # ---
 # w:    the workspace
 # root: the root governing the request, or nil
@@ -1482,9 +1482,9 @@ pub fun module_for_uri(w: *Workspace, root: *Root, uri: str) Option[sess.ModuleI
     ret result;
 }
 
-# module_for_norm: the loaded module in `root` whose normalized source path
+# the loaded module in `root` whose normalized source path
 # equals `norm`, or none. the allocation-free core of module_for_uri, also used
-# where one normalized document path is matched against several roots.
+# where one normalized document path is matched against several roots
 fun module_for_norm(root: *Root, norm: str) Option[sess.ModuleId] {
     if (root == nil || !root.loaded || norm == nil) { ret none[sess.ModuleId](); }
     var i: u32 = 0;
@@ -1497,11 +1497,11 @@ fun module_for_norm(root: *Root, norm: str) Option[sess.ModuleId] {
     ret none[sess.ModuleId]();
 }
 
-# root_vendored: whether `root`'s whole tree is a vendored dependency project
+# whether `root`'s whole tree is a vendored dependency project
 # (its directory lies under an outer project's declared vendor dir), so none of
 # its files are the editor's to rewrite. nil root is not vendored. the per-root
 # read-only signal the rename gate consults for a buffer with no loaded twin,
-# where the per-module is_project_module check has nothing to key on.
+# where the per-module is_project_module check has nothing to key on
 # ---
 # root: the root governing the request, or nil
 # ret:  true when the root is a vendored dependency project
@@ -1510,12 +1510,12 @@ pub fun root_vendored(root: *Root) bool {
     ret root.vendored;
 }
 
-# is_project_module: whether loaded module `mid` in `root` belongs to the user's
+# whether loaded module `mid` in `root` belongs to the user's
 # own editable project rather than a vendored dependency — false outright when
 # the whole root is a vendored dependency project (root_vendored), otherwise true
 # iff the module's fully-qualified path's head segment is the project id. rename
 # gates cross-file edits on it so a dependency's declaration (e.g. a std symbol,
-# or any file of a vendored project) is never rewritten.
+# or any file of a vendored project) is never rewritten
 # ---
 # w:    the workspace
 # root: the root governing the request, or nil
@@ -1537,9 +1537,9 @@ pub fun is_project_module(w: *Workspace, root: *Root, mid: sess.ModuleId) bool {
     ret fqn[plen] == '.';
 }
 
-# document_root: the project root governing `uri` — the nearest ancestor of its
+# the project root governing `uri` — the nearest ancestor of its
 # decoded filesystem path holding a `mach.toml` — as an owned string, or nil
-# for a non-file URI or a document outside any project.
+# for a non-file URI or a document outside any project
 fun document_root(w: *Workspace, uri: str) str {
     val path: str = uri_to_path(w.alloc, uri);
     if (path == nil) { ret nil; }
@@ -1548,11 +1548,11 @@ fun document_root(w: *Workspace, uri: str) str {
     ret root;
 }
 
-# report_load_failure: log the loader error and warn the user through
+# log the loader error and warn the user through
 # window/showMessage so a manifest that fails to load (a malformed or
 # unparseable mach.toml) is distinguishable from "no project found". the slot
 # itself remembers the failure (tracked + !loaded), so the load is only retried
-# when the manifest / lockfile changes.
+# when the manifest / lockfile changes
 fun report_load_failure(w: *Workspace, root: str, msg: str) {
     trace.log("project: failed to load project at ");
     trace.log(root);
@@ -1578,7 +1578,7 @@ fun report_load_failure(w: *Workspace, root: str, msg: str) {
     deallocate[u8](w.alloc, buf, total + 1);
 }
 
-# show_warning: send a window/showMessage notification with Warning severity.
+# send a window/showMessage notification with Warning severity
 fun show_warning(w: *Workspace, text: str) {
     val qmsg: str = json.quote(text, w.alloc);
     if (qmsg == nil) { ret; }
@@ -1598,10 +1598,10 @@ fun show_warning(w: *Workspace, text: str) {
     json.free_str(qmsg, w.alloc);
 }
 
-# build_deps: snapshot every loaded module's public surface into `r.deps`, one
+# snapshot every loaded module's public surface into `r.deps`, one
 # ModuleExports per module keyed by FQN. mirrors the driver's per-module
 # dependency assembly but spans the whole graph, so a buffer's `use` of any
-# loaded module binds. modules with no exports contribute an empty entry.
+# loaded module binds. modules with no exports contribute an empty entry
 fun build_deps(w: *Workspace, r: *Root) {
     val n: u32 = r.p.module_len;
     if (n == 0) { ret; }
@@ -1617,11 +1617,11 @@ fun build_deps(w: *Workspace, r: *Root) {
     }
 }
 
-# module_exports: the public surface of loaded module `mid` in `root` as a
+# the public surface of loaded module `mid` in `root` as a
 # ModuleExports, copying each pub symbol's (kind, name, decl, slot, origin) so
 # resolve can bind a cross-module reference to the declaring module's Ast. this
 # must track the driver's private build_module_exports field-for-field; the
-# driver helper remained private through the #45 dep bump, so the copy stays.
+# driver helper remained private through the #45 dep bump, so the copy stays
 fun module_exports(w: *Workspace, root: *Root, mid: sess.ModuleId) res.ModuleExports {
     val m: *driver.ModuleEntry = ?root.p.modules[mid::u32];
     var mx: res.ModuleExports;
@@ -1653,8 +1653,8 @@ fun module_exports(w: *Workspace, root: *Root, mid: sess.ModuleId) res.ModuleExp
     ret mx;
 }
 
-# free_deps: release a dep snapshot's per-module symbol arrays and the entry
-# array, zeroing it.
+# release a dep snapshot's per-module symbol arrays and the entry
+# array, zeroing it
 fun free_deps(w: *Workspace, deps: *res.ResolveDeps) {
     if (deps.entries == nil) { ret; }
     var i: u32 = 0;
@@ -1670,7 +1670,7 @@ fun free_deps(w: *Workspace, deps: *res.ResolveDeps) {
     deps.count   = 0;
 }
 
-# ensure_sema: run the type checker over `root`'s loaded module graph, retaining
+# run the type checker over `root`'s loaded module graph, retaining
 # one SemaResult per module on the Root — the lazy core of the type-aware layer.
 # a no-op once it has run for the current build (sema_loaded) or for an unloaded
 # root. modules are sema'd in dependency (topological) order, each against a
@@ -1683,7 +1683,7 @@ fun free_deps(w: *Workspace, deps: *res.ResolveDeps) {
 # the server uses to re-publish the open buffers with semantic diagnostics now
 # that the closure's retained typing exists (#113). allocation failure leaves the
 # root un-sema'd (typing simply stays unavailable, no epoch bump) rather than
-# aborting the request.
+# aborting the request
 # ---
 # w:    the workspace
 # root: the loaded root whose graph to type-check
@@ -1700,7 +1700,7 @@ pub fun ensure_sema(w: *Workspace, root: *Root) {
 
     # ready[mid]: whether module mid has a populated SemaResult this pass, so a
     # later module's SemaDeps exposes only the snapshots already produced (every
-    # dep is strictly earlier in topo order and thus ready before its dependents).
+    # dep is strictly earlier in topo order and thus ready before its dependents)
     val rdy_r: Result[*bool, str] = allocate[bool](w.alloc, n::usize);
     if (is_err[*bool, str](rdy_r)) { free_sema(w, root); ret; }
     val ready: *bool = unwrap_ok[*bool, str](rdy_r);
@@ -1719,14 +1719,14 @@ pub fun ensure_sema(w: *Workspace, root: *Root) {
     w.sema_epoch = w.sema_epoch + 1;
 }
 
-# run_module_sema: type-check one loaded module against the modules already sema'd
+# type-check one loaded module against the modules already sema'd
 # this pass, storing its SemaResult into `root.sema[mid]` and marking it ready. a
 # module that did not resolve (no resolve_result) is left zeroed and unready — its
 # types stay TYPE_NIL and dependents simply do not see it among their deps. the
 # comptime context the driver populated for the module (`m.ctx`) drives array-length
 # and `$if`-gate evaluation, matching how the compiler sema's the same module. on
 # any failure the slot is left zeroed; the pass continues so a single bad module
-# does not deny typing to the rest.
+# does not deny typing to the rest
 fun run_module_sema(w: *Workspace, root: *Root, mid: sess.ModuleId, ready: *bool) {
     if (mid::u32 >= root.p.module_len) { ret; }
     val m: *driver.ModuleEntry = ?root.p.modules[mid::u32];
@@ -1742,7 +1742,7 @@ fun run_module_sema(w: *Workspace, root: *Root, mid: sess.ModuleId, ready: *bool
     ready[mid::u32]     = true;
 }
 
-# build_sema_deps: assemble the SemaDeps for the module about to be analysed — one
+# assemble the SemaDeps for the module about to be analysed — one
 # ModuleSema entry per module already sema'd this pass (ready), each borrowing that
 # module's decl_type snapshot. cross-module symbol types are looked up by the
 # symbol's origin ModuleId, and a `fwd` re-export carries the originating
@@ -1750,7 +1750,7 @@ fun run_module_sema(w: *Workspace, root: *Root, mid: sess.ModuleId, ready: *bool
 # not only the direct dependencies — all of them are strictly earlier in topo order
 # and thus already produced. mirrors the compiler's own build_sema_deps. writes the
 # assembled deps into `out`; false on allocation failure (the caller skips the
-# module). an empty set (no module ready yet) is a successful result.
+# module). an empty set (no module ready yet) is a successful result
 fun build_sema_deps(w: *Workspace, root: *Root, ready: *bool, out: *sema.SemaDeps) bool {
     out.entries = nil;
     out.count   = 0;
@@ -1786,9 +1786,9 @@ fun build_sema_deps(w: *Workspace, root: *Root, ready: *bool, out: *sema.SemaDep
     ret true;
 }
 
-# free_sema_deps: release the entries array a build_sema_deps allocated. the
+# release the entries array a build_sema_deps allocated. the
 # borrowed decl_type arrays it points into are owned by the producing SemaResults
-# and are NOT freed here.
+# and are NOT freed here
 fun free_sema_deps(w: *Workspace, deps: *sema.SemaDeps) {
     if (deps.entries == nil) { ret; }
     deallocate[sema.ModuleSema](w.alloc, deps.entries, deps.count::usize);
@@ -1796,9 +1796,9 @@ fun free_sema_deps(w: *Workspace, deps: *sema.SemaDeps) {
     deps.count   = 0;
 }
 
-# zero_sema: zero a freshly allocated SemaResult array so an un-run or skipped
+# zero a freshly allocated SemaResult array so an un-run or skipped
 # module's slot has nil arrays — a lookup against it types to TYPE_NIL, never a
-# wild read. mirrors how the resolve cache zero-fills its gaps.
+# wild read. mirrors how the resolve cache zero-fills its gaps
 fun zero_sema(arr: *sema.SemaResult, n: u32) {
     var i: u32 = 0;
     for (i < n) {
@@ -1813,12 +1813,12 @@ fun zero_sema(arr: *sema.SemaResult, n: u32) {
     }
 }
 
-# cache_hit: the cached ResolveResult for `fid` when it was resolved from the
+# the cached ResolveResult for `fid` when it was resolved from the
 # exact Ast `a` (the editor replaces the Ast pointer on every text update, so
 # pointer identity proves the text is current) and against the same build as
 # `root` (the entry's generation must equal the root's current `gen`, or 0 when
 # resolving single-file), or nil. the generation match is what makes a result
-# from a since-reloaded or different root structurally unhittable.
+# from a since-reloaded or different root structurally unhittable
 fun cache_hit(w: *Workspace, fid: src.FileId, a: *ast.Ast, root: *Root) *res.ResolveResult {
     if (w.cache == nil || fid::u32 >= w.cache_len) { ret nil; }
     val c: *Cached = ?w.cache[fid::u32];
@@ -1827,10 +1827,10 @@ fun cache_hit(w: *Workspace, fid: src.FileId, a: *ast.Ast, root: *Root) *res.Res
     ret c.rr;
 }
 
-# cache_put: store `rr` (resolved from Ast `a` against the build stamped `gen`,
+# store `rr` (resolved from Ast `a` against the build stamped `gen`,
 # or 0 for single-file) as the cached result for `fid`, growing the cache to
 # cover the FileId and zero-filling any gap. false when the grow allocation fails
-# — the caller owns `rr` and must free it.
+# — the caller owns `rr` and must free it
 fun cache_put(w: *Workspace, fid: src.FileId, rr: *res.ResolveResult, a: *ast.Ast, gen: u32) bool {
     val needed: u32 = fid::u32 + 1;
     if (needed > w.cache_len) {
@@ -1858,10 +1858,10 @@ fun cache_put(w: *Workspace, fid: src.FileId, rr: *res.ResolveResult, a: *ast.As
     ret true;
 }
 
-# release_entry: free a cache slot's owned ResolveResult and SemaResult and zero
+# free a cache slot's owned ResolveResult and SemaResult and zero
 # the slot — the one teardown for a Cached entry, shared by every reclamation path.
 # the sema result (populated lazily by sema_doc, nil otherwise) is torn down first.
-# callers guard `c.rr != nil`.
+# callers guard `c.rr != nil`
 fun release_entry(w: *Workspace, c: *Cached) {
     if (c.sr != nil) {
         sema.dnit_result(c.sr);
@@ -1875,10 +1875,10 @@ fun release_entry(w: *Workspace, c: *Cached) {
     c.gen = 0;
 }
 
-# free_cached: release and clear the cached ResolveResult for `fid`, if any.
+# release and clear the cached ResolveResult for `fid`, if any.
 # called before a re-resolve replaces the entry, and by the server on didClose
 # so a retired document's result is reclaimed immediately instead of lingering
-# until its FileId is reused or its root reloads.
+# until its FileId is reused or its root reloads
 # ---
 # w:   the workspace
 # fid: the buffer whose cached result to drop
@@ -1888,12 +1888,12 @@ pub fun free_cached(w: *Workspace, fid: src.FileId) {
     if (c.rr != nil) { release_entry(w, c); }
 }
 
-# evict_root: release every cached result resolved against root `r`'s current
+# release every cached result resolved against root `r`'s current
 # build (matched by generation), reclaiming the entries a graph teardown
 # invalidates. a no-op for an unloaded slot (gen 0, no build of its own — and
 # never the single-file entries that also carry gen 0, since those belong to no
 # root). called by free_root_graph at every reload / free, replacing the blanket
-# whole-cache clear.
+# whole-cache clear
 fun evict_root(w: *Workspace, r: *Root) {
     if (w.cache == nil || r.gen == 0) { ret; }
     var i: u32 = 0;
@@ -1904,8 +1904,8 @@ fun evict_root(w: *Workspace, r: *Root) {
     }
 }
 
-# free_all_cached: release every cached ResolveResult, keeping the slot array.
-# the teardown sweep used by dnit; per-build invalidation goes through evict_root.
+# release every cached ResolveResult, keeping the slot array.
+# the teardown sweep used by dnit; per-build invalidation goes through evict_root
 fun free_all_cached(w: *Workspace) {
     if (w.cache == nil) { ret; }
     var i: u32 = 0;
@@ -1916,8 +1916,8 @@ fun free_all_cached(w: *Workspace) {
     }
 }
 
-# uri_to_path: the percent-decoded filesystem path of a `file://` URI, as an
-# owned string, or nil for a non-file URI / malformed escape.
+# the percent-decoded filesystem path of a `file://` URI, as an
+# owned string, or nil for a non-file URI / malformed escape
 fun uri_to_path(alloc: *Allocator, uri: str) str {
     if (uri == nil) { ret nil; }
     if (!str_starts_with(uri, "file://")) { ret nil; }
@@ -1951,8 +1951,8 @@ fun uri_to_path(alloc: *Allocator, uri: str) str {
     ret buf::str;
 }
 
-# uri_to_norm: the normalized filesystem path of a `file://` URI, as an owned
-# string, or nil for a non-file URI / malformed escape / allocation failure.
+# the normalized filesystem path of a `file://` URI, as an owned
+# string, or nil for a non-file URI / malformed escape / allocation failure
 fun uri_to_norm(alloc: *Allocator, uri: str) str {
     val path: str = uri_to_path(alloc, uri);
     if (path == nil) { ret nil; }
@@ -1961,7 +1961,7 @@ fun uri_to_norm(alloc: *Allocator, uri: str) str {
     ret norm;
 }
 
-# hex_val: the value of a hex digit, or -1.
+# the value of a hex digit, or -1
 fun hex_val(c: u8) i64 {
     if (c >= '0' && c <= '9') { ret (c - '0')::i64; }
     if (c >= 'a' && c <= 'f') { ret (c - 'a')::i64 + 10; }
@@ -1969,9 +1969,9 @@ fun hex_val(c: u8) i64 {
     ret 0 - 1;
 }
 
-# project_root_for: the nearest ancestor directory of `file_path` that holds a
+# the nearest ancestor directory of `file_path` that holds a
 # `mach.toml`, as an owned string, or nil when none exists. walks up to the
-# filesystem root with `path.parent` / `path.join`.
+# filesystem root with `path.parent` / `path.join`
 fun project_root_for(alloc: *Allocator, file_path: str) str {
     val first_r: Result[pathlib.Path, str] = pathlib.parent(alloc, file_path);
     if (is_err[pathlib.Path, str](first_r)) { ret nil; }
@@ -1999,11 +1999,11 @@ fun project_root_for(alloc: *Allocator, file_path: str) str {
     ret nil;
 }
 
-# normalize_path: a lexically normalized owned copy of an absolute `path`,
+# a lexically normalized owned copy of an absolute `path`,
 # collapsing `.` segments and `seg/..` pairs (clamped at the root). dependency
 # file paths carry literal `..` from the manifest's dir_dep joins; clients
 # cannot correlate such locations with open buffers, so every emitted URI is
-# normalized here on the LSP side (the vendored driver is not ours to change).
+# normalized here on the LSP side (the vendored driver is not ours to change)
 fun normalize_path(alloc: *Allocator, path: str) str {
     val n: usize = str_len(path);
     val r: Result[*u8, str] = allocate[u8](alloc, n + 2);
@@ -2037,8 +2037,8 @@ fun normalize_path(alloc: *Allocator, path: str) str {
     ret buf::str;
 }
 
-# norm_uri: a `file://` URI for an already-normalized absolute path, owned by
-# the caller, or nil on allocation failure.
+# a `file://` URI for an already-normalized absolute path, owned by
+# the caller, or nil on allocation failure
 fun norm_uri(alloc: *Allocator, norm: str) str {
     val scheme: str = "file://";
     val plen: usize = str_len(norm);
@@ -2054,7 +2054,7 @@ fun norm_uri(alloc: *Allocator, norm: str) str {
     ret buf::str;
 }
 
-# append: copy `s` into `buf` at `offset`, returning the new offset.
+# copy `s` into `buf` at `offset`, returning the new offset
 fun append(buf: *u8, offset: usize, s: str) usize {
     if (s == nil) { ret offset; }
     val n: usize = str_len(s);
@@ -2091,8 +2091,8 @@ test "project: sema_ready is true only when loaded and sema'd" {
     ret 0;
 }
 
-# t_cat: concatenate two strings into a fresh nul-terminated owned buffer. a test
-# helper; the page allocator reclaims the leaked copies on dnit.
+# concatenate two strings into a fresh nul-terminated owned buffer. a test
+# helper; the page allocator reclaims the leaked copies on dnit
 fun t_cat(alloc: *Allocator, a: str, b: str) str {
     val total: usize = str_len(a) + str_len(b);
     val r: Result[*u8, str] = allocate[u8](alloc, total + 1);
@@ -2105,21 +2105,21 @@ fun t_cat(alloc: *Allocator, a: str, b: str) str {
     ret buf::str;
 }
 
-# t_manifest: the scaffolded project's mach.toml (id "proj", host-resolved native
-# target), mirroring the three-target shape the driver's own union tests use.
+# the scaffolded project's mach.toml (id "proj", host-resolved native
+# target), mirroring the three-target shape the driver's own union tests use
 fun t_manifest() str {
     ret "[project]\nid = \"proj\"\nname = \"p\"\nversion = \"0.0.0\"\nsrc = \"src\"\ntarget = \"native\"\nout = \"out/{target}/bin/{name}{ext}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\next = \".exe\"\n\n[target.linux-arm64]\nisa = \"aarch64\"\nos = \"linux\"\nabi = \"aapcs64\"\n\n[bin.proj]\nentry = \"main.mach\"\n";
 }
 
-# t_write: write `text` to `path` (test helper), true on success.
+# write `text` to `path` (test helper), true on success
 fun t_write(path: str, text: str) bool {
     if (path == nil) { ret false; }
     ret !is_err[bool, str](fs.write_file(path, text, str_len(text), 420));
 }
 
-# t_scaffold: materialize a temp "proj" project (manifest + src/main,leaf,other) on
+# materialize a temp "proj" project (manifest + src/main,leaf,other) on
 # disk and return its owned root path, or nil. the caller removes the tree via
-# fs.remove_all. main imports both leaf and other; only leaf is edited by the test.
+# fs.remove_all. main imports both leaf and other; only leaf is edited by the test
 fun t_scaffold(alloc: *Allocator, main_text: str, leaf_text: str) str {
     val tf_r: Result[fs.TempFile, str] = fs.temp_create(alloc, "mls_inc_test");
     if (is_err[fs.TempFile, str](tf_r)) { ret nil; }
@@ -2140,9 +2140,9 @@ fun t_scaffold(alloc: *Allocator, main_text: str, leaf_text: str) str {
     ret root;
 }
 
-# t_imported_decl: the DeclId (as u32) the buffer's resolve binds the imported symbol
+# the DeclId (as u32) the buffer's resolve binds the imported symbol
 # named `name` to, or 0xFFFFFFFF when absent (test helper). cross-session safe: the
-# name is matched by interned text on `s`.
+# name is matched by interned text on `s`
 fun t_imported_decl(s: *sess.Session, rr: *res.ResolveResult, name: str) u32 {
     if (rr == nil) { ret 0xFFFFFFFF; }
     var i: u32 = 0;
@@ -2156,9 +2156,9 @@ fun t_imported_decl(s: *sess.Session, rr: *res.ResolveResult, name: str) u32 {
     ret 0xFFFFFFFF;
 }
 
-# t_module_rr: the borrowed (query-DB-owned) ResolveResult handle of the loaded module
+# the borrowed (query-DB-owned) ResolveResult handle of the loaded module
 # at `uri` in `root`, or nil (test helper). pointer identity across a reload proves the
-# module's Q_RESOLVE entry was reused.
+# module's Q_RESOLVE entry was reused
 fun t_module_rr(w: *Workspace, root: *Root, uri: str) *res.ResolveResult {
     val mo: Option[sess.ModuleId] = module_for_uri(w, root, uri);
     if (is_none[sess.ModuleId](mo)) { ret nil; }
@@ -2167,10 +2167,10 @@ fun t_module_rr(w: *Workspace, root: *Root, uri: str) *res.ResolveResult {
     ret unwrap[ModuleView](mv).rr;
 }
 
-# t_buffer_fa_decl: open `main_text` at `main_uri` in a fresh workspace over `root`'s
+# open `main_text` at `main_uri` in a fresh workspace over `root`'s
 # on-disk graph and return the DeclId its `use proj.leaf.fa` binds to (test helper).
 # 0xFFFFFFFF on any failure. the from-scratch oracle the incremental result is checked
-# against.
+# against
 fun t_buffer_fa_decl(alloc: *Allocator, root: str, main_uri: str, main_text: str) u32 {
     val srB: Result[sess.Session, str] = sess.init(alloc);
     if (is_err[sess.Session, str](srB)) { ret 0xFFFFFFFF; }
@@ -2204,7 +2204,7 @@ test "project incremental: an on-disk dep edit reloads correctly (matches fresh)
     val main_text: str = "use proj.leaf.fa;\nuse proj.other.fb;\nfun main() i32 { ret fa() + fb(); }\n";
     val leaf_v1:   str = "pub fun fa() i32 { ret 1; }\n";
     # pub-surface change: prepend a new pub function, shifting fa's DeclId — a change
-    # the importer's binding genuinely depends on.
+    # the importer's binding genuinely depends on
     val leaf_v2:   str = "pub fun fz() i32 { ret 0; }\npub fun fa() i32 { ret 1; }\n";
 
     val root: str = t_scaffold(?alloc, main_text, leaf_v1);
@@ -2224,7 +2224,7 @@ test "project incremental: an on-disk dep edit reloads correctly (matches fresh)
 
     var bad: i32 = 0;
 
-    # cold build: open main, load the project, resolve the buffer against the v1 graph.
+    # cold build: open main, load the project, resolve the buffer against the v1 graph
     val fA_r: Result[src.FileId, str] = editor.open(?esA, main_uri, main_text);
     if (is_err[src.FileId, str](fA_r)) { bad = 1; }
     or {
@@ -2236,7 +2236,7 @@ test "project incremental: an on-disk dep edit reloads correctly (matches fresh)
             if (is_err[*res.ResolveResult, str](rrA1_r)) { bad = 1; }
             or {
                 val fa_decl_pre: u32 = t_imported_decl(?sA, unwrap_ok[*res.ResolveResult, str](rrA1_r), "fa");
-                # capture the query-DB resolve handles of the unaffected and edited modules.
+                # capture the query-DB resolve handles of the unaffected and edited modules
                 val rr_other_1: *res.ResolveResult = t_module_rr(?wA, rootA1, other_uri);
                 val rr_leaf_1:  *res.ResolveResult = t_module_rr(?wA, rootA1, leaf_uri);
                 if (rr_other_1 == nil || rr_leaf_1 == nil) { bad = 1; }
@@ -2245,7 +2245,7 @@ test "project incremental: an on-disk dep edit reloads correctly (matches fresh)
                 if (!t_write(leaf_path, leaf_v2)) { bad = 1; }
                 invalidate_uri(?wA, leaf_uri);
 
-                # incremental reload + re-resolve the buffer against the v2 graph.
+                # incremental reload + re-resolve the buffer against the v2 graph
                 val rootA2: *Root = root_for(?wA, main_uri);
                 if (rootA2 == nil) { bad = 1; }
                 or {
@@ -2265,8 +2265,8 @@ test "project incremental: an on-disk dep edit reloads correctly (matches fresh)
                         if (fa_decl_post == fa_decl_pre) { bad = 1; }
                         if (fa_decl_post == 0xFFFFFFFF) { bad = 1; }
 
-                        # correctness: the incrementally-reloaded result equals a
-                        # from-scratch workspace built over the final on-disk graph.
+                        # the incrementally-reloaded result equals a
+                        # from-scratch workspace built over the final on-disk graph
                         val fa_decl_fresh: u32 = t_buffer_fa_decl(?alloc, root, main_uri, main_text);
                         if (fa_decl_post != fa_decl_fresh) { bad = 1; }
                     }

--- a/src/project.mach
+++ b/src/project.mach
@@ -5,19 +5,19 @@
 # SYMBOL_NIL and go-to-definition / references / hover cannot reach it. this
 # module closes that gap: for each project root open in the session it loads a
 # module graph from disk through the compiler's own `driver.build_project_union`
-# (manifest + lockfile + the `dep/` tree — the union of every declared target's
+# (manifest + lockfile + the `dep/` tree - the union of every declared target's
 # import closure, so modules reachable only via a non-default target are present),
 # snapshots every loaded module's
 # public surface into a `res.ResolveDeps`, and re-resolves an open buffer
-# against that dep set with `res.resolve` directly — the lower-level API the
+# against that dep set with `res.resolve` directly - the lower-level API the
 # editor's `resolve` wraps.
 #
 # multi-root by design: a `Workspace` holds one `Root` per distinct project
 # root open in the session, each with its own `driver.Project`, dep snapshot,
 # and synthetic buffer-id base. a document is routed to the root that governs
 # its path (the nearest ancestor `mach.toml`); a document that is a dependency
-# module of a root rooted elsewhere — already loaded, or an ancestor project
-# loaded on demand when the document's own root is nested under it — is routed
+# module of a root rooted elsewhere - already loaded, or an ancestor project
+# loaded on demand when the document's own root is nested under it - is routed
 # to that root read-only, rather than spun up as its own project; a document
 # under no `mach.toml` resolves single-file (empty dep set). the legacy "one
 # project per session" behaviour is just the one-Root case.
@@ -25,12 +25,12 @@
 # module-id namespacing: `driver.build_project_union` allocates project-local
 # module ids from 0 and writes them into the session's global module registries,
 # so a second build over the same session clobbers the first there. those clobbered
-# registries are never read for a lookup — every cross-module lookup (site_of,
+# registries are never read for a lookup - every cross-module lookup (site_of,
 # module_view, ...) reads the per-`Root` `driver.Project.modules` array, whose
 # ids are private to that project. the seam guarding that invariant is a
 # narrowed surface, not a language seal: no feature signature carries a
-# `*sess.Session` — feature code is handed only the per-root accessors plus the
-# two never-clobbered session services (`interner` / `sources`) — so reading a
+# `*sess.Session` - feature code is handed only the per-root accessors plus the
+# two never-clobbered session services (`interner` / `sources`) - so reading a
 # session module registry takes deliberately reaching through `Workspace.s` or
 # the vendored `EditorSession.s`, both of which stay readable because mach's
 # `pub` publishes whole recs (no field-level visibility). each `Root` is
@@ -48,14 +48,14 @@
 # cache stamps each entry with the generation of the root build it resolved
 # against (`Root.gen`, a fresh value per successful build; 0 reserved for a
 # single-file resolve), so a build's teardown makes every entry from it
-# structurally unhittable — no entry survives its root's reload as a stale hit —
+# structurally unhittable - no entry survives its root's reload as a stale hit -
 # while a freed root's entries are evicted per-root rather than by clearing the
 # whole cache.
 #
 # incremental rebuild (lsp #117): the free-and-reload is not a from-scratch
 # rebuild. mach 2.5.7's driver is query-engine-driven, and the session query DB
 # (Q_PARSE / Q_RESOLVE / Q_EXPORTS) lives on `Workspace.s` and SURVIVES
-# `driver.dnit_project` — only the per-build `driver.Project` arrays are freed.
+# `driver.dnit_project` - only the per-build `driver.Project` arrays are freed.
 # so the next `build_project_union` reuses every unchanged module's cached parse
 # and resolve and recomputes only the edited module plus the importers whose
 # public surface moved past the Q_EXPORTS firewall; an on-disk edit's cost is the
@@ -63,7 +63,7 @@
 # graph from a still-unsaved buffer's LIVE text (overriding the driver's per-module
 # disk read): the driver's `parse_module` unconditionally re-reads disk and
 # mirrors it into Q_FILE_TEXT, and the editor's buffers live in their own
-# (URI-keyed) FileId space disjoint from the project's (path-keyed) modules — so an
+# (URI-keyed) FileId space disjoint from the project's (path-keyed) modules - so an
 # unsaved edit reaches an open buffer's own analysis but not its importers'. closing
 # that gap needs a driver-side source-overlay API the vendored driver does not yet
 # expose (tracked as a mach follow-up); until then a cross-module feature reflects an
@@ -123,7 +123,7 @@ use json:      mls.json;
 use trace:     mls.trace;
 use mtypes:    mls.types;
 
-# where a resolved symbol's declaration lives — the Ast and SourceFile to
+# where a resolved symbol's declaration lives - the Ast and SourceFile to
 # read its spans from, and the document URI to report. for a buffer-local symbol
 # this is the request's own buffer; for a cross-module symbol it is the defining
 # dependency module's on-disk file
@@ -139,10 +139,10 @@ pub rec Site {
     owned: bool;
 }
 
-# one buffer's dep-aware resolve result — and, lazily, its sema result —
+# one buffer's dep-aware resolve result - and, lazily, its sema result -
 # stamped with the Ast it was resolved from and the generation of the root build
 # it resolved against. the editor replaces a buffer's `*ast.Ast` on every text
-# update (`drop_analysis`), so Ast pointer identity catches a text edit — the same
+# update (`drop_analysis`), so Ast pointer identity catches a text edit - the same
 # contract `editor.resolve` uses for its own cached result; `gen` catches a
 # cross-root or post-reload staleness, since a result resolved against one build
 # never matches a different build's stamp. the resolve result is populated on every
@@ -180,12 +180,12 @@ rec Cached {
 # man_mtime:      `mach.toml` mtime at the last load attempt, for the
 #                 conservative reload / retry check
 # lock_mtime:     `mach.lock` mtime at the last load attempt (0 when absent)
-# gen:            generation stamp of the current loaded build — a fresh value
+# gen:            generation stamp of the current loaded build - a fresh value
 #                 claimed on each successful load, 0 (reserved) while unloaded;
 #                 resolve cache entries carry it, so a reload or free makes the
 #                 prior build's entries unhittable and per-root evictable
 # vendored:       whether this root's own directory lies under some outer
-#                 project's declared vendor dir — i.e. the whole root is a
+#                 project's declared vendor dir - i.e. the whole root is a
 #                 vendored dependency project, so none of its files are the
 #                 editor's to rewrite, regardless of any loaded graph's closure.
 #                 intrinsic to the path (computed at load_root from the ancestor
@@ -218,7 +218,7 @@ pub rec Root {
 # s:            the compiler session. feature code must reach its safe services
 #               through `interner` / `sources` and never read this field: its
 #               per-build module registries are clobbered on every project load,
-#               and mach's whole-rec `pub` means the field cannot be sealed —
+#               and mach's whole-rec `pub` means the field cannot be sealed -
 #               keeping it out of feature paths is the contract
 # es:           borrowed editor session (buffer parsing)
 # alloc:        allocator for owned storage
@@ -238,7 +238,7 @@ pub rec Root {
 # sema_epoch:   monotonic counter bumped whenever a root's dep closure finishes
 #               sema (ensure_sema), so the server can tell a feature request
 #               triggered the lazy whole-closure typing and re-publish the open
-#               buffers WITH their semantic diagnostics — the type-diagnostics
+#               buffers WITH their semantic diagnostics - the type-diagnostics
 #               twin of load_epoch (#113)
 pub rec Workspace {
     s:            *sess.Session;
@@ -279,7 +279,7 @@ pub fun init(s: *sess.Session, es: *editor.EditorSession, alloc: *Allocator) Wor
     ret w;
 }
 
-# the session's shared string interner — the append-only symbol-name
+# the session's shared string interner - the append-only symbol-name
 # registry feature code resolves StrIds through. handed out instead of the whole
 # session so no feature signature carries one: the session's per-build module
 # registries are clobbered on every project load, and the interner and source
@@ -327,7 +327,7 @@ pub fun set_watch_active(w: *Workspace, on: bool) {
     w.watch_active = on;
 }
 
-# the workspace's current load epoch — a counter bumped on every
+# the workspace's current load epoch - a counter bumped on every
 # successful root build. the server snapshots it around a feature request; a
 # change means a lazy project load completed, so the open buffers it now governs
 # can have their diagnostics re-published with semantic (dep-aware) results
@@ -339,12 +339,12 @@ pub fun load_epoch(w: *Workspace) u32 {
     ret w.load_epoch;
 }
 
-# the workspace's current sema epoch — a counter bumped whenever a
+# the workspace's current sema epoch - a counter bumped whenever a
 # root's dep closure finishes typing (ensure_sema). the server snapshots it around
 # a feature request alongside the load epoch; a change means a type-aware feature
 # lazily sema'd a closure, so the open buffers it governs can be re-published with
-# their semantic diagnostics — which the load-free publish path could not produce
-# while the closure was still un-sema'd — without waiting for an edit (#113)
+# their semantic diagnostics - which the load-free publish path could not produce
+# while the closure was still un-sema'd - without waiting for an edit (#113)
 # ---
 # w:   the workspace
 # ret: the current sema epoch
@@ -354,7 +354,7 @@ pub fun sema_epoch(w: *Workspace) u32 {
 
 # whether `root`'s loaded dep closure has already been sema'd, so its
 # retained per-module typing exists. a load-free check: it never triggers a build
-# or ensure_sema. the diagnostics publish path gates buffer sema on this — only on
+# or ensure_sema. the diagnostics publish path gates buffer sema on this - only on
 # a ready root is sema_doc cheap and correct (one module against retained dep
 # typing); a loaded-but-un-sema'd root publishes parse + resolve only, keeping
 # open/edit instant (#96). false for a nil, unloaded, or un-sema'd root
@@ -412,7 +412,7 @@ pub fun resolve_doc(w: *Workspace, root: *Root, fid: src.FileId) Result[*res.Res
 }
 
 # re-resolve buffer `a` (FileId `fid`) against `root`'s dep set
-# unconditionally — the cache-miss core shared by `resolve_doc` (after its cache
+# unconditionally - the cache-miss core shared by `resolve_doc` (after its cache
 # check) and `diagnose_doc` (which forces a fresh parse to repopulate the session
 # DiagList). drops any prior cached result for `fid`, resolves with `res.resolve`,
 # and caches the new result. the resolve's diagnostics land on the session
@@ -463,12 +463,12 @@ fun resolve_fresh(w: *Workspace, root: *Root, fid: src.FileId, a: *ast.Ast) Resu
     ret ok[*res.ResolveResult, str](slot);
 }
 
-# the buffer's SemaResult under `root` — its per-expression typing,
+# the buffer's SemaResult under `root` - its per-expression typing,
 # computed against the root's dep-closure typing. the type-aware twin of
 # `resolve_doc`: it first resolves the buffer (populating the resolve cache entry),
 # then, on a cache miss for the same Ast / build, lazily sema's the whole root
 # graph (`ensure_sema`) so every dependency's decl types are available, and finally
-# sema's the buffer itself against a SemaDeps spanning every sema'd root module —
+# sema's the buffer itself against a SemaDeps spanning every sema'd root module -
 # keyed on the same Ast-pointer / generation stamp the resolve cache uses, so an
 # unedited buffer reuses it. heavy on a cold root (the first call pays for the whole
 # dep closure), so it is reached only from a type-aware feature, never the
@@ -562,8 +562,8 @@ fun cache_slot(w: *Workspace, fid: src.FileId) *Cached {
 
 # parse and dep-aware-resolve the buffer governed by `root`,
 # returning the session DiagList populated with both its syntactic and its
-# name-resolution diagnostics. resolving against `root.deps` — the same dep set
-# go-to-definition uses — is what makes an import of a module outside the
+# name-resolution diagnostics. resolving against `root.deps` - the same dep set
+# go-to-definition uses - is what makes an import of a module outside the
 # project's dep closure surface its `imported module is not in the dep set`
 # diagnostic instead of binding silently to SYMBOL_NIL, so the published
 # diagnostics and what the features can resolve no longer disagree (#78). the
@@ -603,7 +603,7 @@ pub fun own_module(root: *Root, fid: src.FileId) sess.ModuleId {
     ret (base + fid::u32)::sess.ModuleId;
 }
 
-# the generation stamp a buffer's resolve carries under `root` — the
+# the generation stamp a buffer's resolve carries under `root` - the
 # root's current build generation, or the reserved 0 for a single-file document
 # (root nil). the single source of the stamp rule, shared by cache_put's write
 # and cache_hit's check so the two sides cannot drift
@@ -615,8 +615,8 @@ fun root_gen(root: *Root) u32 {
 # the root governing the document at `uri`, loading it on first use,
 # or nil when the document resolves single-file (no ancestor `mach.toml`, or a
 # remembered failed load). a document that is a dependency module of a root
-# rooted elsewhere — whether that root is already loaded, or is an ancestor
-# project loaded here on demand — is routed to that root read-only, rather than
+# rooted elsewhere - whether that root is already loaded, or is an ancestor
+# project loaded here on demand - is routed to that root read-only, rather than
 # spun up as its own project, regardless of document open order
 # ---
 # w:   the workspace
@@ -646,7 +646,7 @@ pub fun root_for(w: *Workspace, uri: str) *Root {
 
     # fresh root: when an ancestor project declares this root as one of its dep
     # vendor dirs, load that project and prefer it when its graph holds the
-    # document — so a dependency source opened before any project document
+    # document - so a dependency source opened before any project document
     # still routes read-only instead of becoming its own renameable project
     val outer: *Root = ancestor_root(w, uri, doc_root, doc_root);
     if (outer != nil) { strutil.str_free(w.alloc, doc_root); ret outer; }
@@ -655,7 +655,7 @@ pub fun root_for(w: *Workspace, uri: str) *Root {
 }
 
 # the root governing the document at `uri` ONLY when it is
-# already loaded — never triggering a build. unlike `root_for`, this neither
+# already loaded - never triggering a build. unlike `root_for`, this neither
 # loads a fresh root nor speculatively loads a vendoring ancestor nor reloads a
 # stale one; it returns nil when no loaded root holds the document. the
 # diagnostics publish path uses this so opening or editing a buffer publishes
@@ -672,7 +672,7 @@ pub fun root_for_loaded(w: *Workspace, uri: str) *Root {
     if (uri == nil) { ret nil; }
 
     # a loaded root rooted elsewhere holding the document governs it read-only,
-    # exactly as in root_for — checked without reloading
+    # exactly as in root_for - checked without reloading
     val twin: *Root = containing_root_loaded(w, uri);
     if (twin != nil) { ret twin; }
 
@@ -689,11 +689,11 @@ pub fun root_for_loaded(w: *Workspace, uri: str) *Root {
 # walks the chain of ancestor manifest dirs strictly above `dir` (`doc_root` on
 # the outer call), outermost first; an ancestor is only considered when its
 # manifest declares a dependency whose vendor dir encloses `doc_root`
-# (`vendors_enclosing`), so unrelated outer projects — a monorepo root, this repo
-# above its test fixtures — are never speculatively built. the outermost
+# (`vendors_enclosing`), so unrelated outer projects - a monorepo root, this repo
+# above its test fixtures - are never speculatively built. the outermost
 # considered ancestor whose loaded graph holds the document governs it; one that
 # loads but does not hold it stays loaded (it is a real project) and the walk
-# falls inward to the next vendoring ancestor — so a dependency nested inside
+# falls inward to the next vendoring ancestor - so a dependency nested inside
 # another dependency's tree reaches the outermost project that actually closes
 # over it, not merely its immediate parent. ancestors already tracked are
 # skipped: a loaded one was already offered by containing_root, and a failed one
@@ -722,7 +722,7 @@ fun ancestor_root(w: *Workspace, uri: str, doc_root: str, dir: str) *Root {
 }
 
 # whether the project at `root_path` declares a dependency
-# whose vendor dir encloses `dir` — i.e. `dir` equals or lies under
+# whose vendor dir encloses `dir` - i.e. `dir` equals or lies under
 # `<root>/<[project].dep>/<alias>` for some `[deps.<alias>]`, the same layout the
 # driver's dep resolution reads. one small manifest parse answers "could this
 # project's dependency tree contain that nested root?" without paying a full
@@ -730,10 +730,10 @@ fun ancestor_root(w: *Workspace, uri: str, doc_root: str, dir: str) *Root {
 # enclosure rather than equality is the speculative-build gate that lets a dep
 # nested inside another dep's tree reach the outermost vendoring project, not
 # merely its immediate parent, while still never building unrelated outer
-# projects — a monorepo root, this repo above its test fixtures — whose declared
+# projects - a monorepo root, this repo above its test fixtures - whose declared
 # vendor dirs enclose nothing the document sits in. a manifest that fails to read
 # or parse vendors nothing. the parsed table is leaked into the server's page
-# allocator — std.data.toml exposes no teardown, the same convention the driver's
+# allocator - std.data.toml exposes no teardown, the same convention the driver's
 # own manifest reads use
 fun vendors_enclosing(w: *Workspace, root_path: str, dir: str) bool {
     val mp_r: Result[pathlib.Path, str] = pathlib.join(w.alloc, root_path, "mach.toml");
@@ -799,7 +799,7 @@ fun find_root(w: *Workspace, root_path: str) *Root {
 # `uri` as a module (matched on the normalized filesystem path), skipping the
 # document's own root at `doc_root` (which find_root handles, with its
 # outside-the-closure files resolving against its dep set). when several loaded
-# roots hold the document — an outer project and a dependency nested within it —
+# roots hold the document - an outer project and a dependency nested within it -
 # the outermost wins (the shortest root path, since every holder is an ancestor
 # of the document on one root-to-file chain and so they nest), so a dependency
 # module routes to the project that vendors it regardless of which root loaded
@@ -830,7 +830,7 @@ fun containing_root(w: *Workspace, uri: str, doc_root: str) *Root {
 }
 
 # the load-free counterpart of `containing_root` for the
-# diagnostics publish path — the outermost already-loaded root whose graph holds
+# diagnostics publish path - the outermost already-loaded root whose graph holds
 # the document at `uri`, without the per-candidate `maybe_reload` (which would
 # rebuild a stale root). selection is identical otherwise: the shortest holding
 # root path wins, so a vendored module routes to the project that vendors it. nil
@@ -856,7 +856,7 @@ fun containing_root_loaded(w: *Workspace, uri: str) *Root {
 }
 
 # claim a slot for `root_path` (taking ownership of the string) and
-# build its graph. the vendored flag is stamped once here — intrinsic to the
+# build its graph. the vendored flag is stamped once here - intrinsic to the
 # path, so every root-creating path (root_for's fresh-root load, ancestor_root's
 # speculative loads) gets it correct, and it survives in-place reloads (which keep
 # the slot). on failure the slot is kept as a remembered failed load and nil is
@@ -871,14 +871,14 @@ fun load_root(w: *Workspace, root_path: str) *Root {
 }
 
 # whether `root_path`'s own directory lies under some
-# strict-ancestor project's declared vendor dir — i.e. this root is a vendored
+# strict-ancestor project's declared vendor dir - i.e. this root is a vendored
 # dependency of an outer project. climbs the chain of ancestor manifest dirs
 # strictly above `root_path` (the same dirs ancestor_root walks), asking
 # vendors_enclosing of each; true on the first whose declared dep vendor dir
 # encloses `root_path`. this is a property of the path, not of how the root was
 # reached: a root materialized as an outer vendoring project for a deeper dep is
 # still flagged when it itself sits under a grandparent's vendor dir, which is
-# correct — its own sources remain a vendored dependency. a root with no such
+# correct - its own sources remain a vendored dependency. a root with no such
 # ancestor (a top-level project, even one that loads dep modules) is not vendored
 fun vendored_under_ancestor(w: *Workspace, root_path: str) bool {
     var cur: str = root_path;
@@ -1040,7 +1040,7 @@ fun free_mod_paths(w: *Workspace, r: *Root) {
 }
 
 # rebuild `r`'s graph when its manifest or lockfile changed on
-# disk since the last load attempt — the conservative fallback for clients that
+# disk since the last load attempt - the conservative fallback for clients that
 # do not deliver `workspace/didChangeWatchedFiles`, and the retry path for a
 # root whose previous load failed (a since-fixed manifest). skipped entirely
 # when file watching is active: the watcher already invalidates on those
@@ -1081,7 +1081,7 @@ pub fun invalidate_uri(w: *Workspace, uri: str) {
 }
 
 # whether `file_norm` (a normalized absolute path) lies within the
-# project rooted at `root_path` — equal to it or under it
+# project rooted at `root_path` - equal to it or under it
 fun root_covers(w: *Workspace, file_norm: str, root_path: str) bool {
     if (root_path == nil) { ret false; }
     val rn: str = normalize_path(w.alloc, root_path);
@@ -1235,7 +1235,7 @@ pub fun free_site(w: *Workspace, site: *Site) {
 }
 
 # a borrowed view of one loaded module for the workspace-wide
-# use-site walk — its parsed Ast, resolve side tables, and backing source file
+# use-site walk - its parsed Ast, resolve side tables, and backing source file
 # ---
 # a:    the module's parsed Ast (decl / expr / type ids index into it)
 # rr:   the module's ResolveResult side tables
@@ -1300,7 +1300,7 @@ pub fun module_sema(w: *Workspace, root: *Root, mid: sess.ModuleId) Option[*sema
 
 # the semantic type of expression `eid` in SemaResult `sr`, or TYPE_NIL
 # when `sr` is nil or `eid` is out of range. the narrow read the feature layer
-# makes to learn an expression's type — handed a SemaResult (from `sema_doc` or
+# makes to learn an expression's type - handed a SemaResult (from `sema_doc` or
 # `module_sema`), never the session. delegates to the pure helper so the rule lives
 # in one unit-testable place
 # ---
@@ -1322,7 +1322,7 @@ pub fun decl_type_of(sr: *sema.SemaResult, did: id.DeclId) type.TypeId {
 }
 
 # the nominal back-link from a record / union TypeId to its declaring
-# site — what a field go-to-def / rename follows from a value's type to the `rec` /
+# site - what a field go-to-def / rename follows from a value's type to the `rec` /
 # `uni` declaration whose fields it must walk. carries the field range (uniform
 # across rec / uni, both being TypedName slices in `a.typed_names`) and the
 # module's Ast / source so field spans can be read directly
@@ -1345,13 +1345,13 @@ pub rec RecordSite {
 }
 
 # the declaring site a record / union TypeId nominally refers to,
-# resolved against the session's type interner and the root's loaded module array —
+# resolved against the session's type interner and the root's loaded module array -
 # the nominal back-link field features follow. peels a pointer to its pointee and
 # maps a generic instance to its template. none when `tid` is not a nominal type,
 # the declaring module is not a loaded project module, or the declaration is not a
 # rec / uni. the returned Ast / file pointers are owned by the loaded project /
 # session. a record declared in the active buffer (whose synthetic module id is not
-# in the loaded array) is not found here — use `record_decl_in`, which falls back to
+# in the loaded array) is not found here - use `record_decl_in`, which falls back to
 # the buffer's live Ast for that case
 # ---
 # w:    the workspace
@@ -1420,7 +1420,7 @@ fun nominal_of_tid(w: *Workspace, root: *Root, tid: type.TypeId) Option[mtypes.N
 
 # build a RecordSite for the rec / uni decl `decl` in `a` (backed
 # by `file`), or none when the decl is absent or not a rec / uni. the shared core
-# of `record_decl` / `record_decl_in` — both having chosen which Ast / file the
+# of `record_decl` / `record_decl_in` - both having chosen which Ast / file the
 # declaration lives in
 fun record_site_from(origin: sess.ModuleId, decl: id.DeclId, a: *ast.Ast, file: *src.SourceFile) Option[RecordSite] {
     val d_opt: Option[*adecl.Decl] = ast.get_decl(a, decl);
@@ -1466,7 +1466,7 @@ pub fun module_uri(w: *Workspace, root: *Root, mid: sess.ModuleId) str {
 # matching is lexical (`.` / `..` collapse only): the std fs surface exposes
 # neither realpath nor inode identity, so a buffer opened through a symlinked or
 # differently-cased path does not match its twin and that file is walked as a
-# separate module — yielding duplicate locations / a duplicate WorkspaceEdit key
+# separate module - yielding duplicate locations / a duplicate WorkspaceEdit key
 # for the same physical file
 # ---
 # w:    the workspace
@@ -1511,7 +1511,7 @@ pub fun root_vendored(root: *Root) bool {
 }
 
 # whether loaded module `mid` in `root` belongs to the user's
-# own editable project rather than a vendored dependency — false outright when
+# own editable project rather than a vendored dependency - false outright when
 # the whole root is a vendored dependency project (root_vendored), otherwise true
 # iff the module's fully-qualified path's head segment is the project id. rename
 # gates cross-file edits on it so a dependency's declaration (e.g. a std symbol,
@@ -1537,8 +1537,8 @@ pub fun is_project_module(w: *Workspace, root: *Root, mid: sess.ModuleId) bool {
     ret fqn[plen] == '.';
 }
 
-# the project root governing `uri` — the nearest ancestor of its
-# decoded filesystem path holding a `mach.toml` — as an owned string, or nil
+# the project root governing `uri` - the nearest ancestor of its
+# decoded filesystem path holding a `mach.toml` - as an owned string, or nil
 # for a non-file URI or a document outside any project
 fun document_root(w: *Workspace, uri: str) str {
     val path: str = uri_to_path(w.alloc, uri);
@@ -1671,14 +1671,14 @@ fun free_deps(w: *Workspace, deps: *res.ResolveDeps) {
 }
 
 # run the type checker over `root`'s loaded module graph, retaining
-# one SemaResult per module on the Root — the lazy core of the type-aware layer.
+# one SemaResult per module on the Root - the lazy core of the type-aware layer.
 # a no-op once it has run for the current build (sema_loaded) or for an unloaded
 # root. modules are sema'd in dependency (topological) order, each against a
 # SemaDeps assembled from the decl_type snapshots of the modules already sema'd in
 # this pass, exactly as the compiler's own build does; a module that did not
 # resolve is skipped, leaving a zeroed SemaResult that types to TYPE_NIL. the pass
 # is heavy (it walks the whole dep closure), so it runs only when a feature first
-# demands typing — never on the diagnostics publish hot path — and is cached until
+# demands typing - never on the diagnostics publish hot path - and is cached until
 # the build reloads. on completion it bumps the workspace sema epoch, the signal
 # the server uses to re-publish the open buffers with semantic diagnostics now
 # that the closure's retained typing exists (#113). allocation failure leaves the
@@ -1721,7 +1721,7 @@ pub fun ensure_sema(w: *Workspace, root: *Root) {
 
 # type-check one loaded module against the modules already sema'd
 # this pass, storing its SemaResult into `root.sema[mid]` and marking it ready. a
-# module that did not resolve (no resolve_result) is left zeroed and unready — its
+# module that did not resolve (no resolve_result) is left zeroed and unready - its
 # types stay TYPE_NIL and dependents simply do not see it among their deps. the
 # comptime context the driver populated for the module (`m.ctx`) drives array-length
 # and `$if`-gate evaluation, matching how the compiler sema's the same module. on
@@ -1742,12 +1742,12 @@ fun run_module_sema(w: *Workspace, root: *Root, mid: sess.ModuleId, ready: *bool
     ready[mid::u32]     = true;
 }
 
-# assemble the SemaDeps for the module about to be analysed — one
+# assemble the SemaDeps for the module about to be analysed - one
 # ModuleSema entry per module already sema'd this pass (ready), each borrowing that
 # module's decl_type snapshot. cross-module symbol types are looked up by the
 # symbol's origin ModuleId, and a `fwd` re-export carries the originating
 # (transitive) module as the origin, so the snapshot must cover every ready module,
-# not only the direct dependencies — all of them are strictly earlier in topo order
+# not only the direct dependencies - all of them are strictly earlier in topo order
 # and thus already produced. mirrors the compiler's own build_sema_deps. writes the
 # assembled deps into `out`; false on allocation failure (the caller skips the
 # module). an empty set (no module ready yet) is a successful result
@@ -1797,7 +1797,7 @@ fun free_sema_deps(w: *Workspace, deps: *sema.SemaDeps) {
 }
 
 # zero a freshly allocated SemaResult array so an un-run or skipped
-# module's slot has nil arrays — a lookup against it types to TYPE_NIL, never a
+# module's slot has nil arrays - a lookup against it types to TYPE_NIL, never a
 # wild read. mirrors how the resolve cache zero-fills its gaps
 fun zero_sema(arr: *sema.SemaResult, n: u32) {
     var i: u32 = 0;
@@ -1830,7 +1830,7 @@ fun cache_hit(w: *Workspace, fid: src.FileId, a: *ast.Ast, root: *Root) *res.Res
 # store `rr` (resolved from Ast `a` against the build stamped `gen`,
 # or 0 for single-file) as the cached result for `fid`, growing the cache to
 # cover the FileId and zero-filling any gap. false when the grow allocation fails
-# — the caller owns `rr` and must free it
+# - the caller owns `rr` and must free it
 fun cache_put(w: *Workspace, fid: src.FileId, rr: *res.ResolveResult, a: *ast.Ast, gen: u32) bool {
     val needed: u32 = fid::u32 + 1;
     if (needed > w.cache_len) {
@@ -1859,7 +1859,7 @@ fun cache_put(w: *Workspace, fid: src.FileId, rr: *res.ResolveResult, a: *ast.As
 }
 
 # free a cache slot's owned ResolveResult and SemaResult and zero
-# the slot — the one teardown for a Cached entry, shared by every reclamation path.
+# the slot - the one teardown for a Cached entry, shared by every reclamation path.
 # the sema result (populated lazily by sema_doc, nil otherwise) is torn down first.
 # callers guard `c.rr != nil`
 fun release_entry(w: *Workspace, c: *Cached) {
@@ -1890,7 +1890,7 @@ pub fun free_cached(w: *Workspace, fid: src.FileId) {
 
 # release every cached result resolved against root `r`'s current
 # build (matched by generation), reclaiming the entries a graph teardown
-# invalidates. a no-op for an unloaded slot (gen 0, no build of its own — and
+# invalidates. a no-op for an unloaded slot (gen 0, no build of its own - and
 # never the single-file entries that also carry gen 0, since those belong to no
 # root). called by free_root_graph at every reload / free, replacing the blanket
 # whole-cache clear
@@ -2203,7 +2203,7 @@ test "project incremental: an on-disk dep edit reloads correctly (matches fresh)
 
     val main_text: str = "use proj.leaf.fa;\nuse proj.other.fb;\nfun main() i32 { ret fa() + fb(); }\n";
     val leaf_v1:   str = "pub fun fa() i32 { ret 1; }\n";
-    # pub-surface change: prepend a new pub function, shifting fa's DeclId — a change
+    # pub-surface change: prepend a new pub function, shifting fa's DeclId - a change
     # the importer's binding genuinely depends on
     val leaf_v2:   str = "pub fun fz() i32 { ret 0; }\npub fun fa() i32 { ret 1; }\n";
 

--- a/src/server.mach
+++ b/src/server.mach
@@ -26,17 +26,17 @@ use std.allocator.deallocate;
 
 use mem: std.memory;
 
-use sess: mach.lang.session;
-use src:  mach.lang.source;
+use sess:   mach.lang.session;
+use src:    mach.lang.source;
 use editor: mach.lang.editor;
 
-use transport: mls.transport;
-use json:      mls.json;
-use documents: mls.documents;
+use transport:   mls.transport;
+use json:        mls.json;
+use documents:   mls.documents;
 use diagnostics: mls.diagnostics;
-use language:  mls.language;
-use project:   mls.project;
-use trace:     mls.trace;
+use language:    mls.language;
+use project:     mls.project;
+use trace:       mls.trace;
 
 # lifecycle statuses
 pub val STATUS_UNINITIALIZED: u8 = 0;

--- a/src/server.mach
+++ b/src/server.mach
@@ -1,4 +1,4 @@
-# mls.server: top-level server state, lifecycle, message loop, and dispatch.
+# top-level server state, lifecycle, message loop, and dispatch
 #
 # owns the long-lived state of one server process: the lifecycle status, the
 # allocator, the compiler `session.Session` (SourceMap + DiagList), the
@@ -38,13 +38,13 @@ use language:  mls.language;
 use project:   mls.project;
 use trace:     mls.trace;
 
-# lifecycle statuses.
+# lifecycle statuses
 pub val STATUS_UNINITIALIZED: u8 = 0;
 pub val STATUS_RUNNING:       u8 = 1;
 pub val STATUS_SHUTTING_DOWN: u8 = 2;
 pub val STATUS_EXITED:        u8 = 3;
 
-# Server: the long-lived server state.
+# the long-lived server state
 # ---
 # status:        current lifecycle phase
 # exit_code:     process exit code to return from `run`
@@ -66,7 +66,7 @@ pub rec Server {
     watch_dynamic: bool;
 }
 
-# init: build a server over the given allocator.
+# build a server over the given allocator
 # ---
 # srv:   server to initialize
 # alloc: allocator backing all server-owned memory; must outlive the server
@@ -87,7 +87,7 @@ pub fun init(srv: *Server, alloc: *Allocator) bool {
     ret true;
 }
 
-# dnit: tear down the server's owned state.
+# tear down the server's owned state
 # ---
 # srv: server to tear down
 pub fun dnit(srv: *Server) {
@@ -98,7 +98,7 @@ pub fun dnit(srv: *Server) {
     srv.status = STATUS_EXITED;
 }
 
-# run: read and dispatch framed messages until the server exits.
+# read and dispatch framed messages until the server exits
 # ---
 # srv: the server to drive
 # ret: the process exit code
@@ -131,7 +131,7 @@ pub fun run(srv: *Server) i64 {
     ret srv.exit_code;
 }
 
-# dispatch: route one message body by its `method` field.
+# route one message body by its `method` field
 fun dispatch(srv: *Server, msg: *transport.Message) {
     val body: str = msg.body;
     val method: str = json.extract_string(body, "\"method\"", srv.alloc);
@@ -236,8 +236,8 @@ fun dispatch(srv: *Server, msg: *transport.Message) {
     reply_error(srv, body, -32601, "method not found");
 }
 
-# handle_initialize: answer the initialize request with the server's
-# capabilities (full-text document sync) and mark the server running.
+# answer the initialize request with the server's
+# capabilities (full-text document sync) and mark the server running
 fun handle_initialize(srv: *Server, body: str) {
     val id: str = json.extract_raw(body, "\"id\"", srv.alloc);
     if (id == nil) { ret; }
@@ -255,11 +255,11 @@ fun handle_initialize(srv: *Server, body: str) {
     trace.log("initialized\n");
 }
 
-# handle_initialized: once the client signals it is ready, register file
+# once the client signals it is ready, register file
 # watchers for the manifest, lockfile, and source trees so a dep-graph change
 # (pulling deps, editing a dep source) triggers `workspace/didChangeWatchedFiles`
 # and the affected project root is rebuilt. only sent when the client advertised
-# dynamic registration; clients without it fall back to the server's mtime check.
+# dynamic registration; clients without it fall back to the server's mtime check
 fun handle_initialized(srv: *Server) {
     if (!srv.watch_dynamic) { ret; }
     val reg: str = "{\"jsonrpc\":\"2.0\",\"id\":\"mls/registerWatchers\",\"method\":\"client/registerCapability\",\"params\":{\"registrations\":[{\"id\":\"mls-watched-files\",\"method\":\"workspace/didChangeWatchedFiles\",\"registerOptions\":{\"watchers\":[{\"globPattern\":\"**/mach.toml\"},{\"globPattern\":\"**/mach.lock\"},{\"globPattern\":\"**/*.mach\"}]}}]}}";
@@ -269,9 +269,9 @@ fun handle_initialized(srv: *Server) {
     project.set_watch_active(?srv.ws, true);
 }
 
-# handle_did_change_watched_files: invalidate every project root whose tree
+# invalidate every project root whose tree
 # contains a changed file, so the next request rebuilds it from disk. each
-# `uri` in the notification's `changes` array is invalidated in turn.
+# `uri` in the notification's `changes` array is invalidated in turn
 fun handle_did_change_watched_files(srv: *Server, body: str) {
     var i: u32 = 0;
     for (true) {
@@ -283,7 +283,7 @@ fun handle_did_change_watched_files(srv: *Server, body: str) {
     }
 }
 
-# handle_shutdown: acknowledge a shutdown request and enter the shutting-down phase.
+# acknowledge a shutdown request and enter the shutting-down phase
 fun handle_shutdown(srv: *Server, body: str) {
     val id: str = json.extract_raw(body, "\"id\"", srv.alloc);
     if (id != nil) {
@@ -295,14 +295,14 @@ fun handle_shutdown(srv: *Server, body: str) {
     srv.status = STATUS_SHUTTING_DOWN;
 }
 
-# handle_exit: exit the process, with code 0 only after a clean shutdown.
+# exit the process, with code 0 only after a clean shutdown
 fun handle_exit(srv: *Server) {
     if (srv.status == STATUS_SHUTTING_DOWN) { srv.exit_code = 0; }
     or { srv.exit_code = 1; }
     srv.status = STATUS_EXITED;
 }
 
-# handle_did_open: register the opened document and publish its diagnostics.
+# register the opened document and publish its diagnostics
 fun handle_did_open(srv: *Server, body: str) {
     val uri: str = json.extract_after(body, "\"textDocument\"", "\"uri\"", srv.alloc);
     if (uri == nil) { ret; }
@@ -315,9 +315,9 @@ fun handle_did_open(srv: *Server, body: str) {
     json.free_str(uri, srv.alloc);
 }
 
-# handle_did_change: apply the document's new full text and republish diagnostics.
+# apply the document's new full text and republish diagnostics.
 # only full-document sync (textDocumentSync = 1) is advertised, so the change is
-# the entire new text.
+# the entire new text
 fun handle_did_change(srv: *Server, body: str) {
     val uri: str = json.extract_after(body, "\"textDocument\"", "\"uri\"", srv.alloc);
     if (uri == nil) { ret; }
@@ -330,8 +330,8 @@ fun handle_did_change(srv: *Server, body: str) {
     json.free_str(uri, srv.alloc);
 }
 
-# handle_did_close: retire the document, reclaim its cached resolve result, and
-# clear its diagnostics.
+# retire the document, reclaim its cached resolve result, and
+# clear its diagnostics
 fun handle_did_close(srv: *Server, body: str) {
     val uri: str = json.extract_after(body, "\"textDocument\"", "\"uri\"", srv.alloc);
     if (uri == nil) { ret; }
@@ -342,12 +342,12 @@ fun handle_did_close(srv: *Server, body: str) {
     json.free_str(uri, srv.alloc);
 }
 
-# handle_feature: route a language-feature request to its handler in `language`.
+# route a language-feature request to its handler in `language`.
 # the document uri is extracted once here and passed through; the feature code
 # resolves the buffer, pivots the cursor, and replies. `which` selects the
 # feature: 0 hover, 1 definition, 2 references, 3 rename, 4 prepareRename,
 # 5 documentSymbol, 6 completion. an unknown / unopened uri still gets a
-# null / empty reply from the feature so the client is never left waiting.
+# null / empty reply from the feature so the client is never left waiting
 fun handle_feature(srv: *Server, body: str, which: i64) {
     val uri: str = json.extract_after(body, "\"textDocument\"", "\"uri\"", srv.alloc);
 
@@ -355,7 +355,7 @@ fun handle_feature(srv: *Server, body: str, which: i64) {
     # governing project lazily on first use; a type-aware feature additionally
     # sema's the closure lazily (ensure_sema). snapshot both the load epoch and the
     # sema epoch so a load (#96) or a first sema (#113) triggered here re-publishes
-    # the now-loaded / now-typed buffers' diagnostics.
+    # the now-loaded / now-typed buffers' diagnostics
     val epoch_before: u32 = project.load_epoch(?srv.ws);
     val sema_before:  u32 = project.sema_epoch(?srv.ws);
 
@@ -372,7 +372,7 @@ fun handle_feature(srv: *Server, body: str, which: i64) {
     if (project.load_epoch(?srv.ws) != epoch_before || project.sema_epoch(?srv.ws) != sema_before) { republish_loaded(srv); }
 }
 
-# republish_loaded: re-publish diagnostics for every open document now governed
+# re-publish diagnostics for every open document now governed
 # by a loaded project root. run after a feature request triggers a lazy load (#96)
 # or the first whole-closure sema (#113): the buffers under the freshly-loaded root
 # were published parse-only on open, so a load upgrades them to dep-aware
@@ -380,7 +380,7 @@ fun handle_feature(srv: *Server, body: str, which: i64) {
 # and a completed sema further layers their type diagnostics, all without the user
 # touching the file. the publish path is load-free, so a buffer under no loaded
 # root simply re-publishes its parse-only diagnostics (unchanged), and nothing new
-# is built.
+# is built
 fun republish_loaded(srv: *Server) {
     val n: usize = documents.slot_count(?srv.docs);
     var i: usize = 0;
@@ -393,8 +393,8 @@ fun republish_loaded(srv: *Server) {
     }
 }
 
-# publish_for: register/update `uri`'s buffer and publish its diagnostics.
-# `is_open` selects open vs change registration; both end in a publish.
+# register/update `uri`'s buffer and publish its diagnostics.
+# `is_open` selects open vs change registration; both end in a publish
 fun publish_for(srv: *Server, uri: str, text: str, is_open: bool) {
     var dr: Result[*documents.Document, str];
     if (is_open) { dr = documents.open(?srv.docs, uri, text); }
@@ -410,8 +410,8 @@ fun publish_for(srv: *Server, uri: str, text: str, is_open: bool) {
     diagnostics.publish(?srv.ws, ?srv.es, project.sources(?srv.ws), srv.alloc, uri, doc.file_id);
 }
 
-# reply_error: send a JSON-RPC error response for a request that carries an id;
-# a no-op for a notification (no id).
+# send a JSON-RPC error response for a request that carries an id;
+# a no-op for a notification (no id)
 fun reply_error(srv: *Server, body: str, code: i64, message: str) {
     val id: str = json.extract_raw(body, "\"id\"", srv.alloc);
     if (id == nil) { ret; }
@@ -430,13 +430,13 @@ fun reply_error(srv: *Server, body: str, code: i64, message: str) {
     json.free_str(id, srv.alloc);
 }
 
-# send_concat2: frame and send `a + b + c`.
+# frame and send `a + b + c`
 fun send_concat2(srv: *Server, a: str, b: str, c: str) {
     send_concat(srv, a, b, c, nil, nil, nil, nil);
 }
 
-# send_concat: frame and send the concatenation of up to seven fragments,
-# skipping nil fragments.
+# frame and send the concatenation of up to seven fragments,
+# skipping nil fragments
 fun send_concat(srv: *Server, a: str, b: str, c: str, d: str, e: str, f: str, g: str) {
     val total: usize = flen(a) + flen(b) + flen(c) + flen(d) + flen(e) + flen(f) + flen(g);
     val r: Result[*u8, str] = allocate[u8](srv.alloc, total + 1);
@@ -457,13 +457,13 @@ fun send_concat(srv: *Server, a: str, b: str, c: str, d: str, e: str, f: str, g:
     deallocate[u8](srv.alloc, buf, total + 1);
 }
 
-# flen: length of `s`, treating nil as 0.
+# length of `s`, treating nil as 0
 fun flen(s: str) usize {
     if (s == nil) { ret 0; }
     ret str_len(s);
 }
 
-# fappend: copy `s` into `buf` at `offset`, returning the new offset.
+# copy `s` into `buf` at `offset`, returning the new offset
 fun fappend(buf: *u8, offset: usize, s: str) usize {
     if (s == nil) { ret offset; }
     val n: usize = str_len(s);

--- a/src/server.mach
+++ b/src/server.mach
@@ -376,7 +376,7 @@ fun handle_feature(srv: *Server, body: str, which: i64) {
 # by a loaded project root. run after a feature request triggers a lazy load (#96)
 # or the first whole-closure sema (#113): the buffers under the freshly-loaded root
 # were published parse-only on open, so a load upgrades them to dep-aware
-# resolution diagnostics — including any out-of-closure import the load now flags —
+# resolution diagnostics - including any out-of-closure import the load now flags -
 # and a completed sema further layers their type diagnostics, all without the user
 # touching the file. the publish path is load-free, so a buffer under no loaded
 # root simply re-publishes its parse-only diagnostics (unchanged), and nothing new

--- a/src/trace.mach
+++ b/src/trace.mach
@@ -1,4 +1,4 @@
-# mls.trace: append-only file trace log for debugging the server over stdio.
+# append-only file trace log for debugging the server over stdio
 #
 # the LSP speaks JSON-RPC on stdout, so diagnostics about the server's own
 # behaviour cannot go there. every notable event is appended to a fixed log
@@ -21,24 +21,24 @@ use std.types.bool.false;
 use os: std.system.os;
 use env: std.process.env;
 
-# LOG_PATH: fixed file the trace log is appended to.
+# fixed file the trace log is appended to
 val LOG_PATH: str = "/tmp/mach-lsp.log";
 
-# TRACE_VAR: environment variable that enables tracing when set.
+# environment variable that enables tracing when set
 val TRACE_VAR: str = "MLS_TRACE";
 
-# LOG_CHECKED: whether the MLS_TRACE gate has been evaluated yet.
+# whether the MLS_TRACE gate has been evaluated yet
 var LOG_CHECKED: bool = false;
 
-# LOG_ENABLED: cached MLS_TRACE gate; writes happen only when true.
+# cached MLS_TRACE gate; writes happen only when true
 var LOG_ENABLED: bool = false;
 
-# LOG_FD: trace log descriptor, opened lazily once tracing is enabled. -1
+# trace log descriptor, opened lazily once tracing is enabled. -1
 # until opened, and left at -1 when the open fails so logging stays a silent
-# no-op (best-effort).
+# no-op (best-effort)
 var LOG_FD: i64 = -1;
 
-# trace_enabled: report whether the MLS_TRACE variable is set.
+# report whether the MLS_TRACE variable is set
 # ---
 # ret: true when MLS_TRACE is present in the environment
 fun trace_enabled() bool {
@@ -46,7 +46,7 @@ fun trace_enabled() bool {
     ret env.get(TRACE_VAR, ?buf[0], 1) >= 0;
 }
 
-# trace_open: open the trace log for appending.
+# open the trace log for appending
 # ---
 # ret: a live descriptor, or a negative value on failure
 fun trace_open() i64 {
@@ -54,7 +54,7 @@ fun trace_open() i64 {
     ret os.open(os.AT_FDCWD, LOG_PATH::*u8, flags, 420);
 }
 
-# log: append a message to the trace log, best-effort.
+# append a message to the trace log, best-effort
 #
 # the MLS_TRACE gate and log descriptor are resolved on the first call and
 # reused thereafter; when tracing is disabled this returns with no syscalls.

--- a/src/trace.mach
+++ b/src/trace.mach
@@ -18,7 +18,7 @@ use std.types.bool.bool;
 use std.types.bool.true;
 use std.types.bool.false;
 
-use os: std.system.os;
+use os:  std.system.os;
 use env: std.process.env;
 
 # fixed file the trace log is appended to

--- a/src/transport.mach
+++ b/src/transport.mach
@@ -3,7 +3,7 @@
 # every message is a set of `Header: value\r\n` lines, a blank line, then a
 # body of exactly `Content-Length` bytes. this module reads one framed message
 # at a time from stdin and writes one framed message to stdout. it owns no
-# protocol semantics — the body is opaque JSON the server layer interprets.
+# protocol semantics - the body is opaque JSON the server layer interprets.
 
 use std.types.bool.bool;
 use std.types.bool.true;

--- a/src/transport.mach
+++ b/src/transport.mach
@@ -1,4 +1,4 @@
-# mls.transport: LSP base-protocol framing over stdin/stdout.
+# LSP base-protocol framing over stdin/stdout
 #
 # every message is a set of `Header: value\r\n` lines, a blank line, then a
 # body of exactly `Content-Length` bytes. this module reads one framed message
@@ -25,8 +25,8 @@ use mem: std.memory;
 
 use trace: mls.trace;
 
-# Message: one received LSP message. `body` is the owned, nil-terminated JSON
-# payload of length `body_len`; free it with `message_free`.
+# one received LSP message. `body` is the owned, nil-terminated JSON
+# payload of length `body_len`; free it with `message_free`
 # ---
 # body:     owned nil-terminated JSON body
 # body_len: length of the body in bytes (excluding the terminator)
@@ -35,16 +35,16 @@ pub rec Message {
     body_len: usize;
 }
 
-# HEADER_PREFIX: the only response header the server emits.
+# the only response header the server emits
 val HEADER_PREFIX: str = "Content-Length: ";
-# CRLF_CRLF: the header/body separator.
+# the header/body separator
 val CRLF_CRLF: str = "\r\n\r\n";
-# HEADER_BUF_INITIAL: starting capacity for the header accumulation buffer.
+# starting capacity for the header accumulation buffer
 val HEADER_BUF_INITIAL: usize = 256;
-# CL_KEY: lowercased Content-Length header name for case-insensitive matching.
+# lowercased Content-Length header name for case-insensitive matching
 val CL_KEY: str = "content-length";
 
-# message_free: release a message's owned body.
+# release a message's owned body
 # ---
 # msg:   message whose body is freed and zeroed
 # alloc: allocator the body was read with
@@ -56,7 +56,7 @@ pub fun message_free(msg: *Message, alloc: *Allocator) {
     msg.body_len = 0;
 }
 
-# read_message: read one framed message from stdin into `msg`.
+# read one framed message from stdin into `msg`
 # ---
 # msg:   message to populate; its body is owned by `alloc` on success
 # alloc: allocator for the header scratch buffer and the body
@@ -128,7 +128,7 @@ pub fun read_message(msg: *Message, alloc: *Allocator) bool {
     ret true;
 }
 
-# send_message: write `body` as one framed message to stdout.
+# write `body` as one framed message to stdout
 # ---
 # body:  nil-terminated JSON body to send; nil / empty is a no-op
 # alloc: allocator for the send buffer
@@ -166,7 +166,7 @@ pub fun send_message(body: str, alloc: *Allocator) {
     deallocate[u8](alloc, buf, total);
 }
 
-# write_all: write exactly `len` bytes of `buf` to stdout, retrying short writes.
+# write exactly `len` bytes of `buf` to stdout, retrying short writes
 fun write_all(buf: *u8, len: usize) {
     var off: usize = 0;
     for (off < len) {
@@ -176,8 +176,8 @@ fun write_all(buf: *u8, len: usize) {
     }
 }
 
-# parse_content_length: scan accumulated header bytes for a Content-Length value
-# (case-insensitive key), or -1 when absent / unparseable.
+# scan accumulated header bytes for a Content-Length value
+# (case-insensitive key), or -1 when absent / unparseable
 fun parse_content_length(hdr: *u8, hdr_len: usize) i64 {
     val cl_len: usize = str_len(CL_KEY);
     var line_start: usize = 0;
@@ -236,8 +236,8 @@ fun parse_content_length(hdr: *u8, hdr_len: usize) i64 {
     ret -1;
 }
 
-# usize_to_buf: write `value` in base 10 right-aligned into the tail of `buf`,
-# returning the number of digits written.
+# write `value` in base 10 right-aligned into the tail of `buf`,
+# returning the number of digits written
 fun usize_to_buf(buf: *u8, buf_cap: usize, value: usize) usize {
     if (value == 0) {
         buf[buf_cap - 1] = '0';

--- a/src/types.mach
+++ b/src/types.mach
@@ -2,7 +2,7 @@
 #
 # the feature layer reads per-expression types and the nominal back-link from a
 # record TypeId to its declaring module here, so the resolution rules live in one
-# place — and, being free of any session / project state, are unit-testable in
+# place - and, being free of any session / project state, are unit-testable in
 # isolation. `project.mach` re-exports these through its own narrowed accessors so
 # no feature signature carries a `*sess.Session`.
 
@@ -34,7 +34,7 @@ use id:     mach.lang.fe.ast.id;
 use sema:   mach.lang.fe.sema;
 use intern: mach.lang.intern;
 
-# the declaration site a record / union TypeId nominally refers to —
+# the declaration site a record / union TypeId nominally refers to -
 # the back-link a field feature follows from a value's type to the `rec` / `uni`
 # declaration whose fields it must walk. for a generic instance this is the
 # generic template's declaration (`target_origin` / `target_decl`)
@@ -77,7 +77,7 @@ pub fun decl_type_of(sr: *sema.SemaResult, did: id.DeclId) type.TypeId {
 # the declaration site a record / union TypeId nominally refers to,
 # or none when `tid` is not a nominal type (a primitive, pointer, array, function,
 # generic parameter, or a sentinel). a pointer to a record is peeled to the record
-# first, so `*T` and `T` resolve to the same declaration — a field access through a
+# first, so `*T` and `T` resolve to the same declaration - a field access through a
 # pointer reaches the same `rec` decl. a generic instance resolves to its template
 # declaration. this is the nominal back-link a field go-to-def / rename follows
 # ---

--- a/src/types.mach
+++ b/src/types.mach
@@ -1,4 +1,4 @@
-# mls.types: pure helpers over sema's typing output.
+# pure helpers over sema's typing output
 #
 # the feature layer reads per-expression types and the nominal back-link from a
 # record TypeId to its declaring module here, so the resolution rules live in one
@@ -34,10 +34,10 @@ use id:     mach.lang.fe.ast.id;
 use sema:   mach.lang.fe.sema;
 use intern: mach.lang.intern;
 
-# Nominal: the declaration site a record / union TypeId nominally refers to —
+# the declaration site a record / union TypeId nominally refers to —
 # the back-link a field feature follows from a value's type to the `rec` / `uni`
 # declaration whose fields it must walk. for a generic instance this is the
-# generic template's declaration (`target_origin` / `target_decl`).
+# generic template's declaration (`target_origin` / `target_decl`)
 # ---
 # origin: ModuleId of the declaring module
 # decl:   DeclId of the rec / uni declaration in `origin`'s Ast
@@ -48,9 +48,9 @@ pub rec Nominal {
     kind:   type.TypeKind;
 }
 
-# type_of: the semantic type of expression `eid` in `sr`, or TYPE_NIL when `sr`
+# the semantic type of expression `eid` in `sr`, or TYPE_NIL when `sr`
 # is nil or `eid` is out of range. the one read the feature layer makes against a
-# buffer's / module's SemaResult to learn an expression's type.
+# buffer's / module's SemaResult to learn an expression's type
 # ---
 # sr:  the module's / buffer's SemaResult, or nil
 # eid: the expression id to type
@@ -61,9 +61,9 @@ pub fun type_of(sr: *sema.SemaResult, eid: id.ExprId) type.TypeId {
     ret sr.expr_type[eid];
 }
 
-# decl_type_of: the declared (or inferred) type of decl `did` in `sr`, or
+# the declared (or inferred) type of decl `did` in `sr`, or
 # TYPE_NIL when `sr` is nil or `did` is out of range. the decl-keyed twin of
-# `type_of`, for typing a binding from its declaration rather than a use.
+# `type_of`, for typing a binding from its declaration rather than a use
 # ---
 # sr:  the module's / buffer's SemaResult, or nil
 # did: the declaration id to type
@@ -74,12 +74,12 @@ pub fun decl_type_of(sr: *sema.SemaResult, did: id.DeclId) type.TypeId {
     ret sr.decl_type[did];
 }
 
-# nominal_of: the declaration site a record / union TypeId nominally refers to,
+# the declaration site a record / union TypeId nominally refers to,
 # or none when `tid` is not a nominal type (a primitive, pointer, array, function,
 # generic parameter, or a sentinel). a pointer to a record is peeled to the record
 # first, so `*T` and `T` resolve to the same declaration — a field access through a
 # pointer reaches the same `rec` decl. a generic instance resolves to its template
-# declaration. this is the nominal back-link a field go-to-def / rename follows.
+# declaration. this is the nominal back-link a field go-to-def / rename follows
 # ---
 # ti:  the session's type interner
 # tid: the TypeId to resolve
@@ -111,10 +111,10 @@ pub fun nominal_of(ti: *type.TypeInterner, tid: type.TypeId) Option[Nominal] {
     ret none[Nominal]();
 }
 
-# make_sema_result: build a standalone SemaResult over `pa` with the given
+# build a standalone SemaResult over `pa` with the given
 # parallel-array lengths, every slot prefilled to TYPE_NIL. the test helper that
 # stands in for sema's own allocation so the pure accessors can be exercised
-# without running a whole analysis. released with `free_sema_result`.
+# without running a whole analysis. released with `free_sema_result`
 fun make_sema_result(pa: *Allocator, expr_n: u32, decl_n: u32) sema.SemaResult {
     var sr: sema.SemaResult;
     sr.alloc            = pa;
@@ -145,7 +145,7 @@ fun make_sema_result(pa: *Allocator, expr_n: u32, decl_n: u32) sema.SemaResult {
     ret sr;
 }
 
-# free_sema_result: release a SemaResult built by make_sema_result.
+# release a SemaResult built by make_sema_result
 fun free_sema_result(pa: *Allocator, sr: *sema.SemaResult) {
     if (sr.expr_type != nil && sr.expr_count > 0) {
         deallocate[type.TypeId](pa, sr.expr_type, sr.expr_count::usize);


### PR DESCRIPTION
Brings every tracked `src/*.mach` in line with the current `mach` skill. Formatting and documentation only — semantics unchanged; build and tests pass identically (baseline 38 tests, one pre-existing docstring warning).

Passes:
- Docstrings converted from old `# name: summary.` form to the bare form (lowercase summary, no leading identifier, no trailing period). `# ---` component blocks and module-docstring paragraphs preserved.
- `:`-column alignment in field blocks, use/fwd groups, and consecutive val/var runs where it aids scanning.
- Naming and 4-space-indent verification (snake_case funcs, PascalCase types, SCREAMING_SNAKE constants; LSP protocol field names kept spec-faithful per the file's existing convention).

Closes #127