### PR TITLE
chore(deps): advance mach pin to v3.6.1 tip (8045f941 -> da9b0896)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - manifest: Re-touched to RFC-exact totality per the V2 manifest spec (mach#1964/mach#1979).
+- deps: Advanced the vendored mach pin (`8045f941` → `da9b0896`, v3.5.1 → v3.6.1) to the current release tip; the only notable delta is the retired x86_64-darwin platform (mach#2104). (#133)
 
 ### Fixed
 - deps: Bumped the vendored mach pin (`5b3eef8d` → `8045f941`, v3.5.1) past the required `simd` profile key (mach#1965/mach#2013) and the #1971 flag-day strict-root manifest parse, so the server loads current `mach.toml` manifests instead of rejecting them (`unknown key 'simd'`). (#131)

--- a/mach.lock
+++ b/mach.lock
@@ -8,4 +8,4 @@ commit = "9c6eb77880de143090ef48645ba7353ec786d758"
 [dep.mach]
 url = "https://github.com/briar-systems/mach"
 ref = "branch/main"
-commit = "8045f941514915281e4ff957ea5bba5bdd15b508"
+commit = "da9b0896b953689e38f1685bb0a3ef2925252edd"


### PR DESCRIPTION
Closes #133

PR #132 re-resolved the vendored mach pin to branch/main tip, which was `8045f941` (v3.5.1) at resolve time; v3.6.1 was tagged hours later. This advances the pin (gitlink + lock) to `da9b0896` (v3.6.1, current main tip).

- No server source changes needed — no lang API drift between v3.5.1 and v3.6.1 affects mls; the delta of note is the x86_64-darwin platform drop (mach#2104).
- Verified: release build clean, `mach test .` 38/38, LSP initialize + didOpen smoke against a live V2-manifest project (mach-std with `isa = ["*"]` link filters) loads with no failure warning and publishes clean diagnostics.