### PR TITLE
chore(manifest): RFC-exact totality re-touch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- manifest: Re-touched to RFC-exact totality per the V2 manifest spec (mach#1964/mach#1979).
+
 ## [0.9.0] - 2026-07-07
 
 ### Changed

--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "mls"
-name = "Mach Language Server"
-description = "Mach Language Server"
 version = "0.9.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -38,15 +36,19 @@ abi = "aapcs64"
 
 [profile.debug]
 opt = 0
+debug = true
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.mls]
 kind = "bin"
 entry = "main.mach"
 out = "bin/mls"
 targets = ["*"]
+link = []
+need = []
 
 [dep.mach-std]
 git = "https://github.com/briar-systems/mach-std"


### PR DESCRIPTION
Re-touches the manifest to RFC-exact totality under the now-merged strict parser.

Changes:
- `[project]` reduced to exactly id/version/src/out (dropped name/description).
- `[profile.debug]` / `[profile.release]` each spell both `opt` and `debug` (debug=true / release=false).
- `[artifact.mls]` spells `link = []` and `need = []`.
- CHANGELOG Unreleased entry.

Verified with the strict compiler: `mach dep pull` clean, `mach build --profile debug` and `--profile release` both green.

Refs briar-systems/mach#1979