### PR TITLE
fix: adapt to released mach front-end API drift (bump pin past simd/flag-day manifests)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - manifest: Re-touched to RFC-exact totality per the V2 manifest spec (mach#1964/mach#1979).
 
+### Fixed
+- deps: Bumped the vendored mach pin (`5b3eef8d` → `8045f941`, v3.5.1) past the required `simd` profile key (mach#1965/mach#2013) and the #1971 flag-day strict-root manifest parse, so the server loads current `mach.toml` manifests instead of rejecting them (`unknown key 'simd'`). (#131)
+
 ## [0.9.0] - 2026-07-07
 
 ### Changed

--- a/mach.lock
+++ b/mach.lock
@@ -8,4 +8,4 @@ commit = "9c6eb77880de143090ef48645ba7353ec786d758"
 [dep.mach]
 url = "https://github.com/briar-systems/mach"
 ref = "branch/main"
-commit = "5b3eef8d04d16f1747142932337fb451f093311c"
+commit = "8045f941514915281e4ff957ea5bba5bdd15b508"

--- a/src/project.mach
+++ b/src/project.mach
@@ -2106,9 +2106,11 @@ fun t_cat(alloc: *Allocator, a: str, b: str) str {
 }
 
 # the scaffolded project's mach.toml (id "proj", host-resolved native
-# target), mirroring the three-target shape the driver's own union tests use
+# target), mirroring the three-target shape the driver's own union tests use.
+# [project] is trimmed to the V2 id/version/src/out totality and the artifact
+# carries the root-required link/need keys (#1964/#1971)
 fun t_manifest() str {
-    ret "[project]\nid = \"proj\"\nname = \"p\"\ndescription = \"p\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[target.linux-arm64]\nisa = \"aarch64\"\nos = \"linux\"\nabi = \"aapcs64\"\n\n[artifact.proj]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/proj\"\ntargets = [\"*\"]\n";
+    ret "[project]\nid = \"proj\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[target.linux-arm64]\nisa = \"aarch64\"\nos = \"linux\"\nabi = \"aapcs64\"\n\n[artifact.proj]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/proj\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
 }
 
 # write `text` to `path` (test helper), true on success


### PR DESCRIPTION
## Summary
The vendored mach pin (`5b3eef8d`) was **215 commits behind `branch/main`** and predated the required `simd` profile key (mach#1965/#2013) and the #1971 flag-day strict-root manifest parse, so even a fresh build of `mls` rejected current `mach.toml` manifests (`unknown key 'simd'`) — including mach's own manifest and this repo's. This bumps the pin to current main and fixes the one drift the bump surfaced.

Same class as #125. Unlike #125, the server's **compiled** call sites needed **no** adaptation: the server consumes the manifest only through the driver/session (`build_project_union`), never calling `manifest.parse` directly, so the parser's new `as_root` axis never reached a server call site (a clean rebuild of all 159 modules is green). The only break was a stale in-tree test fixture.

## Pin
| dep | old | new |
| --- | --- | --- |
| mach | `5b3eef8d04d16f1747142932337fb451f093311c` | `8045f941514915281e4ff957ea5bba5bdd15b508` (v3.5.1) |
| mach-std | `9c6eb77880de143090ef48645ba7353ec786d758` | unchanged (v0.18.0) |

Re-resolved with `rm mach.lock && mach dep pull`.

## Root causes
1. **Stale pin rejects current manifests (runtime).** The bumped parser knows the `simd` profile key and the #1971 strict-root totality; the old pin did not. Fixed by the pin bump alone — no server source change, because the manifest is parsed inside the driver, not at a server call site.
2. **Test fixture predated the V2 root schema (`src/project.mach:2110`, `t_manifest`).** The incremental-reload test scaffolds a root `mach.toml` from `t_manifest()`. Under #1971 strict-root parsing, `[project]` is trimmed to `id`/`version`/`src`/`out` (so `name`/`description` are rejected at root) and each `[artifact]` must spell `link`/`need`. The fixture still carried `name`/`description` and omitted `link`/`need`, so it failed with `unknown key 'name' in [project]`. Dropped `name`/`description` and added `link = []` / `need = []`. (Profiles remain optional in the parser, so none were added.)

## Verification
- `mach build .` — clean rebuild, 159 modules, `mls` binary produced, **0 errors**.
- `mach test .` — **38 passed, 0 failed** (mls.project 5, mls.types 9, mls.features 24).
- **End-to-end (the exact reported failure).** Drove the freshly built `mls` over stdio with a real LSP handshake — `initialize` (rootUri = the mach repo) → `initialized` → `textDocument/didOpen` for `mach/src/main.mach`, whose nearest-ancestor manifest is the mach repo's current `mach.toml` (the one carrying `simd = "scalarize"` profiles that the old pin rejected). Result: `publishDiagnostics` returned an **empty** diagnostics array (full cross-module load succeeded) and **no** `window/showMessage` "failed to load project" / "unknown key" notification. The manifest that previously failed now loads.

## Follow-up
#126 — drift-guard CI so this class of staleness fails loudly instead of accumulating silently.

Closes #131
