### PR TITLE
ci: add live upstream drift check

### DIFF
--- a/.github/workflows/upstream-drift.yml
+++ b/.github/workflows/upstream-drift.yml
@@ -8,9 +8,9 @@ on:
 permissions:
   contents: read
 
-# this workflow runs only from the default branch, so a failure is an upstream
-# warning rather than a required pull-request check. ci.yml remains the pinned,
-# authoritative merge gate.
+# this workflow has no pull-request trigger, so a failure is an upstream warning
+# rather than a required merge check. ci.yml remains the pinned, authoritative
+# gate.
 jobs:
   live-mach:
     runs-on: ubuntu-latest
@@ -31,20 +31,46 @@ jobs:
           mach info
 
       # mach develops frontend APIs on dev and promotes them to main for
-      # releases. retarget only this disposable checkout so drift is caught
+      # releases. force only this disposable checkout to dev so drift is caught
       # before release without changing the committed pin used by ci.yml.
       - name: Resolve live upstream branches
         run: |
           python3 - <<'PY'
+          import re
+          import tomllib
           from pathlib import Path
 
           path = Path("mach.toml")
           text = path.read_text()
-          pinned = '[dep.mach]\ngit = "https://github.com/briar-systems/mach"\nref = "branch/main"'
-          live = pinned.replace('branch/main', 'branch/dev')
-          if text.count(pinned) != 1:
-              raise SystemExit("mach dependency stanza no longer matches the drift workflow")
-          path.write_text(text.replace(pinned, live))
+          try:
+              manifest = tomllib.loads(text)
+          except tomllib.TOMLDecodeError as error:
+              raise SystemExit(f"invalid mach.toml: {error}") from error
+
+          dependencies = manifest.get("dep")
+          dependency = dependencies.get("mach") if isinstance(dependencies, dict) else None
+          if not isinstance(dependency, dict):
+              raise SystemExit("mach.toml must contain exactly one [dep.mach] stanza")
+          if dependency.get("ref") not in {"branch/main", "branch/dev"}:
+              raise SystemExit("[dep.mach].ref must be branch/main or branch/dev")
+
+          lines = text.splitlines(keepends=True)
+          header = re.compile(r'^\s*\[\s*dep\s*\.\s*mach\s*\]\s*(?:#.*)?$')
+          starts = [index for index, line in enumerate(lines) if header.match(line.rstrip("\r\n"))]
+          if len(starts) != 1:
+              raise SystemExit("mach.toml must contain exactly one [dep.mach] stanza")
+
+          start = starts[0] + 1
+          end = next((index for index in range(start, len(lines)) if lines[index].lstrip().startswith("[")), len(lines))
+          ref = re.compile(r'^(\s*ref\s*=\s*)(["\'])(branch/(?:main|dev))\2(\s*(?:#.*)?)(\r?\n)?$')
+          matches = [index for index in range(start, end) if ref.match(lines[index])]
+          if len(matches) != 1:
+              raise SystemExit("[dep.mach] must contain one simple main/dev ref assignment")
+
+          index = matches[0]
+          match = ref.match(lines[index])
+          lines[index] = f'{match.group(1)}{match.group(2)}branch/dev{match.group(2)}{match.group(4)}{match.group(5) or ""}'
+          path.write_text("".join(lines))
           PY
           mach dep pull
           mach dep update --all

--- a/.github/workflows/upstream-drift.yml
+++ b/.github/workflows/upstream-drift.yml
@@ -1,0 +1,60 @@
+name: Upstream drift
+
+on:
+  schedule:
+    - cron: '17 9 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# this workflow runs only from the default branch, so a failure is an upstream
+# warning rather than a required pull-request check. ci.yml remains the pinned,
+# authoritative merge gate.
+jobs:
+  live-mach:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Install released mach
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p /tmp/machdl
+          gh release download --repo briar-systems/mach \
+            --pattern 'mach-*-x86_64-linux.tar.gz' --dir /tmp/machdl --clobber
+          tar -xzf /tmp/machdl/mach-*-x86_64-linux.tar.gz -C /tmp/machdl
+          install -m 0755 /tmp/machdl/mach /usr/local/bin/mach
+          mach info
+
+      # mach develops frontend APIs on dev and promotes them to main for
+      # releases. retarget only this disposable checkout so drift is caught
+      # before release without changing the committed pin used by ci.yml.
+      - name: Resolve live upstream branches
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+
+          path = Path("mach.toml")
+          text = path.read_text()
+          pinned = '[dep.mach]\ngit = "https://github.com/briar-systems/mach"\nref = "branch/main"'
+          live = pinned.replace('branch/main', 'branch/dev')
+          if text.count(pinned) != 1:
+              raise SystemExit("mach dependency stanza no longer matches the drift workflow")
+          path.write_text(text.replace(pinned, live))
+          PY
+          mach dep pull
+          mach dep update --all
+          mach dep list
+
+      - name: Build
+        run: mach build . --target linux-x86_64 --profile debug
+
+      - name: Test
+        run: mach test .
+
+      - name: Protocol smoke
+        run: python3 test/lsp_protocol.py out/linux-x86_64/debug/bin/mls


### PR DESCRIPTION
Closes #126

Adds a daily and manually dispatchable upstream drift workflow while leaving the existing pinned PR CI unchanged as the authoritative merge gate.

The disposable drift checkout forces only Mach to `branch/dev`, because `dev` is the integration branch where frontend API changes land before release. It accepts either the current `branch/main` manifest or #151’s upcoming `branch/dev` manifest idempotently, structurally rejects missing/duplicate/malformed dependency declarations, and then uses the dependency manager to advance all branch refs. mach-std continues to follow its declared release `main`. No lockfile or dependency tree is deleted.

The workflow runs the build, unit suite, and live protocol harness. It intentionally fails visibly and has no pull-request trigger, so it is not a merge gate.

A dry run against the current tips resolves Mach `66a56e1c` and mach-std `76e8d69e`, then detects current frontend drift via three `comptime.init` arity errors in `src/project.mach`; the pinned lane remains green.

Integration order: this PR is compatible both before and after #151 because the ephemeral rewrite accepts `branch/main` and `branch/dev`. Rebase after #151 is optional rather than required.