### PR TITLE
chore(manifest): add required simd = "scalarize" to profiles

### DIFF
--- a/mach.toml
+++ b/mach.toml
@@ -37,10 +37,12 @@ abi = "aapcs64"
 [profile.debug]
 opt = 0
 debug = true
+simd = "scalarize"
 
 [profile.release]
 opt = 2
 debug = false
+simd = "scalarize"
 
 [artifact.mls]
 kind = "bin"


### PR DESCRIPTION
Sets the required `simd` profile key (default posture `scalarize`) on every declared `[profile.X]`, per the mach SIMD tier-1 required-key rollout (briar-systems/mach#2013 / #2017). No other manifest changes.

Verified: builds clean under both the 3.3.1 seed and a from-source current-dev mach.

Part of briar-systems/mach#2046.