### PR TITLE
fix(transport): harden stdio framing and closed-pipe handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- transport: distinguishes clean EOF from malformed/error input, caps LSP
+  headers at 8 KiB and bodies at 16 MiB with overflow-safe `Content-Length`
+  parsing, and surfaces response-write failures to the server loop. Portable
+  POSIX SIGPIPE suppression remains blocked on briar-systems/mach-std#468. (#149)
+
 ## [0.10.0] - 2026-08-07
 
 ### Added

--- a/src/server.mach
+++ b/src/server.mach
@@ -107,13 +107,15 @@ pub fun run(srv: *Server) i64 {
 
     for (srv.status != STATUS_EXITED) {
         var msg: transport.Message;
-        val ok: bool = transport.read_message(?msg, srv.alloc);
-        if (!ok) {
-            if (srv.status == STATUS_SHUTTING_DOWN) {
+        val read_status: transport.ReadStatus = transport.read_message(?msg, srv.alloc);
+        if (read_status != transport.READ_OK) {
+            if (read_status == transport.READ_EOF && srv.status == STATUS_SHUTTING_DOWN) {
                 srv.status = STATUS_EXITED;
                 brk;
             }
-            trace.log("transport: read failed\n");
+            if (read_status == transport.READ_EOF) { trace.log("transport: input closed before shutdown\n"); }
+            or (read_status == transport.READ_MALFORMED) { trace.log("transport: malformed input frame\n"); }
+            or { trace.log("transport: input error\n"); }
             srv.exit_code = 1;
             srv.status = STATUS_EXITED;
             brk;
@@ -125,6 +127,11 @@ pub fun run(srv: *Server) i64 {
 
         dispatch(srv, ?msg);
         transport.message_free(?msg, srv.alloc);
+        if (transport.write_failed()) {
+            trace.log("transport: output failed\n");
+            srv.exit_code = 1;
+            srv.status = STATUS_EXITED;
+        }
     }
 
     trace.log("=== mach-lsp exiting ===\n");

--- a/src/transport.mach
+++ b/src/transport.mach
@@ -1,9 +1,9 @@
-# LSP base-protocol framing over stdin/stdout
+# bounded LSP base-protocol framing over stdin/stdout
 #
-# every message is a set of `Header: value\r\n` lines, a blank line, then a
-# body of exactly `Content-Length` bytes. this module reads one framed message
-# at a time from stdin and writes one framed message to stdout. it owns no
-# protocol semantics - the body is opaque JSON the server layer interprets.
+# reads one `Content-Length` frame at a time, distinguishes clean EOF from a
+# truncated / malformed frame and an OS error, and caps both headers and bodies
+# before allocating from attacker-controlled lengths. writes are latched: once
+# stdout fails, every later send reports false without attempting more output.
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -17,7 +17,6 @@ use std.types.result.unwrap_ok;
 
 use std.allocator.Allocator;
 use std.allocator.allocate;
-use std.allocator.reallocate;
 use std.allocator.deallocate;
 
 use os:  std.system.os;
@@ -25,230 +24,270 @@ use mem: std.memory;
 
 use trace: mls.trace;
 
-# one received LSP message. `body` is the owned, nil-terminated JSON
-# payload of length `body_len`; free it with `message_free`
-# ---
-# body:     owned nil-terminated JSON body
-# body_len: length of the body in bytes (excluding the terminator)
+# one received message. `body` is owned and nil-terminated
 pub rec Message {
     body:     str;
     body_len: usize;
 }
 
-# the only response header the server emits
-val HEADER_PREFIX: str = "Content-Length: ";
-# the header/body separator
-val CRLF_CRLF: str = "\r\n\r\n";
-# starting capacity for the header accumulation buffer
-val HEADER_BUF_INITIAL: usize = 256;
-# lowercased Content-Length header name for case-insensitive matching
-val CL_KEY: str = "content-length";
+# read_message outcomes
+pub def ReadStatus: u8;
+pub val READ_OK:        ReadStatus = 0;
+pub val READ_EOF:       ReadStatus = 1;
+pub val READ_MALFORMED: ReadStatus = 2;
+pub val READ_ERROR:     ReadStatus = 3;
 
-# release a message's owned body
+# protocol resource bounds. 8 KiB is ample for LSP headers; 16 MiB admits large
+# full-text didOpen/didChange messages without allowing an advertised length to
+# drive an unbounded allocation
+val HEADER_MAX: usize = 8 * 1024;
+val BODY_MAX:   usize = 16 * 1024 * 1024;
+
+val HEADER_PREFIX: str = "Content-Length: ";
+val CRLF_CRLF:     str = "\r\n\r\n";
+val CL_KEY:        str = "content-length";
+
+# output has one process-wide destination (stdout). latching its first failure
+# prevents later handlers from silently pretending that a response was sent
+var WRITE_FAILED: bool = false;
+
+# release a message's owned body and zero it
 # ---
-# msg:   message whose body is freed and zeroed
-# alloc: allocator the body was read with
+# msg:   message returned by read_message
+# alloc: allocator passed to read_message
 pub fun message_free(msg: *Message, alloc: *Allocator) {
-    if (msg.body != nil && msg.body_len > 0) {
-        deallocate[u8](alloc, msg.body::*u8, msg.body_len + 1);
-    }
+    if (msg.body != nil) { deallocate[u8](alloc, msg.body::*u8, msg.body_len + 1); }
     msg.body = nil;
     msg.body_len = 0;
 }
 
-# read one framed message from stdin into `msg`
+# whether any response write has failed during this process
 # ---
-# msg:   message to populate; its body is owned by `alloc` on success
-# alloc: allocator for the header scratch buffer and the body
-# ret:   true on a complete message, false on EOF or a malformed frame
-pub fun read_message(msg: *Message, alloc: *Allocator) bool {
+# ret: true after the first failed allocation or stdout write
+pub fun write_failed() bool {
+    ret WRITE_FAILED;
+}
+
+# read one bounded frame from stdin
+# ---
+# msg:   output message, owned on READ_OK and zeroed otherwise
+# alloc: allocator for bounded header and body storage
+# ret:   READ_OK, clean READ_EOF, READ_MALFORMED, or READ_ERROR
+pub fun read_message(msg: *Message, alloc: *Allocator) ReadStatus {
     msg.body = nil;
     msg.body_len = 0;
 
-    var hdr_cap: usize = HEADER_BUF_INITIAL;
-    val hr: Result[*u8, str] = allocate[u8](alloc, hdr_cap);
-    if (is_err[*u8, str](hr)) { ret false; }
-    var hdr_buf: *u8 = unwrap_ok[*u8, str](hr);
+    val hr: Result[*u8, str] = allocate[u8](alloc, HEADER_MAX);
+    if (is_err[*u8, str](hr)) { ret READ_ERROR; }
+    val header: *u8 = unwrap_ok[*u8, str](hr);
 
-    var hdr_len: usize = 0;
-    var done: bool = false;
-    for (!done) {
+    var header_len: usize = 0;
+    for (true) {
+        if (header_len >= HEADER_MAX) {
+            deallocate[u8](alloc, header, HEADER_MAX);
+            ret READ_MALFORMED;
+        }
         var c: u8;
-        val n: i64 = os.read(os.STDIN_FD, ?c, 1);
-        if (n <= 0) {
-            deallocate[u8](alloc, hdr_buf, hdr_cap);
-            ret false;
+        val n: i64 = read_retry(?c, 1);
+        if (n == 0) {
+            deallocate[u8](alloc, header, HEADER_MAX);
+            if (header_len == 0) { ret READ_EOF; }
+            ret READ_MALFORMED;
         }
-        hdr_buf[hdr_len] = c;
-        hdr_len = hdr_len + 1;
+        if (n < 0) {
+            deallocate[u8](alloc, header, HEADER_MAX);
+            ret READ_ERROR;
+        }
+        header[header_len] = c;
+        header_len = header_len + 1;
 
-        if (hdr_len >= hdr_cap) {
-            val new_cap: usize = hdr_cap * 2;
-            val gr: Result[*u8, str] = reallocate[u8](alloc, hdr_buf, hdr_cap, new_cap);
-            if (is_err[*u8, str](gr)) {
-                deallocate[u8](alloc, hdr_buf, hdr_cap);
-                ret false;
-            }
-            hdr_buf = unwrap_ok[*u8, str](gr);
-            hdr_cap = new_cap;
-        }
-
-        if (hdr_len >= 4 &&
-            hdr_buf[hdr_len - 4] == '\r' && hdr_buf[hdr_len - 3] == '\n' &&
-            hdr_buf[hdr_len - 2] == '\r' && hdr_buf[hdr_len - 1] == '\n') {
-            done = true;
-        }
+        if (header_len >= 4
+            && header[header_len - 4] == '\r' && header[header_len - 3] == '\n'
+            && header[header_len - 2] == '\r' && header[header_len - 1] == '\n') { brk; }
     }
 
-    val content_length: i64 = parse_content_length(hdr_buf, hdr_len);
-    deallocate[u8](alloc, hdr_buf, hdr_cap);
-    if (content_length <= 0) {
-        trace.log("transport: missing or invalid Content-Length\n");
-        ret false;
+    val body_len_r: i64 = parse_content_length(header, header_len);
+    deallocate[u8](alloc, header, HEADER_MAX);
+    if (body_len_r <= 0 || body_len_r::usize > BODY_MAX) {
+        trace.log("transport: missing, invalid, or oversized Content-Length\n");
+        ret READ_MALFORMED;
     }
-    val body_len: usize = content_length::usize;
+    val body_len: usize = body_len_r::usize;
 
+    # body_len is capped below usize max, so the terminator addition cannot wrap
     val br: Result[*u8, str] = allocate[u8](alloc, body_len + 1);
-    if (is_err[*u8, str](br)) { ret false; }
-    val body_buf: *u8 = unwrap_ok[*u8, str](br);
+    if (is_err[*u8, str](br)) { ret READ_ERROR; }
+    val body: *u8 = unwrap_ok[*u8, str](br);
 
     var got: usize = 0;
     for (got < body_len) {
-        val n: i64 = os.read(os.STDIN_FD, (body_buf::usize + got)::*u8, body_len - got);
-        if (n <= 0) {
-            deallocate[u8](alloc, body_buf, body_len + 1);
-            ret false;
+        val n: i64 = read_retry((body::usize + got)::*u8, body_len - got);
+        if (n == 0) {
+            deallocate[u8](alloc, body, body_len + 1);
+            ret READ_MALFORMED;
+        }
+        if (n < 0) {
+            deallocate[u8](alloc, body, body_len + 1);
+            ret READ_ERROR;
         }
         got = got + n::usize;
     }
-    body_buf[body_len] = 0;
-
-    msg.body = body_buf::str;
+    body[body_len] = 0;
+    msg.body = body::str;
     msg.body_len = body_len;
-    ret true;
+    ret READ_OK;
 }
 
-# write `body` as one framed message to stdout
+# frame and write `body`
 # ---
-# body:  nil-terminated JSON body to send; nil / empty is a no-op
-# alloc: allocator for the send buffer
-pub fun send_message(body: str, alloc: *Allocator) {
-    if (body == nil) { ret; }
+# body:  nil-terminated JSON payload
+# alloc: allocator for the combined header/body frame
+# ret:   true when fully written, false on allocation or stdout failure
+pub fun send_message(body: str, alloc: *Allocator) bool {
+    if (WRITE_FAILED) { ret false; }
+    if (body == nil || str_len(body) == 0) { ret true; }
     val body_len: usize = str_len(body);
-    if (body_len == 0) { ret; }
 
     var digits: [20]u8;
     val digit_len: usize = usize_to_buf(?digits[0], 20, body_len);
     val digit_start: usize = 20 - digit_len;
-
     val prefix_len: usize = str_len(HEADER_PREFIX);
     val sep_len: usize = str_len(CRLF_CRLF);
-    val total: usize = prefix_len + digit_len + sep_len + body_len;
+    # the response body is server-owned and bounded by available address space;
+    # guard the two fixed-size additions before allocating the frame
+    val fixed: usize = prefix_len + digit_len + sep_len;
+    val usize_max: usize = ~(0::usize);
+    if (body_len > usize_max - fixed) { WRITE_FAILED = true; ret false; }
+    val total: usize = fixed + body_len;
 
     val r: Result[*u8, str] = allocate[u8](alloc, total);
-    if (is_err[*u8, str](r)) { ret; }
+    if (is_err[*u8, str](r)) { WRITE_FAILED = true; ret false; }
     val buf: *u8 = unwrap_ok[*u8, str](r);
-
     var off: usize = 0;
-    mem.raw_copy((buf::usize + off)::ptr, HEADER_PREFIX::ptr, prefix_len);
-    off = off + prefix_len;
-    mem.raw_copy((buf::usize + off)::ptr, (?digits[digit_start])::ptr, digit_len);
-    off = off + digit_len;
-    mem.raw_copy((buf::usize + off)::ptr, CRLF_CRLF::ptr, sep_len);
-    off = off + sep_len;
+    mem.raw_copy((buf::usize + off)::ptr, HEADER_PREFIX::ptr, prefix_len); off = off + prefix_len;
+    mem.raw_copy((buf::usize + off)::ptr, (?digits[digit_start])::ptr, digit_len); off = off + digit_len;
+    mem.raw_copy((buf::usize + off)::ptr, CRLF_CRLF::ptr, sep_len); off = off + sep_len;
     mem.raw_copy((buf::usize + off)::ptr, body::ptr, body_len);
 
-    trace.log("send: ");
-    trace.log(body);
-    trace.log("\n");
-
-    write_all(buf, total);
+    trace.log("send: "); trace.log(body); trace.log("\n");
+    val ok: bool = write_all(buf, total);
     deallocate[u8](alloc, buf, total);
+    if (!ok) { WRITE_FAILED = true; }
+    ret ok;
 }
 
-# write exactly `len` bytes of `buf` to stdout, retrying short writes
-fun write_all(buf: *u8, len: usize) {
+# write exactly `len`, accepting short writes. os.write retries EINTR on every
+# supported backend; a zero/negative result is a terminal output failure
+fun write_all(buf: *u8, len: usize) bool {
     var off: usize = 0;
     for (off < len) {
-        val n: i64 = os.write(os.STDOUT_FD, (buf::usize + off)::*u8, len - off);
-        if (n <= 0) { ret; }
+        val n: i64 = write_retry((buf::usize + off)::*u8, len - off);
+        if (n <= 0) { ret false; }
         off = off + n::usize;
     }
+    ret true;
 }
 
-# scan accumulated header bytes for a Content-Length value
-# (case-insensitive key), or -1 when absent / unparseable
-fun parse_content_length(hdr: *u8, hdr_len: usize) i64 {
-    val cl_len: usize = str_len(CL_KEY);
+# std.system.os retries EINTR internally with a bounded guard. If signals exhaust
+# that guard, retry the operation rather than turning an interruption into an LSP
+# transport failure
+fun read_retry(buf: *u8, len: usize) i64 {
+    for (true) {
+        val n: i64 = os.read(os.STDIN_FD, buf, len);
+        if (n != os.EINTR) { ret n; }
+    }
+    ret os.EINTR;
+}
+
+fun write_retry(buf: *u8, len: usize) i64 {
+    for (true) {
+        val n: i64 = os.write(os.STDOUT_FD, buf, len);
+        if (n != os.EINTR) { ret n; }
+    }
+    ret os.EINTR;
+}
+
+# parse exactly one decimal Content-Length, rejecting duplicate fields, trailing
+# junk, values outside BODY_MAX, and overflow before multiplication
+fun parse_content_length(header: *u8, header_len: usize) i64 {
+    val key_len: usize = str_len(CL_KEY);
+    var found: bool = false;
+    var result: usize = 0;
     var line_start: usize = 0;
     var i: usize = 0;
-    for (i <= hdr_len) {
-        val at_end: bool = (i == hdr_len);
-        val is_nl: bool = (!at_end && hdr[i] == '\n');
-        if (at_end || is_nl) {
+    for (i <= header_len) {
+        val at_end: bool = i == header_len;
+        val at_nl: bool = !at_end && header[i] == '\n';
+        if (at_end || at_nl) {
             var line_end: usize = i;
-            if (line_end > line_start && hdr[line_end - 1] == '\r') { line_end = line_end - 1; }
-
-            var colon: i64 = -1;
+            if (line_end > line_start && header[line_end - 1] == '\r') { line_end = line_end - 1; }
+            var colon: usize = line_end;
             var j: usize = line_start;
             for (j < line_end) {
-                if (hdr[j] == ':') { colon = j::i64; brk; }
+                if (header[j] == ':') { colon = j; brk; }
                 j = j + 1;
             }
-            if (colon >= 0) {
-                val key_len: usize = (colon::usize) - line_start;
-                if (key_len == cl_len) {
-                    var match: bool = true;
-                    var k: usize = 0;
-                    for (k < key_len) {
-                        var ch: u8 = hdr[line_start + k];
-                        if (ch >= 'A' && ch <= 'Z') { ch = ch + 32; }
-                        if (ch != CL_KEY[k]) { match = false; brk; }
-                        k = k + 1;
-                    }
-                    if (match) {
-                        var vs: usize = (colon::usize) + 1;
-                        for (vs < line_end) {
-                            val c: u8 = hdr[vs];
-                            if (c != ' ' && c != '\t') { brk; }
-                            vs = vs + 1;
-                        }
-                        var result: i64 = 0;
-                        var valid: bool = false;
-                        var d: usize = vs;
-                        for (d < line_end) {
-                            val digit: u8 = hdr[d];
-                            if (digit >= '0' && digit <= '9') {
-                                result = result * 10 + ((digit - '0')::i64);
-                                valid = true;
-                            }
-                            or { brk; }
-                            d = d + 1;
-                        }
-                        if (valid) { ret result; }
-                    }
+            if (colon < line_end && colon - line_start == key_len && key_equals(header, line_start, key_len)) {
+                if (found) { ret -1; }
+                found = true;
+                var d: usize = colon + 1;
+                for (d < line_end && (header[d] == ' ' || header[d] == '\t')) { d = d + 1; }
+                if (d == line_end) { ret -1; }
+                for (d < line_end) {
+                    val digit: u8 = header[d];
+                    if (digit < '0' || digit > '9') { ret -1; }
+                    val value: usize = (digit - '0')::usize;
+                    # cap while parsing: this bounds arithmetic as well as allocation
+                    if (result > (BODY_MAX - value) / 10) { ret -1; }
+                    result = result * 10 + value;
+                    d = d + 1;
                 }
             }
             line_start = i + 1;
         }
         i = i + 1;
     }
-    ret -1;
+    if (!found || result == 0 || result > BODY_MAX) { ret -1; }
+    ret result::i64;
 }
 
-# write `value` in base 10 right-aligned into the tail of `buf`,
-# returning the number of digits written
-fun usize_to_buf(buf: *u8, buf_cap: usize, value: usize) usize {
-    if (value == 0) {
-        buf[buf_cap - 1] = '0';
-        ret 1;
+fun key_equals(header: *u8, start: usize, len: usize) bool {
+    var i: usize = 0;
+    for (i < len) {
+        var c: u8 = header[start + i];
+        if (c >= 'A' && c <= 'Z') { c = c + 32; }
+        if (c != CL_KEY[i]) { ret false; }
+        i = i + 1;
     }
+    ret true;
+}
+
+fun usize_to_buf(buf: *u8, cap: usize, value: usize) usize {
+    if (value == 0) { buf[cap - 1] = '0'; ret 1; }
     var v: usize = value;
-    var pos: usize = buf_cap;
+    var pos: usize = cap;
     for (v > 0 && pos > 0) {
         pos = pos - 1;
         buf[pos] = ('0' + (v % 10))::u8;
         v = v / 10;
     }
-    ret buf_cap - pos;
+    ret cap - pos;
+}
+
+test "mls.transport.parse_content_length:bounded_strict_decimal" {
+    val valid: str = "content-type: application/vscode-jsonrpc; charset=utf-8\r\nCONTENT-LENGTH: 42\r\n\r\n";
+    if (parse_content_length(valid::*u8, str_len(valid)) != 42) { ret 1; }
+
+    val duplicate: str = "Content-Length: 4\r\ncontent-length: 4\r\n\r\n";
+    if (parse_content_length(duplicate::*u8, str_len(duplicate)) >= 0) { ret 1; }
+
+    val trailing: str = "Content-Length: 12junk\r\n\r\n";
+    if (parse_content_length(trailing::*u8, str_len(trailing)) >= 0) { ret 1; }
+
+    val oversized: str = "Content-Length: 16777217\r\n\r\n";
+    if (parse_content_length(oversized::*u8, str_len(oversized)) >= 0) { ret 1; }
+
+    val overflow: str = "Content-Length: 999999999999999999999999999999999999\r\n\r\n";
+    if (parse_content_length(overflow::*u8, str_len(overflow)) >= 0) { ret 1; }
+    ret 0;
 }

--- a/src/transport.mach
+++ b/src/transport.mach
@@ -275,8 +275,11 @@ fun usize_to_buf(buf: *u8, cap: usize, value: usize) usize {
 }
 
 test "mls.transport.parse_content_length:bounded_strict_decimal" {
-    val valid: str = "content-type: application/vscode-jsonrpc; charset=utf-8\r\nCONTENT-LENGTH: 42\r\n\r\n";
+    val valid: str = "content-type: application/vscode-jsonrpc; charset=utf-8\r\nCoNtEnT-LeNgTh:\t 42\r\n\r\n";
     if (parse_content_length(valid::*u8, str_len(valid)) != 42) { ret 1; }
+
+    val boundary: str = "Content-Length: 16777216\r\n\r\n";
+    if (parse_content_length(boundary::*u8, str_len(boundary)) != BODY_MAX::i64) { ret 1; }
 
     val duplicate: str = "Content-Length: 4\r\ncontent-length: 4\r\n\r\n";
     if (parse_content_length(duplicate::*u8, str_len(duplicate)) >= 0) { ret 1; }

--- a/test/lsp_protocol.py
+++ b/test/lsp_protocol.py
@@ -7,6 +7,7 @@ import argparse
 import json
 import os
 import queue
+import signal
 import subprocess
 import sys
 import tempfile
@@ -14,6 +15,9 @@ import threading
 import time
 from pathlib import Path
 from typing import Any, Callable
+
+HEADER_MAX = 8 * 1024
+BODY_MAX = 16 * 1024 * 1024
 
 
 class ProtocolError(RuntimeError):
@@ -155,11 +159,12 @@ class LspSession:
             f"diagnostics for {uri}",
         )
 
-    def finish(self) -> tuple[int, float, int]:
+    def finish(self, send_exit: bool = True) -> tuple[int, float, int]:
         """Perform shutdown/exit and return process telemetry."""
         response = self.request("shutdown")
         require(response.get("result", object()) is None, f"invalid shutdown response: {response!r}")
-        self.notify("exit")
+        if send_exit:
+            self.notify("exit")
         self.proc.stdin.close()
         try:
             code = self.proc.wait(timeout=self.timeout)
@@ -362,6 +367,84 @@ def run_smoke(server: Path, timeout: float) -> tuple[tuple[int, float, int], lis
                 session.abort()
 
 
+def run_bad_frame(server: Path, frame: bytes, timeout: float, label: str) -> None:
+    """Require one malformed or oversized frame to terminate with status 1."""
+    with tempfile.TemporaryDirectory(prefix="mls-protocol-bad-") as directory:
+        try:
+            result = subprocess.run(
+                [str(server)],
+                cwd=directory,
+                input=frame,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as error:
+            raise ProtocolError(f"{label}: server did not terminate") from error
+    require(result.returncode == 1, f"{label}: expected exit 1, got {result.returncode}")
+    require(result.stdout == b"", f"{label}: server emitted a partial response")
+
+
+def run_clean_eof(server: Path, timeout: float) -> None:
+    """A clean EOF after shutdown is not a malformed-frame failure."""
+    with tempfile.TemporaryDirectory(prefix="mls-protocol-eof-") as directory:
+        root = Path(directory).resolve()
+        session = LspSession(server, root, timeout)
+        finished = False
+        try:
+            session.request("initialize", {"rootUri": root.as_uri(), "capabilities": {}})
+            exit_code, _, _ = session.finish(send_exit=False)
+            require(exit_code == 0, f"clean EOF after shutdown exited {exit_code}")
+            finished = True
+        finally:
+            if not finished:
+                session.abort()
+
+
+def run_transport_regressions(server: Path, timeout: float) -> None:
+    """Exercise malformed/truncated and resource-bounded input framing."""
+    cases = (
+        (b"X-Header: value\r\n\r\n", "missing Content-Length"),
+        (b"Content-Length: 12junk\r\n\r\n", "malformed Content-Length"),
+        (b"Content-Length: 4\r\nContent-Length: 4\r\n\r\nnull", "duplicate Content-Length"),
+        (b"Content-Length: 20\r\n\r\n{}", "truncated body"),
+        (f"Content-Length: {BODY_MAX + 1}\r\n\r\n".encode(), "oversized body"),
+        (b"Content-Length: 999999999999999999999999999999999999\r\n\r\n", "overflowing length"),
+        (b"X-Fill: " + (b"x" * HEADER_MAX), "oversized header"),
+    )
+    for frame, label in cases:
+        run_bad_frame(server, frame, timeout, label)
+
+
+def probe_closed_stdout(server: Path, timeout: float, restore_signals: bool) -> int:
+    """Close the client read end, trigger output, and return the process status."""
+    with tempfile.TemporaryDirectory(prefix="mls-protocol-pipe-") as directory:
+        read_fd, write_fd = os.pipe()
+        proc = subprocess.Popen(
+            [str(server)],
+            cwd=directory,
+            stdin=subprocess.PIPE,
+            stdout=write_fd,
+            stderr=subprocess.PIPE,
+            close_fds=True,
+            restore_signals=restore_signals,
+        )
+        os.close(write_fd)
+        os.close(read_fd)
+        assert proc.stdin is not None
+        payload = json.dumps({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}).encode()
+        try:
+            proc.stdin.write(f"Content-Length: {len(payload)}\r\n\r\n".encode() + payload)
+            proc.stdin.flush()
+            proc.stdin.close()
+            return proc.wait(timeout=timeout)
+        except subprocess.TimeoutExpired as error:
+            proc.kill()
+            proc.wait()
+            raise ProtocolError("closed stdout reader: server did not terminate") from error
+
+
 def main() -> int:
     """Run the suite and print request timing plus process-exit telemetry."""
     parser = argparse.ArgumentParser(description=__doc__)
@@ -375,10 +458,24 @@ def main() -> int:
         parser.error("--timeout must be positive")
     try:
         (exit_code, elapsed, message_count), timings = run_smoke(server, args.timeout)
+        run_clean_eof(server, args.timeout)
+        run_transport_regressions(server, args.timeout)
+        closed_stdout_status = probe_closed_stdout(server, args.timeout, True)
+        suppressed_status = probe_closed_stdout(server, args.timeout, False)
+        require(suppressed_status == 1, f"suppressed SIGPIPE: expected exit 1, got {suppressed_status}")
+        if os.name != "posix" or closed_stdout_status != -signal.SIGPIPE:
+            require(closed_stdout_status == 1, f"closed stdout reader: expected exit 1, got {closed_stdout_status}")
     except Exception as error:
         print(f"protocol smoke: FAIL: {error}", file=sys.stderr)
         return 1
     print(f"protocol smoke: PASS ({message_count} messages, exit {exit_code}, {elapsed:.3f}s)")
+    print("  clean EOF after shutdown: exit 0")
+    print("  malformed/oversized frames: 7 rejected with exit 1")
+    print("  closed stdout reader with inherited SIG_IGN: exit 1")
+    if os.name == "posix" and closed_stdout_status == -signal.SIGPIPE:
+        print("  closed stdout reader: SIGPIPE (blocked by mach-std#468)")
+    else:
+        print("  closed stdout reader: exit 1")
     for label, duration in timings:
         print(f"  {label}: {duration:.3f}s")
     return 0

--- a/test/lsp_protocol.py
+++ b/test/lsp_protocol.py
@@ -406,6 +406,7 @@ def run_transport_regressions(server: Path, timeout: float) -> None:
     """Exercise malformed/truncated and resource-bounded input framing."""
     cases = (
         (b"X-Header: value\r\n\r\n", "missing Content-Length"),
+        (b"Content-Length: 4\r\n", "truncated header"),
         (b"Content-Length: 12junk\r\n\r\n", "malformed Content-Length"),
         (b"Content-Length: 4\r\nContent-Length: 4\r\n\r\nnull", "duplicate Content-Length"),
         (b"Content-Length: 20\r\n\r\n{}", "truncated body"),
@@ -470,7 +471,7 @@ def main() -> int:
         return 1
     print(f"protocol smoke: PASS ({message_count} messages, exit {exit_code}, {elapsed:.3f}s)")
     print("  clean EOF after shutdown: exit 0")
-    print("  malformed/oversized frames: 7 rejected with exit 1")
+    print("  malformed/oversized frames: 8 rejected with exit 1")
     print("  closed stdout reader with inherited SIG_IGN: exit 1")
     if os.name == "posix" and closed_stdout_status == -signal.SIGPIPE:
         print("  closed stdout reader: SIGPIPE (blocked by mach-std#468)")


### PR DESCRIPTION
Refs #149.

## Summary

- distinguish clean EOF, malformed frames, and transport errors
- cap headers at 8 KiB and bodies at 16 MiB with strict overflow-safe Content-Length parsing
- retry interrupted and short I/O and surface output failures to the server loop
- add live protocol regressions for malformed, oversized, truncated, and closed-pipe behavior

## Remaining blocker

Portable POSIX SIGPIPE suppression requires a mach-std API and is tracked by briar-systems/mach-std#468. This PR deliberately avoids an architecture-specific raw-syscall workaround, so it does not close #149 yet.

## Verification

- `mach test .` — 52 passed
- `mach build . --all-targets --profile debug` — linux-x86_64, linux-arm64, linux-riscv64, windows-x86_64, darwin-x86_64
- `python3 -m py_compile test/lsp_protocol.py`
- `python3 test/lsp_protocol.py out/linux-x86_64/debug/bin/mls` — normal session exit 0; clean EOF after shutdown exit 0; eight malformed/oversized/truncated frames exit 1; closed stdout with inherited SIGPIPE ignore reports exit 1
- GitHub Actions CI — pass

Default POSIX SIGPIPE still terminates by signal, as captured by the harness and the linked blocker.