### PR TITLE
chore(release): bump version to 0.10.0 and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-08-07
+
 ### Added
 - diagnostics: a diagnostic's `note` and `help` lines now ride the published
   message, and its secondary `related` locations become LSP
@@ -14,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   build` renders them - but the editor dropped them, throwing away the half of
   a mach diagnostic that says what to do about it. A secondary location
   resolves its own URI, so a "previous definition here" pointing into a
-  dependency module is a link the client can follow.
+  dependency module is a link the client can follow. (#135)
 - json: `Buf`, an append-only growable JSON sink. The fixed-shape
   sum-the-lengths-then-append pattern cannot express a payload whose shape is
   data-dependent (a diagnostic's relatedInformation array); every response of
@@ -31,14 +33,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   surfaces: the `std.filesystem` rename to `read_string` / `metadata` /
   `write_bytes`, `pointer_width` moving from `RegMachine` to the ISA vtable,
   `build_project_union` returning `outcome.Fail`, and `intern_instance` taking
-  the template's nominal TypeId.
+  the template's nominal TypeId. (#135)
 - project: manifest / lockfile staleness is checked in unix nanoseconds rather
   than seconds. The check is an equality test, and a save followed immediately
   by a request lands inside the same second.
-
-### Changed (previously unreleased)
+- deps: Advanced the vendored mach pin (`8045f941` → `da9b0896`, v3.5.1 → v3.6.1) to the then-current release tip; the only notable delta is the retired x86_64-darwin platform (mach#2104). (#133)
 - manifest: Re-touched to RFC-exact totality per the V2 manifest spec (mach#1964/mach#1979).
-- deps: Advanced the vendored mach pin (`8045f941` → `da9b0896`, v3.5.1 → v3.6.1) to the current release tip; the only notable delta is the retired x86_64-darwin platform (mach#2104). (#133)
 
 ### Fixed
 - deps: Bumped the vendored mach pin (`5b3eef8d` → `8045f941`, v3.5.1) past the required `simd` profile key (mach#1965/mach#2013) and the #1971 flag-day strict-root manifest parse, so the server loads current `mach.toml` manifests instead of rejecting them (`unknown key 'simd'`). (#131)

--- a/mach.toml
+++ b/mach.toml
@@ -1,6 +1,6 @@
 [project]
 id = "mls"
-version = "0.9.0"
+version = "0.10.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 


### PR DESCRIPTION
Cuts **v0.10.0**.

Minor bump on a 0.x line: the release advances the vendored mach pin across two majors (`v3.6.1` -> `v4.7.1`) and adds a user-visible feature (diagnostic `note` / `help` / `relatedInformation` reaching the editor). No breaking change to the LSP surface the editor talks to, so this is not a 1.0.

- `mach.toml` version `0.9.0` -> `0.10.0`
- CHANGELOG `[Unreleased]` promoted to `[0.10.0] - 2026-08-07`

The `### Changed (previously unreleased)` block is folded into the single `### Changed` list. Those entries (#133, mach#1979) landed on `dev` after 0.9.0 was cut and ship here.

Contents of the release: #136 (closes #135), #134, #132, #130, #129, #128.

`mach build .` and `mach test .` (51 passed, 0 failed) pass locally on this branch.