### PR TITLE
perf/architecture: fix the quadratic fingerprint scan, give diagnostics the pipeline, and move analysis off the reading loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- perf: source fingerprints are stat-only. `file_fingerprint` read and FNV-hashed
+  every module's full source on every snapshot build and every 250 ms scan, and
+  its hash loop re-evaluated `str_len` as the loop condition, making the hash
+  quadratic in file size. On this repository (222 modules) that put 225 s of the
+  server's own bookkeeping in front of a 7.4 s compiler analysis and repeated it
+  on every request. `textDocument/definition` cold 231 s → 7.4 s, warm 222 s →
+  0.6 ms, after an edit → 181 ms. (#95)
+- diagnostics: publishing drives the analysis instead of reporting whichever
+  snapshot a previous request left behind. A file with a type error opened clean
+  and only started reporting once an unrelated feature request built the project.
+  Editor output now matches `mach build` from `didOpen`, and a hover no longer
+  changes it. Republishing is scoped to the root that changed. (#142)
+- server: `exit` terminates the process even when the client leaves stdin open,
+  which the spec entitles it to do.
+
+### Added
+- server: analysis runs on a worker thread. The reading thread owns stdin and
+  nothing else, so a cold analysis no longer blocks the client mid-write —
+  flooding the server with 60 edits during a cold load went from 18.6 s of
+  blocked writes (worst single write 7.5 s) to 0.00 s. Document revisions
+  superseded by queued input are coalesced, so the same burst costs one analysis
+  instead of 60: 19.0 s → 0.9 s. (#143, #155)
+- jobs: bounded single-consumer message queue, futex-blocking so an idle server
+  costs no CPU.
+
 ### Changed
+- json: JSON-RPC messages are parsed with `std.data.json` instead of scanning the
+  raw body for a quoted key. The scanner matched a key ANYWHERE in the document,
+  including inside an opened file's own source text, and correct dispatch relied
+  on clients ordering `method` before `params`. Request ids now keep their wire
+  type, malformed bodies get a spec parse error, and string escaping is the std
+  emitter's. Messages parse into a per-message arena. (#153)
+
+### Known issues
+- memory grows ~7.4 MiB per analysis, without bound, whether or not any source
+  changed. The leak is inside the compiler's `analyze_project` / `dnit_project`
+  cycle and reproduces with no LSP code involved; tracked upstream as
+  briar-systems/mach#3001.
+
+### Changed (#141, earlier in this cycle)
 - project: replaced the shared-session, manually re-resolved graph with one
   stable compiler Session and retained `analyze_project` snapshot per root.
   Open document text is mirrored as filesystem overlays with explicit input and

--- a/README.md
+++ b/README.md
@@ -18,14 +18,29 @@ selected primary artifact supplies the target, profile, defines, `$project`, and
 come from the same compiler-owned ModuleEntry rather than LSP copies of compiler
 internals.
 
+The reading thread owns stdin and nothing else. Every message, parsing
+included, is handled on one worker thread that owns the sessions, snapshots,
+document registry, and feature handlers, so compiler state has exactly one owner
+and needs no locking. A cold analysis therefore cannot stop the server from
+reading the cancellation, edit, or shutdown behind it, and cannot block the
+client mid-write when a `didChange` fills the pipe. A change whose analysis is
+superseded by input already queued is coalesced: the text and revision are
+recorded, the analysis is deferred, and the debt is paid when the queue drains,
+so a burst of keystrokes costs one analysis of the newest text rather than one
+per revision.
+
 Roots are independent identity domains, so projects with colliding FQNs can be
 queried and rebuilt in either order. Dependency modules already present in an
 ancestor graph route to that graph read-only; unrelated nested projects remain
 isolated. Files outside a project use the upstream single-file editor API.
 
-Open/change notifications publish fast standalone parse diagnostics when no
-current project snapshot exists. A feature request rebuilds a stale snapshot and
-the server republishes compiler diagnostics afterward. Watch registration is
+Diagnostics own the analysis rather than reporting whichever snapshot a previous
+request happened to leave behind: open and change drive the load, so what the
+editor shows matches `mach build` from the first notification and does not move
+because hover or definition was requested. Documents outside any project fall
+back to standalone parse diagnostics. Republishing is scoped to the root that
+changed, so an edit in one project does not emit a notification for every open
+buffer in another. Watch registration is
 considered active only after the client acknowledges it; `didSave`, watched-file
 notifications, manifest/lock mtimes, and exact content fingerprints of previously
 loaded source paths all drive invalidation and retry. Fingerprint scans are
@@ -88,9 +103,10 @@ and fetched by `mach dep pull`; Mach tracks `branch/dev` while mach-std tracks
 | Module | Responsibility |
 |---|---|
 | `main` | entry point; page allocator + server loop |
-| `server` | lifecycle state, message loop, method dispatch |
+| `server` | lifecycle state, reading loop, and the analysis-thread dispatch |
+| `jobs` | bounded message queue feeding the single analysis thread |
 | `transport` | LSP base-protocol framing over stdin/stdout |
-| `json` | minimal JSON field extraction and response assembly |
+| `json` | JSON-RPC reading over `std.data.json`, plus LSP payload assembly |
 | `documents` | live URI/path/text/version/revision ownership plus fallback `FileId` |
 | `diagnostics` | publish compiler snapshot diagnostics, with single-file fallback |
 | `positions` | byte offset ⇄ LSP `(line, character)` (UTF-16 columns ⇄ bytes) and span text — the single conversion point |

--- a/src/diagnostics.mach
+++ b/src/diagnostics.mach
@@ -45,6 +45,19 @@ val MAX_DIAGNOSTICS: usize = 200;
 
 # publish compiler-owned diagnostics for a document's exact snapshot, falling
 # back to isolated editor diagnostics outside a project
+#
+# The analysis is DRIVEN here rather than merely read. Publishing used to take
+# whatever snapshot a previous request happened to leave behind, so a file with
+# a type error opened clean and only started reporting once some unrelated
+# hover or definition request built the project - and stopped again when that
+# snapshot was invalidated. Diagnostics are the one output that must not depend
+# on what the user asked for, so they own the pipeline: `document_view` loads
+# or refreshes the root, and the result is parse, resolve, and sema at the same
+# fidelity `mach build` reports.
+#
+# `project.refresh_inputs` makes this a revision check once the snapshot is
+# current, so republishing every open document after a change costs one
+# comparison per document rather than one analysis.
 # ---
 # w:     project workspace
 # es:    standalone editor fallback
@@ -54,7 +67,7 @@ pub fun publish(w: *project.Workspace, es: *editor.EditorSession, alloc: *Alloca
     var list: *diag.DiagList = nil;
     var sources: *src.SourceMap = nil;
     var own: src.FileId = d.file_id;
-    val vr: Result[project.DocumentView, str] = project.document_view_loaded(w, d);
+    val vr: Result[project.DocumentView, str] = project.document_view(w, d);
     if (!is_err[project.DocumentView, str](vr)) {
         val v: project.DocumentView = unwrap_ok[project.DocumentView, str](vr);
         list = ?v.root.s.diags;

--- a/src/jobs.mach
+++ b/src/jobs.mach
@@ -1,0 +1,415 @@
+# a single-consumer job queue handing message bodies to an analysis thread
+#
+# the protocol loop must keep reading while the compiler works. a cold project
+# analysis takes seconds, and running it on the reading thread means the server
+# cannot see a cancellation, a newer edit, or a shutdown until it finishes -
+# which is how an editor concludes the server is dead and restarts it, only to
+# pay the same cost again.
+#
+# so the reading thread owns stdin and this queue, and one worker thread owns
+# everything the compiler touches: the sessions, the snapshots, the document
+# registry, and the feature handlers. exactly one thread ever reaches compiler
+# state, so nothing there needs locking; the queue is the only shared structure
+# and the only thing a lock protects.
+#
+# the worker blocks on a futex rather than polling, so an idle server costs no
+# CPU: `seq` advances on every push and on stop, and a waiter that saw the old
+# value sleeps until someone bumps it.
+
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.size.usize;
+use std.types.string.str;
+use std.types.string.str_len;
+use std.types.result.Result;
+use std.types.result.is_err;
+use std.types.result.unwrap_ok;
+
+use std.allocator.Allocator;
+use std.allocator.allocate;
+use std.allocator.deallocate;
+
+use mem:    std.memory;
+use os:     std.system.os;
+use atomic: std.sync.atomic;
+use mutex:  std.sync.mutex;
+use thread: std.sync.thread;
+
+# what the worker does with one dequeued body
+#
+# ctx is the opaque pointer handed to `start`; body is owned by the callback
+# for the duration of the call and released by the queue afterwards.
+pub def JobFn: fun(ptr, str, usize);
+
+# one queued message body, owned by the queue
+# ---
+# body: nul-terminated copy of the message body
+# len:  body length in bytes, excluding the terminator
+rec Job {
+    body: str;
+    len:  usize;
+}
+
+# the queue and the worker thread draining it
+#
+# `lock` guards `jobs`, `head`, `count`, and `closed`. `seq` is the futex word
+# the worker sleeps on and is written under the lock but read without it, so a
+# waiter can compare against a value it sampled before locking.
+# ---
+# alloc:  allocator backing the ring and every queued body
+# lock:   guards the ring and `closed`
+# jobs:   ring of `cap` slots
+# cap:    ring length
+# head:   index of the next job to pop
+# count:  queued jobs
+# seq:    futex word, advanced on every push and on close
+# closed: no further pushes are accepted and the worker should drain and exit
+# th:     the worker thread handle
+# live:   whether `th` was spawned and still needs joining
+pub rec Queue {
+    alloc:  *Allocator;
+    lock:   mutex.Mutex;
+    jobs:   *Job;
+    cap:    usize;
+    head:   usize;
+    count:  usize;
+    seq:    i64;
+    closed: bool;
+    th:     thread.Thread;
+    live:   bool;
+}
+
+# the queue a spawned worker drains
+#
+# `thread.spawn_with` hands the entry a single opaque pointer and std has no
+# thread-local storage, so the callback and its context ride the queue itself.
+# ---
+# q:  the queue to drain
+# f:  the callback to run per job
+# fx: opaque context handed to `f`
+rec Bound {
+    q:  *Queue;
+    f:  JobFn;
+    fx: ptr;
+}
+
+# bound state for the single worker, addressed by the spawned thread
+#
+# The handle must outlive the thread and std threads take one pointer, so the
+# binding lives here rather than in a caller frame. One server runs one queue.
+var BOUND: Bound;
+
+# how many messages may wait before a push is refused
+#
+# The queue holds whole message bodies, and `didChange` carries a document's
+# full text, so this bounds memory as well as latency. A client that outruns
+# the worker by more than this is answered rather than buffered without limit.
+pub val CAPACITY: usize = 256;
+
+# construct an empty queue over `alloc`
+# ---
+# q:     queue to initialize
+# alloc: allocator backing the ring and queued bodies; must outlive the queue
+# ret:   true on success
+pub fun init(q: *Queue, alloc: *Allocator) bool {
+    q.alloc  = alloc;
+    q.lock   = mutex.make();
+    q.jobs   = nil;
+    q.cap    = 0;
+    q.head   = 0;
+    q.count  = 0;
+    q.seq    = 0;
+    q.closed = false;
+    q.live   = false;
+
+    val r: Result[*Job, str] = allocate[Job](alloc, CAPACITY);
+    if (is_err[*Job, str](r)) { ret false; }
+    q.jobs = unwrap_ok[*Job, str](r);
+    q.cap  = CAPACITY;
+    var i: usize = 0;
+    for (i < q.cap) {
+        q.jobs[i].body = nil;
+        q.jobs[i].len  = 0;
+        i = i + 1;
+    }
+    ret true;
+}
+
+# spawn the worker thread draining `q` into `f`
+#
+# `f` runs on the worker for every pushed body, in push order, one at a time.
+# ---
+# q:   the initialized queue
+# f:   per-job callback
+# fx:  opaque context handed to `f`
+# ret: true when the thread started
+pub fun start(q: *Queue, f: JobFn, fx: ptr) bool {
+    if (q.jobs == nil || q.live) { ret false; }
+    BOUND.q  = q;
+    BOUND.f  = f;
+    BOUND.fx = fx;
+    thread.spawn_with(worker_main, (?BOUND)::*u8, ?q.th);
+    if (q.th.tid < 0) { ret false; }
+    q.live = true;
+    ret true;
+}
+
+# copy `body` onto the queue and wake the worker
+#
+# The body is copied because the caller's frame owns the transport buffer and
+# reuses it for the next frame.
+# ---
+# q:    the queue
+# body: nul-terminated message body
+# len:  body length in bytes
+# ret:  true when queued; false when closed, full, or out of memory
+pub fun push(q: *Queue, body: str, len: usize) bool {
+    if (body == nil) { ret false; }
+
+    val r: Result[*u8, str] = allocate[u8](q.alloc, len + 1);
+    if (is_err[*u8, str](r)) { ret false; }
+    val copy: *u8 = unwrap_ok[*u8, str](r);
+    if (len > 0) { mem.raw_copy(copy::ptr, body::ptr, len); }
+    copy[len] = 0;
+
+    mutex.lock(?q.lock);
+    if (q.closed || q.count == q.cap) {
+        mutex.unlock(?q.lock);
+        deallocate[u8](q.alloc, copy, len + 1);
+        ret false;
+    }
+    val slot: usize = (q.head + q.count) % q.cap;
+    q.jobs[slot].body = copy::str;
+    q.jobs[slot].len  = len;
+    q.count = q.count + 1;
+    atomic.store(?q.seq, atomic.load(?q.seq) + 1);
+    mutex.unlock(?q.lock);
+
+    os.thread_wake(?q.seq);
+    ret true;
+}
+
+# refuse further pushes and wake the worker so it drains and exits
+pub fun close(q: *Queue) {
+    mutex.lock(?q.lock);
+    q.closed = true;
+    atomic.store(?q.seq, atomic.load(?q.seq) + 1);
+    mutex.unlock(?q.lock);
+    os.thread_wake(?q.seq);
+}
+
+# close the queue and wait for the worker to finish the jobs already queued
+#
+# Every accepted message is handled before this returns, so a shutdown does not
+# strand a reply the client is waiting for.
+pub fun join(q: *Queue) {
+    close(q);
+    if (q.live) {
+        thread.join(?q.th);
+        q.live = false;
+    }
+}
+
+# release the ring and any body still queued
+pub fun dnit(q: *Queue) {
+    if (q.live) { join(q); }
+    if (q.jobs == nil) { ret; }
+    var i: usize = 0;
+    for (i < q.count) {
+        val slot: usize = (q.head + i) % q.cap;
+        free_job(q, ?q.jobs[slot]);
+        i = i + 1;
+    }
+    deallocate[Job](q.alloc, q.jobs, q.cap);
+    q.jobs  = nil;
+    q.cap   = 0;
+    q.count = 0;
+}
+
+# how many messages are waiting
+#
+# A sample, not a reservation: the worker may pop between the read and its use.
+pub fun depth(q: *Queue) usize {
+    mutex.lock(?q.lock);
+    val n: usize = q.count;
+    mutex.unlock(?q.lock);
+    ret n;
+}
+
+# release one job's owned body
+fun free_job(q: *Queue, j: *Job) {
+    if (j.body != nil) { deallocate[u8](q.alloc, j.body::*u8, j.len + 1); }
+    j.body = nil;
+    j.len  = 0;
+}
+
+# take the next job, blocking until one arrives or the queue closes
+#
+# The futex word is sampled before locking so a push that lands between the
+# empty check and the sleep changes the value the sleep compares against, and
+# the sleep returns immediately instead of missing the wake.
+# ---
+# q:   the queue
+# out: receives the popped job on success
+# ret: true when a job was taken; false once the queue is closed and drained
+fun pop_blocking(q: *Queue, out: *Job) bool {
+    for (true) {
+        val sampled: i64 = atomic.load(?q.seq);
+
+        mutex.lock(?q.lock);
+        if (q.count > 0) {
+            @out = q.jobs[q.head];
+            q.jobs[q.head].body = nil;
+            q.jobs[q.head].len  = 0;
+            q.head  = (q.head + 1) % q.cap;
+            q.count = q.count - 1;
+            mutex.unlock(?q.lock);
+            ret true;
+        }
+        val done: bool = q.closed;
+        mutex.unlock(?q.lock);
+
+        if (done) { ret false; }
+        os.thread_wait(?q.seq, sampled);
+    }
+    ret false;
+}
+
+# the worker thread entry: drain the queue into the bound callback until close
+fun worker_main(arg: *u8) {
+    val b: *Bound = arg::*Bound;
+    val q: *Queue = b.q;
+    for (true) {
+        var j: Job;
+        j.body = nil;
+        j.len  = 0;
+        if (!pop_blocking(q, ?j)) { brk; }
+        if (j.body != nil) { b.f(b.fx, j.body, j.len); }
+        free_job(q, ?j);
+    }
+}
+
+use page: std.allocator.page;
+use std.types.string.str_equals;
+
+# the queue's contract is that every accepted body reaches the callback exactly
+# once and in push order, so the tests assert the sequence rather than a count
+
+var SEEN:     [64]u8;
+var SEEN_LEN: i64 = 0;
+var SEEN_SUM: i64 = 0;
+
+fun record(ctx: ptr, body: str, len: usize) {
+    if (SEEN_LEN < 64) {
+        SEEN[SEEN_LEN::usize] = body[0];
+        SEEN_LEN = SEEN_LEN + 1;
+    }
+    SEEN_SUM = SEEN_SUM + len::i64;
+}
+
+test "jobs: every pushed body reaches the worker once, in order" {
+    var pa: Allocator;
+    page.make(?pa);
+    var q: Queue;
+    if (!init(?q, ?pa)) { ret 1; }
+    SEEN_LEN = 0;
+    SEEN_SUM = 0;
+    if (!start(?q, record, nil)) { dnit(?q); ret 1; }
+
+    if (!push(?q, "a1", 2)) { dnit(?q); ret 1; }
+    if (!push(?q, "b22", 3)) { dnit(?q); ret 1; }
+    if (!push(?q, "c333", 4)) { dnit(?q); ret 1; }
+    join(?q);
+
+    var fail: bool = false;
+    if (SEEN_LEN != 3)   { fail = true; }
+    or {
+        if (SEEN[0] != 'a') { fail = true; }
+        if (SEEN[1] != 'b') { fail = true; }
+        if (SEEN[2] != 'c') { fail = true; }
+    }
+    if (SEEN_SUM != 9) { fail = true; }
+    dnit(?q);
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+# the worker must sleep on the futex rather than spin, so a queue that is
+# started and immediately joined without work still terminates
+test "jobs: an idle worker joins without any job" {
+    var pa: Allocator;
+    page.make(?pa);
+    var q: Queue;
+    if (!init(?q, ?pa)) { ret 1; }
+    SEEN_LEN = 0;
+    if (!start(?q, record, nil)) { dnit(?q); ret 1; }
+    join(?q);
+    var fail: bool = false;
+    if (SEEN_LEN != 0) { fail = true; }
+    dnit(?q);
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+# a body is copied on push, so the caller's buffer may be reused immediately
+test "jobs: a pushed body is copied, not borrowed" {
+    var pa: Allocator;
+    page.make(?pa);
+    var q: Queue;
+    if (!init(?q, ?pa)) { ret 1; }
+    SEEN_LEN = 0;
+    SEEN_SUM = 0;
+
+    var scratch: [8]u8;
+    scratch[0] = 'x';
+    scratch[1] = 'y';
+    scratch[2] = 0;
+    if (!push(?q, (?scratch[0])::str, 2)) { dnit(?q); ret 1; }
+    scratch[0] = 'z';
+
+    if (!start(?q, record, nil)) { dnit(?q); ret 1; }
+    join(?q);
+
+    var fail: bool = false;
+    if (SEEN_LEN != 1)  { fail = true; }
+    or { if (SEEN[0] != 'x') { fail = true; } }
+    dnit(?q);
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+# the bound is what stops a client from buying unbounded memory with didChange
+test "jobs: a full queue refuses a push instead of growing" {
+    var pa: Allocator;
+    page.make(?pa);
+    var q: Queue;
+    if (!init(?q, ?pa)) { ret 1; }
+
+    var fail: bool = false;
+    var i: usize = 0;
+    for (i < CAPACITY) {
+        if (!push(?q, "j", 1)) { fail = true; }
+        i = i + 1;
+    }
+    if (push(?q, "overflow", 8)) { fail = true; }
+    if (depth(?q) != CAPACITY)   { fail = true; }
+
+    dnit(?q);
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+# a closed queue accepts nothing further, so a shutdown cannot be overtaken
+test "jobs: a closed queue refuses further pushes" {
+    var pa: Allocator;
+    page.make(?pa);
+    var q: Queue;
+    if (!init(?q, ?pa)) { ret 1; }
+    close(?q);
+    var fail: bool = false;
+    if (push(?q, "late", 4)) { fail = true; }
+    dnit(?q);
+    if (fail) { ret 1; }
+    ret 0;
+}

--- a/src/json.mach
+++ b/src/json.mach
@@ -1,13 +1,21 @@
-# minimal JSON extraction and construction for LSP messages
+# JSON-RPC message reading and LSP payload construction
 #
-# the server never builds a full JSON tree: requests are small, flat objects
-# and the fields it needs (method, id, uri, text, version, position) are read
-# by key with a forgiving string scanner, and responses are assembled from
-# string fragments. this keeps the protocol layer dependency-free and avoids a
-# general parser the diagnostics slice does not need.
+# reading goes through `std.data.json`: a message is parsed once into a real
+# Value tree and every field is reached by navigating it. the server used to
+# scan the raw body for a quoted key, which matched that key ANYWHERE in the
+# document - including inside an opened file's own source text, which for a
+# language server is attacker-shaped input. structure, ordering, nesting, and
+# escapes are now the parser's problem, not a scanner's.
 #
-# every accessor returns owned `str` allocated from the caller's allocator (or
-# nil on miss / allocation failure); callers free with `free_str`.
+# a parsed tree borrows its string bytes from the message body and the std
+# parser has no free entry, so a message is parsed into a per-message arena
+# that `Reader` resets once the message is handled. that also retires the
+# per-field owned-string bookkeeping the scanner required.
+#
+# writing stays a `Buf` append sink: LSP payloads are shaped by the data
+# (a diagnostic's related locations, a rename's per-file edits), so the
+# fragment count is only known while emitting. string escaping is the std
+# emitter's, so a control byte or a non-ASCII identifier survives the trip.
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -20,14 +28,20 @@ use std.types.string.str_equals;
 use std.types.result.Result;
 use std.types.result.is_err;
 use std.types.result.unwrap_ok;
+use std.types.result.ok;
+use std.types.option.Option;
+use std.types.option.is_some;
 
 use std.allocator.Allocator;
 use std.allocator.allocate;
 use std.allocator.deallocate;
 use std.allocator.reallocate;
 
-use mem:  std.memory;
-use page: std.allocator.page;
+use mem:   std.memory;
+use page:  std.allocator.page;
+use arena: std.allocator.arena;
+use sj:    std.data.json;
+use writer: std.io.writer;
 
 # a growable byte buffer for assembling one JSON payload
 #
@@ -121,24 +135,33 @@ pub fun buf_push_byte(b: *Buf, ch: u8) {
     b.len = b.len + 1;
 }
 
-# append `s` as a quoted, escaped JSON string. nil renders as `""`
+# writer callback appending into the Buf behind `ctx`
+fun buf_write(ctx: ptr, p: *u8, len: usize) Result[usize, str] {
+    val b: *Buf = ctx::*Buf;
+    if (!buf_reserve(b, len)) { ret ok[usize, str](len); }
+    mem.raw_copy((b.data::usize + b.len)::ptr, p::ptr, len);
+    b.len = b.len + len;
+    ret ok[usize, str](len);
+}
+
+# a `std.io.writer` view over `b`, so the std JSON escaper can emit into it
+# ---
+# b: the buffer to wrap
+# w: writer initialized in place; borrows `b`, which must outlive it
+pub fun buf_writer(b: *Buf, w: *writer.Writer) {
+    w.ctx     = b::ptr;
+    w.f_write = buf_write;
+}
+
+# append `s` as a quoted JSON string, escaped by the std emitter
+#
+# escaping is `ESCAPE_ENSURE_ASCII`, so every emitted byte is printable ASCII
+# and a non-ASCII identifier or path survives as a `\uXXXX` escape rather than
+# raw bytes. nil renders as `""`.
 pub fun buf_push_quoted(b: *Buf, s: str) {
-    buf_push_byte(b, '"');
-    if (s == nil) { buf_push_byte(b, '"'); ret; }
-    val n: usize = str_len(s);
-    var i: usize = 0;
-    for (i < n) {
-        val ch: u8 = s[i];
-        if (ch == '"')  { buf_push(b, "\\\""); }
-        or (ch == '\\') { buf_push(b, "\\\\"); }
-        or (ch == '\n') { buf_push(b, "\\n"); }
-        or (ch == '\r') { buf_push(b, "\\r"); }
-        or (ch == '\t') { buf_push(b, "\\t"); }
-        or (ch < 32)    { buf_push_byte(b, '?'); }
-        or              { buf_push_byte(b, ch); }
-        i = i + 1;
-    }
-    buf_push_byte(b, '"');
+    var w: writer.Writer;
+    buf_writer(b, ?w);
+    sj.write_json_string(?w, s::*u8);
 }
 
 # append `value` in base 10
@@ -179,458 +202,283 @@ pub fun buf_str(b: *Buf) str {
     ret b.data::str;
 }
 
-# read the string value of `key` in `data`, decoding JSON
-# escapes. returns owned text, or nil when the key is absent or not a string
+
+# one parsed JSON-RPC message and the arena its tree lives in
+#
+# `root` borrows string bytes from the body the caller still owns, so the body
+# must outlive the Message. `arena_reset` releases the tree.
 # ---
-# data:  JSON text to scan
-# key:   quoted key to find, e.g. `"method"`
-# alloc: allocator backing the returned string
-# ret:   owned decoded value, or nil
-pub fun extract_string(data: str, key: str, alloc: *Allocator) str {
-    val idx: isize = find_key(data, key);
-    if (idx < 0) { ret nil; }
-
-    val data_len: usize = str_len(data);
-    val key_len: usize = str_len(key);
-    var pos: usize = (idx::usize) + key_len;
-
-    pos = skip_ws(data, pos);
-    if (pos >= data_len || data[pos] != ':') { ret nil; }
-    pos = pos + 1;
-
-    pos = skip_ws(data, pos);
-    if (pos >= data_len || data[pos] != '"') { ret nil; }
-    pos = pos + 1;
-
-    var scan: usize = pos;
-    var out_len: usize = 0;
-    for (scan < data_len) {
-        val ch: u8 = data[scan];
-        if (ch == '\\') { scan = scan + 2; out_len = out_len + 1; }
-        or (ch == '"') { brk; }
-        or { scan = scan + 1; out_len = out_len + 1; }
-    }
-    if (scan >= data_len) { ret nil; }
-    if (out_len == 0) { ret nil; }
-
-    val r: Result[*u8, str] = allocate[u8](alloc, out_len + 1);
-    if (is_err[*u8, str](r)) { ret nil; }
-    val buf: *u8 = unwrap_ok[*u8, str](r);
-
-    scan = pos;
-    var w: usize = 0;
-    for (scan < data_len && w < out_len) {
-        val ch: u8 = data[scan];
-        if (ch == '\\') {
-            scan = scan + 1;
-            if (scan >= data_len) { brk; }
-            val esc: u8 = data[scan];
-            if (esc == 'n')  { buf[w] = '\n'; }
-            or (esc == 'r')  { buf[w] = '\r'; }
-            or (esc == 't')  { buf[w] = '\t'; }
-            or (esc == '"')  { buf[w] = '"'; }
-            or (esc == '\\') { buf[w] = '\\'; }
-            or (esc == '/')  { buf[w] = '/'; }
-            or               { buf[w] = esc; }
-            scan = scan + 1;
-            w = w + 1;
-        }
-        or (ch == '"') { brk; }
-        or { buf[w] = ch; scan = scan + 1; w = w + 1; }
-    }
-
-    buf[w] = 0;
-    ret buf::str;
+# root:   parsed root value; an object for any well-formed message
+# valid:  whether the body parsed at all
+pub rec Message {
+    root:  sj.Value;
+    valid: bool;
 }
 
-# read the raw token of `key` (a quoted string copied verbatim, or
-# a bare number / literal). returns owned text, or nil on miss
+# a reusable per-message parse arena
+#
+# one server owns one Reader. `read` parses a body into it, `release` rolls the
+# arena back so the next message reuses the same chunks instead of allocating.
 # ---
-# data:  JSON text to scan
-# key:   quoted key to find
-# alloc: allocator backing the returned string
-# ret:   owned raw token, or nil
-pub fun extract_raw(data: str, key: str, alloc: *Allocator) str {
-    val idx: isize = find_key(data, key);
-    if (idx < 0) { ret nil; }
-
-    val data_len: usize = str_len(data);
-    val key_len: usize = str_len(key);
-    var pos: usize = (idx::usize) + key_len;
-
-    pos = skip_ws(data, pos);
-    if (pos >= data_len || data[pos] != ':') { ret nil; }
-    pos = pos + 1;
-
-    pos = skip_ws(data, pos);
-    if (pos >= data_len) { ret nil; }
-    val start: usize = pos;
-
-    if (data[pos] == '"') {
-        pos = pos + 1;
-        for (pos < data_len) {
-            val ch: u8 = data[pos];
-            if (ch == '\\') { pos = pos + 2; }
-            or (ch == '"') { pos = pos + 1; brk; }
-            or { pos = pos + 1; }
-        }
-        ret copy_range(data, start, pos, alloc);
-    }
-
-    for (pos < data_len) {
-        val ch: u8 = data[pos];
-        if (ch == ',' || ch == '}' || ch == ']' ||
-            ch == ' ' || ch == '\t' || ch == '\r' || ch == '\n') { brk; }
-        pos = pos + 1;
-    }
-    if (pos == start) { ret nil; }
-    ret copy_range(data, start, pos, alloc);
+# ar:    the arena backing every parsed tree
+# ready: whether `ar` was initialized
+pub rec Reader {
+    ar:    arena.Arena;
+    ready: bool;
 }
 
-# read the integer value of `key`, or 0 when absent
+# seed capacity for the message arena, sized so an ordinary request parses
+# without growing
+val READER_ARENA_CAP: usize = 64 * 1024;
+
+# construct a message reader over `backing`
 # ---
-# data:  JSON text to scan
-# key:   quoted key to find
-# alloc: scratch allocator (the raw token is freed before return)
-# ret:   the parsed integer, or 0
-pub fun extract_number_i64(data: str, key: str, alloc: *Allocator) i64 {
-    val raw: str = extract_raw(data, key, alloc);
-    if (raw == nil) { ret 0; }
-    val result: i64 = parse_i64(raw);
-    free_str(raw, alloc);
-    ret result;
-}
-
-# the tail of `data` starting just past the first occurrence of
-# `anchor` as an object key, or nil when the anchor is absent or ends the text.
-# the shared prologue of the *_after accessors; the returned pointer borrows
-# `data`
-fun seek_after(data: str, anchor: str) str {
-    val idx: isize = find_key(data, anchor);
-    if (idx < 0) { ret nil; }
-    val offset: usize = (idx::usize) + str_len(anchor);
-    if (offset >= str_len(data)) { ret nil; }
-    ret (data::usize + offset)::str;
-}
-
-# read string `key` that appears after the first occurrence of
-# `anchor` (scopes a key lookup to a nested object whose opening key is known)
-# ---
-# data:   JSON text to scan
-# anchor: quoted key marking where to start scanning
-# key:    quoted key to read after the anchor
-# alloc:  allocator backing the returned string
-# ret:    owned decoded value, or nil
-pub fun extract_after(data: str, anchor: str, key: str, alloc: *Allocator) str {
-    val sub: str = seek_after(data, anchor);
-    if (sub == nil) { ret nil; }
-    ret extract_string(sub, key, alloc);
-}
-
-# read integer `key` after `anchor`, or 0 on miss
-# ---
-# data:   JSON text to scan
-# anchor: quoted key marking where to start scanning
-# key:    quoted key to read after the anchor
-# alloc:  scratch allocator
-# ret:    the parsed integer, or 0
-pub fun extract_number_after(data: str, anchor: str, key: str, alloc: *Allocator) i64 {
-    val sub: str = seek_after(data, anchor);
-    if (sub == nil) { ret 0; }
-    ret extract_number_i64(sub, key, alloc);
-}
-
-# decode the string value of the `index`-th occurrence of
-# `key` in `data` (0-based), or nil when there are fewer than index+1
-# occurrences. lets a caller iterate a repeated key - e.g. every `"uri"` in a
-# `workspace/didChangeWatchedFiles` changes array - by bumping `index` until nil
-# ---
-# data:  JSON text to scan
-# key:   quoted key to find, e.g. `"uri"`
-# index: zero-based occurrence to read
-# alloc: allocator backing the returned string
-# ret:   owned decoded value, or nil
-pub fun extract_string_seq(data: str, key: str, index: u32, alloc: *Allocator) str {
-    var sub: str = data;
-    var i: u32 = 0;
-    for (i < index) {
-        sub = seek_after(sub, key);
-        if (sub == nil) { ret nil; }
-        i = i + 1;
-    }
-    ret extract_string(sub, key, alloc);
-}
-
-# whether the boolean `key` inside the object value of
-# `anchor` is the literal `true`. the scan is scoped to the anchor's balanced
-# object, so an equally-named key in a later sibling object is never misread -
-# e.g. another capability's `dynamicRegistration` after an empty
-# `"didChangeWatchedFiles":{}`. false when the anchor is absent, its value is
-# not an object, or the key is absent / non-true, so a missing capability reads
-# as unsupported
-# ---
-# data:   JSON text to scan
-# anchor: quoted key whose object value scopes the lookup
-# key:    quoted boolean key to read inside the anchor's object
-# alloc:  scratch allocator (the window and raw token are freed before return)
-# ret:    true only when the value is the literal `true`
-pub fun extract_bool_after(data: str, anchor: str, key: str, alloc: *Allocator) bool {
-    val sub: str = seek_after(data, anchor);
-    if (sub == nil) { ret false; }
-    val sub_len: usize = str_len(sub);
-    var pos: usize = skip_ws(sub, 0);
-    if (pos >= sub_len || sub[pos] != ':') { ret false; }
-    pos = skip_ws(sub, pos + 1);
-    if (pos >= sub_len || sub[pos] != '{') { ret false; }
-    val end: usize = object_end(sub, pos);
-    if (end == 0) { ret false; }
-
-    val window: str = copy_range(sub, pos, end, alloc);
-    if (window == nil) { ret false; }
-    val raw: str = extract_raw(window, key, alloc);
-    var is_true: bool = false;
-    if (raw != nil) {
-        is_true = str_equals(raw, "true");
-        free_str(raw, alloc);
-    }
-    free_str(window, alloc);
-    ret is_true;
-}
-
-# the index one past the matching `}` of the `{` at `start`,
-# skipping string contents, or 0 when the object is unbalanced
-fun object_end(data: str, start: usize) usize {
-    val n: usize = str_len(data);
-    var depth: usize = 0;
-    var in_str: bool = false;
-    var i: usize = start;
-    for (i < n) {
-        val c: u8 = data[i];
-        if (in_str) {
-            if (c == '\\') { i = i + 2; }
-            or {
-                if (c == '"') { in_str = false; }
-                i = i + 1;
-            }
-        }
-        or {
-            if (c == '"')  { in_str = true; }
-            or (c == '{')  { depth = depth + 1; }
-            or (c == '}')  {
-                depth = depth - 1;
-                if (depth == 0) { ret i + 1; }
-            }
-            i = i + 1;
-        }
-    }
-    ret 0;
-}
-
-# JSON-encode `s` as a quoted, escaped string literal (including the
-# surrounding quotes). returns owned text, or nil on allocation failure
-# ---
-# s:     raw text to encode
-# alloc: allocator backing the returned string
-# ret:   owned quoted literal, or nil
-pub fun quote(s: str, alloc: *Allocator) str {
-    var s_len: usize = 0;
-    if (s != nil) { s_len = str_len(s); }
-
-    var encoded_len: usize = 2;
-    var i: usize = 0;
-    for (i < s_len) {
-        val ch: u8 = s[i];
-        if (ch == '"' || ch == '\\' || ch == '\n' || ch == '\r' || ch == '\t') {
-            encoded_len = encoded_len + 2;
-        }
-        or { encoded_len = encoded_len + 1; }
-        i = i + 1;
-    }
-
-    val r: Result[*u8, str] = allocate[u8](alloc, encoded_len + 1);
-    if (is_err[*u8, str](r)) { ret nil; }
-    val buf: *u8 = unwrap_ok[*u8, str](r);
-
-    var pos: usize = 0;
-    buf[pos] = '"';
-    pos = pos + 1;
-
-    i = 0;
-    for (i < s_len) {
-        val ch: u8 = s[i];
-        if (ch == '"')        { buf[pos] = '\\'; buf[pos + 1] = '"';  pos = pos + 2; }
-        or (ch == '\\')       { buf[pos] = '\\'; buf[pos + 1] = '\\'; pos = pos + 2; }
-        or (ch == '\n')       { buf[pos] = '\\'; buf[pos + 1] = 'n';  pos = pos + 2; }
-        or (ch == '\r')       { buf[pos] = '\\'; buf[pos + 1] = 'r';  pos = pos + 2; }
-        or (ch == '\t')       { buf[pos] = '\\'; buf[pos + 1] = 't';  pos = pos + 2; }
-        or (ch < 32)          { buf[pos] = '?';  pos = pos + 1; }
-        or                    { buf[pos] = ch;   pos = pos + 1; }
-        i = i + 1;
-    }
-
-    buf[pos] = '"';
-    pos = pos + 1;
-    buf[pos] = 0;
-    ret buf::str;
-}
-
-# render `value` in base 10. returns owned text, or nil on failure
-# ---
-# value: number to render
-# alloc: allocator backing the returned string
-# ret:   owned decimal text, or nil
-pub fun format_usize(value: usize, alloc: *Allocator) str {
-    var tmp: [20]u8;
-    var pos: usize = 20;
-    var v: usize = value;
-    if (v == 0) { pos = pos - 1; tmp[pos] = '0'; }
-    or {
-        for (v > 0 && pos > 0) {
-            pos = pos - 1;
-            tmp[pos] = ('0'::usize + (v % 10))::u8;
-            v = v / 10;
-        }
-    }
-    val len: usize = 20 - pos;
-    val r: Result[*u8, str] = allocate[u8](alloc, len + 1);
-    if (is_err[*u8, str](r)) { ret nil; }
-    val buf: *u8 = unwrap_ok[*u8, str](r);
-    mem.raw_copy(buf::ptr, (?tmp[pos])::ptr, len);
-    buf[len] = 0;
-    ret buf::str;
-}
-
-# render `value` in base 10 with a leading sign for negatives
-# ---
-# value: number to render
-# alloc: allocator backing the returned string
-# ret:   owned decimal text, or nil
-pub fun format_i64(value: i64, alloc: *Allocator) str {
-    var tmp: [21]u8;
-    var pos: usize = 21;
-    var negative: bool = false;
-    var v: i64 = value;
-    if (v < 0) { negative = true; v = -v; }
-    if (v == 0) { pos = pos - 1; tmp[pos] = '0'; }
-    or {
-        for (v > 0 && pos > 0) {
-            pos = pos - 1;
-            tmp[pos] = ('0'::i64 + (v % 10))::u8;
-            v = v / 10;
-        }
-    }
-    if (negative && pos > 0) { pos = pos - 1; tmp[pos] = '-'; }
-    val len: usize = 21 - pos;
-    val r: Result[*u8, str] = allocate[u8](alloc, len + 1);
-    if (is_err[*u8, str](r)) { ret nil; }
-    val buf: *u8 = unwrap_ok[*u8, str](r);
-    mem.raw_copy(buf::ptr, (?tmp[pos])::ptr, len);
-    buf[len] = 0;
-    ret buf::str;
-}
-
-# release a string returned by this module
-# ---
-# s:     string to free; nil is a no-op
-# alloc: allocator the string was allocated from
-pub fun free_str(s: str, alloc: *Allocator) {
-    if (s == nil) { ret; }
-    val len: usize = str_len(s);
-    deallocate[u8](alloc, s::*u8, len + 1);
-}
-
-# byte offset of the opening quote of `key` as an object key in
-# `data` (a `"key"` token outside any string value), or -1 when absent
-fun find_key(data: str, key: str) isize {
-    val key_len: usize = str_len(key);
-    val data_len: usize = str_len(data);
-    if (key_len == 0 || key_len > data_len) { ret -1; }
-
-    var in_string: bool = false;
-    var i: usize = 0;
-    val limit: usize = data_len - key_len;
-    for (i <= limit) {
-        val ch: u8 = data[i];
-        if (ch == '"' && !is_escaped(data, i)) {
-            if (!in_string) {
-                if (match_at(data, i, key)) { ret i::isize; }
-                in_string = true;
-            }
-            or { in_string = false; }
-        }
-        i = i + 1;
-    }
-    ret -1;
-}
-
-# whether the byte at `index` is preceded by an odd run of backslashes
-fun is_escaped(data: str, index: usize) bool {
-    if (index == 0) { ret false; }
-    var back: usize = index - 1;
-    var count: usize = 0;
-    for {
-        if (data[back] != '\\') { brk; }
-        count = count + 1;
-        if (back == 0) { brk; }
-        back = back - 1;
-    }
-    ret (count & 1) == 1;
-}
-
-# whether `pattern` occurs verbatim at `offset` in `data`
-fun match_at(data: str, offset: usize, pattern: str) bool {
-    val pattern_len: usize = str_len(pattern);
-    val data_len: usize = str_len(data);
-    if (offset + pattern_len > data_len) { ret false; }
-    var i: usize = 0;
-    for (i < pattern_len) {
-        if (data[offset + i] != pattern[i]) { ret false; }
-        i = i + 1;
-    }
+# rd:      reader to initialize
+# backing: allocator the arena draws chunks from; must outlive the reader
+# ret:     true when the arena was created
+pub fun reader_init(rd: *Reader, backing: *Allocator) bool {
+    rd.ready = false;
+    var opt: Option[*u8] = arena.init(?rd.ar, backing, READER_ARENA_CAP);
+    if (is_some[*u8](opt)) { ret false; }
+    rd.ready = true;
     ret true;
 }
 
-# advance past JSON whitespace starting at `pos`
-fun skip_ws(data: str, pos: usize) usize {
-    val data_len: usize = str_len(data);
-    var p: usize = pos;
-    for (p < data_len) {
-        val ch: u8 = data[p];
-        if (ch != ' ' && ch != '\t' && ch != '\r' && ch != '\n') { brk; }
-        p = p + 1;
-    }
-    ret p;
+# release the reader's arena
+pub fun reader_dnit(rd: *Reader) {
+    if (!rd.ready) { ret; }
+    arena.dnit(?rd.ar);
+    rd.ready = false;
 }
 
-# parse a leading optionally-signed decimal integer from `s`
-fun parse_i64(s: str) i64 {
-    if (s == nil) { ret 0; }
-    val s_len: usize = str_len(s);
-    if (s_len == 0) { ret 0; }
-    var pos: usize = 0;
-    var negative: bool = false;
-    if (s[pos] == '-') { negative = true; pos = pos + 1; }
-    var result: i64 = 0;
-    for (pos < s_len) {
-        val ch: u8 = s[pos];
-        if (ch >= '0' && ch <= '9') { result = result * 10 + ((ch - '0')::i64); }
-        or { brk; }
-        pos = pos + 1;
-    }
-    if (negative) { ret -result; }
-    ret result;
+# the reader's arena as an Allocator, for values that live as long as the message
+# ---
+# rd:  the reader
+# ret: the arena allocator, or nil when the reader failed to initialize
+pub fun reader_alloc(rd: *Reader) *Allocator {
+    if (!rd.ready) { ret nil; }
+    ret ?rd.ar.backing;
 }
 
-# owned copy of `data[start..end)`, nil-terminated
-fun copy_range(data: str, start: usize, end: usize, alloc: *Allocator) str {
-    val len: usize = end - start;
-    if (len == 0) { ret nil; }
-    val r: Result[*u8, str] = allocate[u8](alloc, len + 1);
-    if (is_err[*u8, str](r)) { ret nil; }
-    val buf: *u8 = unwrap_ok[*u8, str](r);
-    mem.raw_copy(buf::ptr, (data::usize + start)::ptr, len);
-    buf[len] = 0;
+# parse one message body into the reader's arena
+#
+# `body` is borrowed: the returned tree points into it and stays valid until
+# `release`. an unparseable body yields a Message with `valid` false, which the
+# caller answers with a JSON-RPC parse error rather than ignoring.
+# ---
+# rd:   the reader owning the arena
+# body: nul-terminated message body, retained by the caller
+# len:  body length in bytes
+# ret:  the parsed message
+pub fun read(rd: *Reader, body: str, len: usize) Message {
+    var m: Message;
+    m.valid = false;
+    if (!rd.ready || body == nil) { ret m; }
+    var a: Allocator;
+    arena.make(?a, ?rd.ar);
+    val r: Result[sj.Value, str] = sj.parse(body::*u8, len, ?a);
+    if (is_err[sj.Value, str](r)) { ret m; }
+    m.root  = unwrap_ok[sj.Value, str](r);
+    m.valid = true;
+    ret m;
+}
+
+# roll the arena back, retiring every tree parsed since the last release
+pub fun release(rd: *Reader) {
+    if (!rd.ready) { ret; }
+    arena.reset(?rd.ar);
+}
+
+# the object member `key` of `v`, or nil when absent or `v` is not an object
+# ---
+# v:   value to read
+# key: member name
+# ret: borrowed member value, or nil
+pub fun member(v: *sj.Value, key: str) *sj.Value {
+    if (v == nil) { ret nil; }
+    ret sj.value_find(v, key);
+}
+
+# the member `key` of the member `outer` of `v`, or nil at any miss
+# ---
+# v:     value to read
+# outer: outer member name
+# key:   inner member name
+# ret:   borrowed member value, or nil
+pub fun member2(v: *sj.Value, outer: str, key: str) *sj.Value {
+    ret member(member(v, outer), key);
+}
+
+# the `index`-th element of array `v`, or nil when out of range
+pub fun element(v: *sj.Value, index: usize) *sj.Value {
+    if (v == nil || !sj.value_is_array(v)) { ret nil; }
+    ret sj.value_get(v, index);
+}
+
+# the number of elements in array or object `v`, 0 for anything else
+pub fun count(v: *sj.Value) usize {
+    if (v == nil) { ret 0; }
+    ret sj.value_count(v);
+}
+
+# whether `v` is present and JSON null
+pub fun is_null(v: *sj.Value) bool {
+    if (v == nil) { ret false; }
+    ret sj.value_is_null(v);
+}
+
+# the decoded text of string value `v`, allocated from `alloc`
+#
+# JSON escapes are resolved, so the result is the logical text the client sent.
+# nil when `v` is absent or not a string.
+# ---
+# v:     value to decode
+# alloc: allocator backing the returned string
+# ret:   owned nul-terminated text, or nil
+pub fun text(v: *sj.Value, alloc: *Allocator) str {
+    if (v == nil || !sj.value_is_string(v)) { ret nil; }
+    val sr: Result[usize, str] = sj.value_string_decode(v, nil, 0);
+    if (is_err[usize, str](sr)) { ret nil; }
+    val n: usize = unwrap_ok[usize, str](sr);
+    val br: Result[*u8, str] = allocate[u8](alloc, n + 1);
+    if (is_err[*u8, str](br)) { ret nil; }
+    val buf: *u8 = unwrap_ok[*u8, str](br);
+    val dr: Result[usize, str] = sj.value_string_decode(v, buf, n);
+    if (is_err[usize, str](dr)) { deallocate[u8](alloc, buf, n + 1); ret nil; }
+    buf[n] = 0;
     ret buf::str;
+}
+
+# the integer value of number `v`, or `fallback` when absent or not a number
+pub fun number(v: *sj.Value, fallback: i64) i64 {
+    if (v == nil || !sj.value_is_number(v)) { ret fallback; }
+    ret sj.value_number(v);
+}
+
+# the boolean value of `v`, or `fallback` when absent or not a boolean
+pub fun boolean(v: *sj.Value, fallback: bool) bool {
+    if (v == nil || !sj.value_is_bool(v)) { ret fallback; }
+    ret sj.value_bool(v);
+}
+
+# whether string value `v` equals `s` after decoding
+#
+# compares against the DECODED text, so a client that escapes an ASCII byte in
+# a method name still matches.
+# ---
+# v:     value to compare
+# s:     expected text
+# alloc: scratch allocator for the decode
+# ret:   true when `v` is a string equal to `s`
+pub fun text_equals(v: *sj.Value, s: str, alloc: *Allocator) bool {
+    val got: str = text(v, alloc);
+    if (got == nil) { ret false; }
+    val eq: bool = str_equals(got, s);
+    free_str(got, alloc);
+    ret eq;
+}
+
+# append a JSON-RPC id verbatim, preserving its wire type
+#
+# an id is a string, an integer, or null, and the response MUST echo the type
+# the request used. a parsed string's bytes are already wire-escaped, so they
+# are re-emitted as-is rather than decoded and re-escaped.
+# ---
+# b:  buffer to append to
+# id: the request's id value, or nil for a message that carried none
+pub fun buf_push_id(b: *Buf, id: *sj.Value) {
+    if (id == nil) { buf_push(b, "null"); ret; }
+    if (sj.value_is_string(id)) {
+        var n: usize = 0;
+        val raw: *u8 = sj.value_string(id, ?n);
+        buf_push_byte(b, '"');
+        if (raw != nil && n > 0) {
+            if (buf_reserve(b, n)) {
+                mem.raw_copy((b.data::usize + b.len)::ptr, raw::ptr, n);
+                b.len = b.len + n;
+            }
+        }
+        buf_push_byte(b, '"');
+        ret;
+    }
+    if (sj.value_is_number(id)) { buf_push_i64(b, sj.value_number(id)); ret; }
+    buf_push(b, "null");
+}
+
+# release a string returned by `text`
+# ---
+# s:     the string to release; nil is a no-op
+# alloc: the allocator it was taken from
+pub fun free_str(s: str, alloc: *Allocator) {
+    if (s == nil) { ret; }
+    deallocate[u8](alloc, s::*u8, str_len(s) + 1);
+}
+
+# `s` as an owned, quoted, escaped JSON string literal
+#
+# the allocating counterpart to `buf_push_quoted`, for the fragment-assembled
+# payloads that still size themselves before filling.
+# ---
+# s:     the text to quote; nil renders as `""`
+# alloc: allocator backing the result
+# ret:   owned nul-terminated literal including its quotes, or nil
+pub fun quote(s: str, alloc: *Allocator) str {
+    var b: Buf = buf_init(alloc);
+    buf_push_quoted(?b, s);
+    val view: str = buf_str(?b);
+    if (view == nil) { buf_dnit(?b); ret nil; }
+    val n: usize = str_len(view);
+    val r: Result[*u8, str] = allocate[u8](alloc, n + 1);
+    if (is_err[*u8, str](r)) { buf_dnit(?b); ret nil; }
+    val out: *u8 = unwrap_ok[*u8, str](r);
+    if (n > 0) { mem.raw_copy(out::ptr, view::ptr, n); }
+    out[n] = 0;
+    buf_dnit(?b);
+    ret out::str;
+}
+
+# `value` rendered in base 10 as an owned string
+pub fun format_usize(value: usize, alloc: *Allocator) str {
+    var b: Buf = buf_init(alloc);
+    buf_push_usize(?b, value);
+    ret buf_take(?b, alloc);
+}
+
+# `value` rendered in base 10 as an owned string, with a sign for negatives
+pub fun format_i64(value: i64, alloc: *Allocator) str {
+    var b: Buf = buf_init(alloc);
+    buf_push_i64(?b, value);
+    ret buf_take(?b, alloc);
+}
+
+# copy a buffer's contents into a fresh owned string and release the buffer
+fun buf_take(b: *Buf, alloc: *Allocator) str {
+    val view: str = buf_str(b);
+    if (view == nil) { buf_dnit(b); ret nil; }
+    val n: usize = str_len(view);
+    val r: Result[*u8, str] = allocate[u8](alloc, n + 1);
+    if (is_err[*u8, str](r)) { buf_dnit(b); ret nil; }
+    val out: *u8 = unwrap_ok[*u8, str](r);
+    if (n > 0) { mem.raw_copy(out::ptr, view::ptr, n); }
+    out[n] = 0;
+    buf_dnit(b);
+    ret out::str;
+}
+
+# a request id rendered as its JSON token text, owned by `alloc`
+#
+# the response must echo the id with the wire type the request used, and the
+# fragment-assembled replies splice it in as text. nil when the message carried
+# no id, which marks a notification the server owes no response.
+# ---
+# id:    the request's id value, or nil
+# alloc: allocator backing the result
+# ret:   owned token text (`"abc"`, `7`, `null`), or nil when there is no id
+pub fun id_text(id: *sj.Value, alloc: *Allocator) str {
+    if (id == nil) { ret nil; }
+    var b: Buf = buf_init(alloc);
+    buf_push_id(?b, id);
+    ret buf_take(?b, alloc);
 }
 
 # --- Buf ---
@@ -680,7 +528,6 @@ test "json: content survives growth past the initial capacity" {
     if (s == nil)               { fail = true; }
     or {
         if (str_len(s) != 2000) { fail = true; }
-        # spot-check both ends and the first doubling boundary
         if (s[0] != 'x')        { fail = true; }
         if (s[1] != 'y')        { fail = true; }
         if (s[256] != 'x')      { fail = true; }
@@ -691,7 +538,9 @@ test "json: content survives growth past the initial capacity" {
     ret 0;
 }
 
-test "json: buf_push_quoted escapes the JSON control set" {
+# escaping is the std emitter's, so a control byte survives as an escape rather
+# than the `?` placeholder the hand-rolled escaper substituted
+test "json: buf_push_quoted escapes the JSON control set losslessly" {
     var pa: Allocator;
     page.make(?pa);
     var b: Buf = buf_init(?pa);
@@ -703,8 +552,6 @@ test "json: buf_push_quoted escapes the JSON control set" {
     ret 0;
 }
 
-# a nil string is a valid JSON value only as `""` - a diagnostic's optional
-# `related` label arrives nil and the protocol requires a string there
 test "json: buf_push_quoted renders nil as an empty JSON string" {
     var pa: Allocator;
     page.make(?pa);
@@ -722,32 +569,168 @@ test "json: numbers render in base 10 with a sign only where negative" {
     page.make(?pa);
     var b: Buf = buf_init(?pa);
     buf_push_usize(?b, 0);
-    buf_push_byte(?b, ',');
-    buf_push_usize(?b, 1234);
-    buf_push_byte(?b, ',');
-    buf_push_i64(?b, -7);
-    buf_push_byte(?b, ',');
+    buf_push_byte(?b, ' ');
+    buf_push_i64(?b, -42);
+    buf_push_byte(?b, ' ');
     buf_push_i64(?b, 42);
     var fail: bool = false;
-    if (!str_equals(buf_str(?b), "0,1234,-7,42")) { fail = true; }
+    if (!str_equals(buf_str(?b), "0 -42 42")) { fail = true; }
     buf_dnit(?b);
     if (fail) { ret 1; }
     ret 0;
 }
 
-# the failure latch is what lets callers check once at the end instead of at
-# every push, so a latched buffer must stay latched and read as nil
-test "json: a failed Buf latches and reads nil" {
+# --- reading ---
+
+# the scanner this replaced looked for a quoted key ANYWHERE in the body, so a
+# key spelled inside an opened file's own source text could win over the real
+# envelope member. a language server is handed exactly that input on didOpen
+test "json: a key spelled inside a string value never shadows a real member" {
     var pa: Allocator;
     page.make(?pa);
-    var b: Buf = buf_init(?pa);
-    buf_push(?b, "kept");
-    b.failed = true;
-    buf_push(?b, "dropped");
+    var rd: Reader;
+    if (!reader_init(?rd, ?pa)) { ret 1; }
+    val body: str = "{\"jsonrpc\":\"2.0\",\"params\":{\"text\":\"val s = \\\"method\\\": fake;\"},\"method\":\"textDocument/didOpen\"}";
+    var m: Message = read(?rd, body, str_len(body));
     var fail: bool = false;
-    if (b.len != 4)          { fail = true; }
-    if (buf_str(?b) != nil)  { fail = true; }
-    buf_dnit(?b);
+    if (!m.valid) { fail = true; }
+    or {
+        val method: str = text(member(?m.root, "method"), ?pa);
+        if (method == nil)                                    { fail = true; }
+        or {
+            if (!str_equals(method, "textDocument/didOpen"))  { fail = true; }
+            free_str(method, ?pa);
+        }
+    }
+    release(?rd);
+    reader_dnit(?rd);
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+test "json: member2 walks one level and misses report nil" {
+    var pa: Allocator;
+    page.make(?pa);
+    var rd: Reader;
+    if (!reader_init(?rd, ?pa)) { ret 1; }
+    val body: str = "{\"textDocument\":{\"uri\":\"file:///a.mach\",\"version\":7}}";
+    var m: Message = read(?rd, body, str_len(body));
+    var fail: bool = false;
+    if (!m.valid) { fail = true; }
+    or {
+        val uri: str = text(member2(?m.root, "textDocument", "uri"), ?pa);
+        if (uri == nil)                                 { fail = true; }
+        or {
+            if (!str_equals(uri, "file:///a.mach"))     { fail = true; }
+            free_str(uri, ?pa);
+        }
+        if (number(member2(?m.root, "textDocument", "version"), -1) != 7) { fail = true; }
+        if (member2(?m.root, "textDocument", "absent") != nil)            { fail = true; }
+        if (member2(?m.root, "absent", "uri") != nil)                     { fail = true; }
+    }
+    release(?rd);
+    reader_dnit(?rd);
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+test "json: string escapes in a value decode to their logical bytes" {
+    var pa: Allocator;
+    page.make(?pa);
+    var rd: Reader;
+    if (!reader_init(?rd, ?pa)) { ret 1; }
+    val body: str = "{\"text\":\"a\\nb\\tc\\\"d\"}";
+    var m: Message = read(?rd, body, str_len(body));
+    var fail: bool = false;
+    if (!m.valid) { fail = true; }
+    or {
+        val v: str = text(member(?m.root, "text"), ?pa);
+        if (v == nil)                        { fail = true; }
+        or {
+            if (!str_equals(v, "a\nb\tc\"d")) { fail = true; }
+            free_str(v, ?pa);
+        }
+    }
+    release(?rd);
+    reader_dnit(?rd);
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+# a response must echo the request id with the type it arrived as; a string id
+# is re-emitted from its wire bytes rather than decoded and re-escaped
+test "json: an id round-trips with its wire type preserved" {
+    var pa: Allocator;
+    page.make(?pa);
+    var rd: Reader;
+    if (!reader_init(?rd, ?pa)) { ret 1; }
+    var fail: bool = false;
+
+    val numeric: str = "{\"id\":12}";
+    var mn: Message = read(?rd, numeric, str_len(numeric));
+    val tn: str = id_text(member(?mn.root, "id"), ?pa);
+    if (tn == nil)                { fail = true; }
+    or { if (!str_equals(tn, "12")) { fail = true; } free_str(tn, ?pa); }
+
+    val quoted: str = "{\"id\":\"mls/registerWatchers\"}";
+    var mq: Message = read(?rd, quoted, str_len(quoted));
+    val tq: str = id_text(member(?mq.root, "id"), ?pa);
+    if (tq == nil)                { fail = true; }
+    or { if (!str_equals(tq, "\"mls/registerWatchers\"")) { fail = true; } free_str(tq, ?pa); }
+
+    val nulled: str = "{\"id\":null}";
+    var mz: Message = read(?rd, nulled, str_len(nulled));
+    val tz: str = id_text(member(?mz.root, "id"), ?pa);
+    if (tz == nil)                  { fail = true; }
+    or { if (!str_equals(tz, "null")) { fail = true; } free_str(tz, ?pa); }
+
+    # a notification carries no id and must not be answered
+    val notif: str = "{\"method\":\"exit\"}";
+    var mv: Message = read(?rd, notif, str_len(notif));
+    if (id_text(member(?mv.root, "id"), ?pa) != nil) { fail = true; }
+
+    release(?rd);
+    reader_dnit(?rd);
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+test "json: a malformed body reports invalid rather than a partial tree" {
+    var pa: Allocator;
+    page.make(?pa);
+    var rd: Reader;
+    if (!reader_init(?rd, ?pa)) { ret 1; }
+    var fail: bool = false;
+    val truncated: str = "{\"method\":\"initialize\"";
+    var m: Message = read(?rd, truncated, str_len(truncated));
+    if (m.valid) { fail = true; }
+    val trailing: str = "{\"a\":1} garbage";
+    var m2: Message = read(?rd, trailing, str_len(trailing));
+    if (m2.valid) { fail = true; }
+    release(?rd);
+    reader_dnit(?rd);
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+# the arena is what makes per-message parsing affordable: releasing must return
+# the chunks rather than grow without bound across a session's messages
+test "json: releasing a message reuses the arena instead of growing it" {
+    var pa: Allocator;
+    page.make(?pa);
+    var rd: Reader;
+    if (!reader_init(?rd, ?pa)) { ret 1; }
+    val body: str = "{\"method\":\"textDocument/didChange\",\"params\":{\"a\":[1,2,3,4,5,6,7,8]}}";
+    var i: usize = 0;
+    for (i < 200) {
+        var m: Message = read(?rd, body, str_len(body));
+        if (!m.valid) { release(?rd); reader_dnit(?rd); ret 1; }
+        release(?rd);
+        i = i + 1;
+    }
+    var fail: bool = false;
+    if (rd.ar.first_chunk != rd.ar.chunk) { fail = true; }
+    reader_dnit(?rd);
     if (fail) { ret 1; }
     ret 0;
 }

--- a/src/language.mach
+++ b/src/language.mach
@@ -58,6 +58,7 @@ use sema:   mach.lang.fe.sema;
 
 use transport: mls.transport;
 use json:      mls.json;
+use sj:        std.data.json;
 use documents: mls.documents;
 use features:  mls.features;
 use positions: mls.positions;
@@ -84,12 +85,12 @@ rec Analyzed {
 
 # answer textDocument/hover with the type / declaration of the symbol at
 # the cursor, or null when the position is not on a resolved symbol
-pub fun hover(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
-    val id_raw: str = json.extract_raw(body, "\"id\"", alloc);
+pub fun hover(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, id: *sj.Value, params: *sj.Value, uri: str) {
+    val id_raw: str = json.id_text(id, alloc);
     if (id_raw == nil) { ret; }
 
     var an: Analyzed;
-    val off_o: Option[usize] = locate(ws, es, alloc, docs, body, uri, ?an);
+    val off_o: Option[usize] = locate(ws, es, alloc, docs, params, uri, ?an);
     if (!is_some[usize](off_o)) { reply_null(alloc, id_raw); ret; }
     val offset: usize = unwrap[usize](off_o);
 
@@ -462,12 +463,12 @@ fun compose_kind_name(sym: *res.Symbol, interner: *intern.Interner, alloc: *Allo
 # symbol's declaration. lands in the buffer for a local symbol and in the
 # defining dependency module's on-disk file for a cross-module one; null when
 # the position is not on a resolved symbol or its declaration cannot be located
-pub fun definition(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
-    val id_raw: str = json.extract_raw(body, "\"id\"", alloc);
+pub fun definition(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, id: *sj.Value, params: *sj.Value, uri: str) {
+    val id_raw: str = json.id_text(id, alloc);
     if (id_raw == nil) { ret; }
 
     var an: Analyzed;
-    val off_o: Option[usize] = locate(ws, es, alloc, docs, body, uri, ?an);
+    val off_o: Option[usize] = locate(ws, es, alloc, docs, params, uri, ?an);
     if (!is_some[usize](off_o)) { reply_null(alloc, id_raw); ret; }
     val offset: usize = unwrap[usize](off_o);
 
@@ -1011,12 +1012,12 @@ fun field_rename_group_json(s: *FieldXRef, ti: *type.TypeInterner, t: FieldTarge
 # the symbol at the cursor - its declaration plus every use-site across the
 # loaded project graph (the requesting buffer and every other module that
 # references the symbol). empty when the position is not on a resolved symbol
-pub fun references(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
-    val id_raw: str = json.extract_raw(body, "\"id\"", alloc);
+pub fun references(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, id: *sj.Value, params: *sj.Value, uri: str) {
+    val id_raw: str = json.id_text(id, alloc);
     if (id_raw == nil) { ret; }
 
     var an: Analyzed;
-    val off_o: Option[usize] = locate(ws, es, alloc, docs, body, uri, ?an);
+    val off_o: Option[usize] = locate(ws, es, alloc, docs, params, uri, ?an);
     if (!is_some[usize](off_o)) { reply_empty_array(alloc, id_raw); ret; }
     val offset: usize = unwrap[usize](off_o);
 
@@ -1056,15 +1057,15 @@ pub fun references(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Al
 # editor's to rewrite (whether referenced cross-module or opened as the buffer
 # itself), so those yield an empty edit. an empty edit is also returned when a
 # module-scope symbol resolves to a dependency owned by the user
-pub fun rename(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
-    val id_raw: str = json.extract_raw(body, "\"id\"", alloc);
+pub fun rename(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, id: *sj.Value, params: *sj.Value, uri: str) {
+    val id_raw: str = json.id_text(id, alloc);
     if (id_raw == nil) { ret; }
 
-    val new_name: str = json.extract_string(body, "\"newName\"", alloc);
+    val new_name: str = json.text(json.member(params, "newName"), alloc);
     if (new_name == nil) { reply_null(alloc, id_raw); ret; }
 
     var an: Analyzed;
-    val off_o: Option[usize] = locate(ws, es, alloc, docs, body, uri, ?an);
+    val off_o: Option[usize] = locate(ws, es, alloc, docs, params, uri, ?an);
     if (!is_some[usize](off_o)) { reply_empty_edit(alloc, id_raw); json.free_str(new_name, alloc); ret; }
     val offset: usize = unwrap[usize](off_o);
 
@@ -1140,12 +1141,12 @@ fun param_generic_doc_span(an: Analyzed, sym: *res.Symbol, name: str, out: *toke
 # project-owned cross-module one) or a field of a known, project-owned record, or
 # null when it is not the editor's to rename (an unresolved position, a dependency
 # symbol, or a field of a vendored record)
-pub fun prepare_rename(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
-    val id_raw: str = json.extract_raw(body, "\"id\"", alloc);
+pub fun prepare_rename(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, id: *sj.Value, params: *sj.Value, uri: str) {
+    val id_raw: str = json.id_text(id, alloc);
     if (id_raw == nil) { ret; }
 
     var an: Analyzed;
-    val off_o: Option[usize] = locate(ws, es, alloc, docs, body, uri, ?an);
+    val off_o: Option[usize] = locate(ws, es, alloc, docs, params, uri, ?an);
     if (!is_some[usize](off_o)) { reply_null(alloc, id_raw); ret; }
     val offset: usize = unwrap[usize](off_o);
 
@@ -1183,8 +1184,8 @@ fun reply_range(alloc: *Allocator, id_raw: str, file: *src.SourceFile, span: tok
 # answer textDocument/documentSymbol with a flat list of the
 # file's top-level declarations as DocumentSymbol nodes (name, kind, range,
 # selectionRange)
-pub fun document_symbol(es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
-    val id_raw: str = json.extract_raw(body, "\"id\"", alloc);
+pub fun document_symbol(es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, id: *sj.Value, params: *sj.Value, uri: str) {
+    val id_raw: str = json.id_text(id, alloc);
     if (id_raw == nil) { ret; }
 
     val d: *documents.Document = documents.find(docs, uri);
@@ -1202,8 +1203,8 @@ pub fun document_symbol(es: *editor.EditorSession, alloc: *Allocator, docs: *doc
 
 # answer textDocument/completion with the in-scope top-level names
 # (module decls, `use` aliases / imports, primitives) as CompletionItems
-pub fun completion(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
-    val id_raw: str = json.extract_raw(body, "\"id\"", alloc);
+pub fun completion(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, id: *sj.Value, params: *sj.Value, uri: str) {
+    val id_raw: str = json.id_text(id, alloc);
     if (id_raw == nil) { ret; }
 
     var an: Analyzed;
@@ -1340,11 +1341,12 @@ fun analyze(ws: *project.Workspace, es: *editor.EditorSession, docs: *documents.
 # analyze the target document and resolve the request's cursor position
 # to a byte offset, or none when the document is unknown / unresolvable or the
 # position is invalid (callers fall back to a null / empty reply)
-fun locate(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, body: str, uri: str, out: *Analyzed) Option[usize] {
+fun locate(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, params: *sj.Value, uri: str, out: *Analyzed) Option[usize] {
     if (!analyze(ws, es, docs, uri, out)) { ret none[usize](); }
 
-    val line: i64 = json.extract_number_after(body, "\"position\"", "\"line\"", alloc);
-    val ch:   i64 = json.extract_number_after(body, "\"position\"", "\"character\"", alloc);
+    val pos: *sj.Value = json.member(params, "position");
+    val line: i64 = json.number(json.member(pos, "line"), -1);
+    val ch:   i64 = json.number(json.member(pos, "character"), -1);
     if (line < 0 || ch < 0) { ret none[usize](); }
 
     ret positions.offset_at(out.file, line::usize, ch::usize);

--- a/src/project.mach
+++ b/src/project.mach
@@ -38,6 +38,7 @@ use std.allocator.deallocate;
 use std.allocator.reallocate;
 
 use strutil: std.text.string;
+use fnv1a:   std.crypto.hash.fnv1a;
 use fs:      std.filesystem;
 use chrono:  std.chrono.time;
 use pathlib: std.types.path;
@@ -83,6 +84,14 @@ pub rec Site {
     owned: bool;
 }
 
+# sentinel for a content hash that has not been computed (or could not be)
+val HASH_UNKNOWN: u64 = 0;
+
+# a source file's change-detection state
+# ---
+# mtime: modification time in unix nanoseconds, 0 when absent
+# size:  size in bytes
+# hash:  FNV-1a of the contents, HASH_UNKNOWN until a stat mismatch forces it
 rec SourceFingerprint {
     mtime: i64;
     size:  usize;
@@ -570,6 +579,8 @@ fun alloc_slot(w: *Workspace) *Root {
 # compose the selected primary artifact request and retain the compiler-owned
 # load/resolve/sema snapshot for `r.path`
 fun try_load(w: *Workspace, r: *Root) bool {
+    val started_ns: i64 = trace.now_ns();
+    fin { trace.logf("project: analyzed {} in {}ms", r.path, (trace.now_ns() - started_ns) / 1000000); }
     record_mtimes(w, r);
     r.dirty = false;
     val sor: Result[bool, str] = sync_overlays(w, r);
@@ -875,7 +886,7 @@ fun build_mod_paths(w: *Workspace, r: *Root) Result[bool, str] {
             free_path_snapshot(w.alloc, paths, fingerprints, n, i);
             ret err[bool, str]("project: failed to normalize loaded module path");
         }
-        fingerprints[i] = file_fingerprint(w.alloc, paths[i]);
+        fingerprints[i] = file_fingerprint(paths[i]);
         i = i + 1;
     }
     free_mod_paths(w, r);
@@ -919,11 +930,8 @@ fun maybe_reload(w: *Workspace, r: *Root) {
     var changed: bool = man != r.man_mtime || lock != r.lock_mtime;
     var i: u32 = 0;
     for (!changed && i < r.mod_path_count) {
-        if (r.mod_paths[i] != nil) {
-            val fp: SourceFingerprint = file_fingerprint(w.alloc, r.mod_paths[i]);
-            if (fp.mtime != r.mod_fingerprints[i].mtime || fp.size != r.mod_fingerprints[i].size
-                || fp.hash != r.mod_fingerprints[i].hash) { changed = true; }
-        }
+        if (r.mod_paths[i] != nil
+            && !fingerprint_matches(w.alloc, r.mod_paths[i], ?r.mod_fingerprints[i])) { changed = true; }
         i = i + 1;
     }
     if (!changed) { ret; }
@@ -1103,26 +1111,77 @@ fun join_mtime(alloc: *Allocator, dir: str, name: str) i64 {
     ret m;
 }
 
-fun file_fingerprint(alloc: *Allocator, path: str) SourceFingerprint {
+# stat-only fingerprint: the metadata half is what every scan reads
+#
+# `hash` is left HASH_UNKNOWN. The content hash exists only to suppress a
+# rebuild after a touch that did not change bytes, so it is computed lazily by
+# `fingerprint_matches` for the rare file whose (mtime, size) moved - never for
+# the whole module set on a periodic scan.
+# ---
+# path: absolute source path to stat
+# ret:  the file's (mtime, size) with an unresolved hash; zeroed when absent
+fun file_fingerprint(path: str) SourceFingerprint {
     var fp: SourceFingerprint;
     fp.mtime = 0;
     fp.size = 0;
-    fp.hash = 0;
+    fp.hash = HASH_UNKNOWN;
     val fi_r: Result[fs.Metadata, str] = fs.metadata(path);
     if (is_err[fs.Metadata, str](fi_r)) { ret fp; }
     var fi: fs.Metadata = unwrap_ok[fs.Metadata, str](fi_r);
     fp.mtime = chrono.time_unix_nsec(fi.modified);
     fp.size = fi.size;
-    val text_r: Result[str, str] = fs.read_string(alloc, path);
-    if (!is_err[str, str](text_r)) {
-        val text: str = unwrap_ok[str, str](text_r);
-        var h: u64 = 14695981039346656037;
-        var i: usize = 0;
-        for (i < str_len(text)) { h = (h ^ text[i]::u64) * 1099511628211; i = i + 1; }
-        fp.hash = h;
-        strutil.str_free(alloc, text);
-    }
     ret fp;
+}
+
+# FNV-1a over a file's bytes, or HASH_UNKNOWN when it cannot be read
+# ---
+# alloc: allocator for the transient file read
+# path:  absolute source path to hash
+# ret:   the content hash, or HASH_UNKNOWN on a read failure
+fun file_content_hash(alloc: *Allocator, path: str) u64 {
+    val text_r: Result[str, str] = fs.read_string(alloc, path);
+    if (is_err[str, str](text_r)) { ret HASH_UNKNOWN; }
+    val text: str = unwrap_ok[str, str](text_r);
+    val n: usize = str_len(text);
+    var h: u64 = fnv1a.FNV_INIT;
+    var i: usize = 0;
+    for (i < n) {
+        h = fnv1a.step_u8(h, text[i]);
+        i = i + 1;
+    }
+    strutil.str_free(alloc, text);
+    if (h == HASH_UNKNOWN) { ret HASH_UNKNOWN + 1; }
+    ret h;
+}
+
+# whether `path` still matches the fingerprint recorded in `prev`
+#
+# Equal (mtime, size) accepts without touching the file's bytes, which is the
+# whole-module-set case on every periodic scan. Only a moved stat pair falls
+# through to a content hash, and only then is `prev.hash` resolved so a pure
+# touch does not force a rebuild. `prev` is updated in place so the resolved
+# hash is reused by later scans.
+# ---
+# alloc: allocator for the transient read a hash comparison needs
+# path:  absolute source path to check
+# prev:  recorded fingerprint, updated in place
+# ret:   true when the file's content is unchanged
+fun fingerprint_matches(alloc: *Allocator, path: str, prev: *SourceFingerprint) bool {
+    val now: SourceFingerprint = file_fingerprint(path);
+    if (now.mtime == prev.mtime && now.size == prev.size) { ret true; }
+    if (now.size != prev.size) {
+        @prev = now;
+        ret false;
+    }
+    # same size, different mtime: only a content hash separates a touch from an
+    # edit, so resolve both sides once and cache them.
+    if (prev.hash == HASH_UNKNOWN) { prev.hash = file_content_hash(alloc, path); }
+    val h: u64 = file_content_hash(alloc, path);
+    prev.mtime = now.mtime;
+    prev.size = now.size;
+    if (h == prev.hash && h != HASH_UNKNOWN) { ret true; }
+    prev.hash = h;
+    ret false;
 }
 
 # where symbol `sym` is declared, as an Ast / SourceFile / URI triple.

--- a/src/project.mach
+++ b/src/project.mach
@@ -38,7 +38,6 @@ use std.allocator.deallocate;
 use std.allocator.reallocate;
 
 use strutil: std.text.string;
-use fnv1a:   std.crypto.hash.fnv1a;
 use fs:      std.filesystem;
 use chrono:  std.chrono.time;
 use pathlib: std.types.path;
@@ -84,18 +83,20 @@ pub rec Site {
     owned: bool;
 }
 
-# sentinel for a content hash that has not been computed (or could not be)
-val HASH_UNKNOWN: u64 = 0;
-
 # a source file's change-detection state
+#
+# Stat metadata only. A content hash would suppress a rebuild after a touch
+# that did not change bytes, but reading and hashing every module to save that
+# case costs more than the case does: a spurious rebuild reuses the retained
+# session, where `Q_FILE_TEXT`'s byte-equality cutoff keeps every unchanged
+# module's parse, resolve, and sema entry valid. The compiler already owns
+# content-change detection, so the LSP does not duplicate it.
 # ---
 # mtime: modification time in unix nanoseconds, 0 when absent
 # size:  size in bytes
-# hash:  FNV-1a of the contents, HASH_UNKNOWN until a stat mismatch forces it
 rec SourceFingerprint {
     mtime: i64;
     size:  usize;
-    hash:  u64;
 }
 
 # one project root and its compiler-owned semantic snapshot
@@ -875,7 +876,6 @@ fun build_mod_paths(w: *Workspace, r: *Root) Result[bool, str] {
         paths[i] = nil;
         fingerprints[i].mtime = 0;
         fingerprints[i].size = 0;
-        fingerprints[i].hash = 0;
         val fo: Option[*src.SourceFile] = src.get(?r.s.sources, (?r.p.modules[i]).file_id);
         if (!is_some[*src.SourceFile](fo)) {
             free_path_snapshot(w.alloc, paths, fingerprints, n, i);
@@ -931,7 +931,7 @@ fun maybe_reload(w: *Workspace, r: *Root) {
     var i: u32 = 0;
     for (!changed && i < r.mod_path_count) {
         if (r.mod_paths[i] != nil
-            && !fingerprint_matches(w.alloc, r.mod_paths[i], ?r.mod_fingerprints[i])) { changed = true; }
+            && !fingerprint_matches(r.mod_paths[i], ?r.mod_fingerprints[i])) { changed = true; }
         i = i + 1;
     }
     if (!changed) { ret; }
@@ -1111,20 +1111,14 @@ fun join_mtime(alloc: *Allocator, dir: str, name: str) i64 {
     ret m;
 }
 
-# stat-only fingerprint: the metadata half is what every scan reads
-#
-# `hash` is left HASH_UNKNOWN. The content hash exists only to suppress a
-# rebuild after a touch that did not change bytes, so it is computed lazily by
-# `fingerprint_matches` for the rare file whose (mtime, size) moved - never for
-# the whole module set on a periodic scan.
+# the `(mtime, size)` of `path`, zeroed when it is absent or unreadable
 # ---
 # path: absolute source path to stat
-# ret:  the file's (mtime, size) with an unresolved hash; zeroed when absent
+# ret:  the file's stat fingerprint
 fun file_fingerprint(path: str) SourceFingerprint {
     var fp: SourceFingerprint;
     fp.mtime = 0;
     fp.size = 0;
-    fp.hash = HASH_UNKNOWN;
     val fi_r: Result[fs.Metadata, str] = fs.metadata(path);
     if (is_err[fs.Metadata, str](fi_r)) { ret fp; }
     var fi: fs.Metadata = unwrap_ok[fs.Metadata, str](fi_r);
@@ -1133,54 +1127,18 @@ fun file_fingerprint(path: str) SourceFingerprint {
     ret fp;
 }
 
-# FNV-1a over a file's bytes, or HASH_UNKNOWN when it cannot be read
-# ---
-# alloc: allocator for the transient file read
-# path:  absolute source path to hash
-# ret:   the content hash, or HASH_UNKNOWN on a read failure
-fun file_content_hash(alloc: *Allocator, path: str) u64 {
-    val text_r: Result[str, str] = fs.read_string(alloc, path);
-    if (is_err[str, str](text_r)) { ret HASH_UNKNOWN; }
-    val text: str = unwrap_ok[str, str](text_r);
-    val n: usize = str_len(text);
-    var h: u64 = fnv1a.FNV_INIT;
-    var i: usize = 0;
-    for (i < n) {
-        h = fnv1a.step_u8(h, text[i]);
-        i = i + 1;
-    }
-    strutil.str_free(alloc, text);
-    if (h == HASH_UNKNOWN) { ret HASH_UNKNOWN + 1; }
-    ret h;
-}
-
 # whether `path` still matches the fingerprint recorded in `prev`
 #
-# Equal (mtime, size) accepts without touching the file's bytes, which is the
-# whole-module-set case on every periodic scan. Only a moved stat pair falls
-# through to a content hash, and only then is `prev.hash` resolved so a pure
-# touch does not force a rebuild. `prev` is updated in place so the resolved
-# hash is reused by later scans.
+# `prev` is refreshed on a mismatch so one disk change triggers one rebuild
+# rather than one per scan until the snapshot is replaced.
 # ---
-# alloc: allocator for the transient read a hash comparison needs
-# path:  absolute source path to check
-# prev:  recorded fingerprint, updated in place
-# ret:   true when the file's content is unchanged
-fun fingerprint_matches(alloc: *Allocator, path: str, prev: *SourceFingerprint) bool {
+# path: absolute source path to check
+# prev: recorded fingerprint, updated in place on a mismatch
+# ret:  true when the file looks unchanged
+fun fingerprint_matches(path: str, prev: *SourceFingerprint) bool {
     val now: SourceFingerprint = file_fingerprint(path);
     if (now.mtime == prev.mtime && now.size == prev.size) { ret true; }
-    if (now.size != prev.size) {
-        @prev = now;
-        ret false;
-    }
-    # same size, different mtime: only a content hash separates a touch from an
-    # edit, so resolve both sides once and cache them.
-    if (prev.hash == HASH_UNKNOWN) { prev.hash = file_content_hash(alloc, path); }
-    val h: u64 = file_content_hash(alloc, path);
-    prev.mtime = now.mtime;
-    prev.size = now.size;
-    if (h == prev.hash && h != HASH_UNKNOWN) { ret true; }
-    prev.hash = h;
+    @prev = now;
     ret false;
 }
 

--- a/src/project.mach
+++ b/src/project.mach
@@ -1058,6 +1058,21 @@ fun document_belongs(w: *Workspace, r: *Root, path: str) bool {
     ret vendored;
 }
 
+# whether `d` is mirrored into `r`'s session, and so shares its snapshot
+#
+# Diagnostics for a document can only move when the root that analyzes it is
+# rebuilt, so this is the republish set after a change: the documents a root
+# actually governs, not every open buffer in the session.
+# ---
+# w:   the workspace
+# r:   the root to test against, or nil
+# d:   the open document
+# ret: true when `r` governs `d`
+pub fun root_covers_document(w: *Workspace, r: *Root, d: *documents.Document) bool {
+    if (r == nil || d == nil || d.path == nil || r.path == nil || r.s == nil) { ret false; }
+    ret document_belongs(w, r, d.path);
+}
+
 # release a root's retained Project, source index, Session, and owned path
 fun free_root(w: *Workspace, r: *Root) {
     free_root_graph(w, r);

--- a/src/server.mach
+++ b/src/server.mach
@@ -33,6 +33,8 @@ use editor: mach.lang.editor;
 use transport:   mls.transport;
 use json:        mls.json;
 use sj:          std.data.json;
+use jobs:        mls.jobs;
+use atomic:      std.sync.atomic;
 use documents:   mls.documents;
 use diagnostics: mls.diagnostics;
 use language:    mls.language;
@@ -66,7 +68,9 @@ val WATCH_ACTIVE:   u8 = 2;
 # es:            editor session over `s` (per-buffer analysis)
 # docs:          URI -> editor buffer registry
 # ws:            per-root project graphs backing cross-module analysis
-# rd:            per-message JSON parse arena
+# rd:            per-message JSON parse arena, owned by the analysis thread
+# q:             message queue feeding the analysis thread
+# stop:          set once the reading thread should stop; read atomically
 # watch_dynamic: whether the client supports dynamic file-watch registration
 #                (`workspace/didChangeWatchedFiles`), advertised at initialize
 pub rec Server {
@@ -78,6 +82,8 @@ pub rec Server {
     docs:          documents.Store;
     ws:            project.Workspace;
     rd:            json.Reader;
+    q:             jobs.Queue;
+    stop:          i64;
     watch_dynamic: bool;
     watch_state:   u8;
 }
@@ -103,6 +109,8 @@ pub fun init(srv: *Server, alloc: *Allocator) bool {
     srv.ws = project.init(?srv.s, alloc);
     project.attach_documents(?srv.ws, ?srv.docs);
     if (!json.reader_init(?srv.rd, alloc)) { ret false; }
+    srv.stop = 0;
+    if (!jobs.init(?srv.q, alloc)) { ret false; }
     ret true;
 }
 
@@ -110,6 +118,7 @@ pub fun init(srv: *Server, alloc: *Allocator) bool {
 # ---
 # srv: server to tear down
 pub fun dnit(srv: *Server) {
+    jobs.dnit(?srv.q);
     json.reader_dnit(?srv.rd);
     documents.dnit(?srv.docs);
     project.dnit(?srv.ws);
@@ -118,49 +127,76 @@ pub fun dnit(srv: *Server) {
     srv.status = STATUS_EXITED;
 }
 
-# read and dispatch framed messages until the server exits
+# read framed messages until input ends, handing each to the analysis thread
+#
+# This thread owns stdin and nothing else. Every message - parsing included -
+# is handled on the worker, so the compiler's state has exactly one owner and
+# needs no locking, and a cold analysis cannot stop the server from reading the
+# cancellation, edit, or shutdown that follows it.
+#
+# The worker decides the exit code, so the read loop drains the queue before
+# reading it: an EOF arriving while `shutdown` is still queued must not be
+# mistaken for input closing before shutdown.
 # ---
 # srv: the server to drive
 # ret: the process exit code
 pub fun run(srv: *Server) i64 {
     trace.log("=== mach-lsp started ===\n");
 
-    for (srv.status != STATUS_EXITED) {
+    if (!jobs.start(?srv.q, handle_job, (srv)::ptr)) {
+        trace.log("server: could not start the analysis thread\n");
+        ret 1;
+    }
+
+    var last_read: transport.ReadStatus = transport.READ_OK;
+    for (true) {
         var msg: transport.Message;
-        val read_status: transport.ReadStatus = transport.read_message(?msg, srv.alloc);
-        if (read_status != transport.READ_OK) {
-            if (read_status == transport.READ_EOF && srv.status == STATUS_SHUTTING_DOWN) {
-                srv.status = STATUS_EXITED;
-                brk;
-            }
-            if (read_status == transport.READ_EOF) { trace.log("transport: input closed before shutdown\n"); }
-            or (read_status == transport.READ_MALFORMED) { trace.log("transport: malformed input frame\n"); }
-            or { trace.log("transport: input error\n"); }
-            srv.exit_code = 1;
-            srv.status = STATUS_EXITED;
+        last_read = transport.read_message(?msg, srv.alloc);
+        if (last_read != transport.READ_OK) {
+            if (last_read == transport.READ_EOF)        { trace.log("transport: input closed\n"); }
+            or (last_read == transport.READ_MALFORMED)  { trace.log("transport: malformed input frame\n"); }
+            or                                          { trace.log("transport: input error\n"); }
             brk;
         }
 
-        trace.log("recv: ");
-        trace.log(msg.body);
-        trace.log("\n");
-
-        val started_ns: i64 = trace.now_ns();
-        var parsed: json.Message = json.read(?srv.rd, msg.body, msg.body_len);
-        if (parsed.valid) { dispatch(srv, ?parsed.root); }
-        or { reply_parse_error(srv); }
-        json.release(?srv.rd);
-        trace.logf("server: handled message in {}ms", (trace.now_ns() - started_ns) / 1000000);
-        transport.message_free(?msg, srv.alloc);
-        if (transport.write_failed()) {
-            trace.log("transport: output failed\n");
-            srv.exit_code = 1;
-            srv.status = STATUS_EXITED;
+        if (!jobs.push(?srv.q, msg.body, msg.body_len)) {
+            trace.logf("server: analysis queue full at {} messages, dropping input",
+                       jobs.depth(?srv.q)::i64);
         }
+        transport.message_free(?msg, srv.alloc);
+        if (atomic.load(?srv.stop) != 0) { brk; }
     }
 
+    # every accepted message is answered before the exit code is decided
+    jobs.join(?srv.q);
     trace.log("=== mach-lsp exiting ===\n");
-    ret srv.exit_code;
+
+    if (transport.write_failed()) { ret 1; }
+    if (srv.status == STATUS_EXITED)       { ret srv.exit_code; }
+    if (last_read == transport.READ_EOF && srv.status == STATUS_SHUTTING_DOWN) { ret 0; }
+    ret 1;
+}
+
+# handle one queued message on the analysis thread
+#
+# The parse arena and every compiler-owned structure belong to this thread.
+fun handle_job(ctx: ptr, body: str, len: usize) {
+    val srv: *Server = ctx::*Server;
+
+    trace.log("recv: ");
+    trace.log(body);
+    trace.log("\n");
+
+    val started_ns: i64 = trace.now_ns();
+    var parsed: json.Message = json.read(?srv.rd, body, len);
+    if (parsed.valid) { dispatch(srv, ?parsed.root); }
+    or { reply_parse_error(srv); }
+    json.release(?srv.rd);
+    trace.logf("server: handled message in {}ms", (trace.now_ns() - started_ns) / 1000000);
+
+    if (srv.status == STATUS_EXITED || transport.write_failed()) {
+        atomic.store(?srv.stop, 1);
+    }
 }
 
 # route one parsed message by its `method` member

--- a/src/server.mach
+++ b/src/server.mach
@@ -131,7 +131,9 @@ pub fun run(srv: *Server) i64 {
         trace.log(msg.body);
         trace.log("\n");
 
+        val started_ns: i64 = trace.now_ns();
         dispatch(srv, ?msg);
+        trace.logf("server: handled message in {}ms", (trace.now_ns() - started_ns) / 1000000);
         transport.message_free(?msg, srv.alloc);
         if (transport.write_failed()) {
             trace.log("transport: output failed\n");

--- a/src/server.mach
+++ b/src/server.mach
@@ -71,6 +71,8 @@ val WATCH_ACTIVE:   u8 = 2;
 # rd:            per-message JSON parse arena, owned by the analysis thread
 # q:             message queue feeding the analysis thread
 # stop:          set once the reading thread should stop; read atomically
+# deferred:      a document changed but its analysis was postponed behind newer
+#                input, and must run once the queue drains
 # watch_dynamic: whether the client supports dynamic file-watch registration
 #                (`workspace/didChangeWatchedFiles`), advertised at initialize
 pub rec Server {
@@ -84,6 +86,7 @@ pub rec Server {
     rd:            json.Reader;
     q:             jobs.Queue;
     stop:          i64;
+    deferred:      bool;
     watch_dynamic: bool;
     watch_state:   u8;
 }
@@ -110,6 +113,7 @@ pub fun init(srv: *Server, alloc: *Allocator) bool {
     project.attach_documents(?srv.ws, ?srv.docs);
     if (!json.reader_init(?srv.rd, alloc)) { ret false; }
     srv.stop = 0;
+    srv.deferred = false;
     if (!jobs.init(?srv.q, alloc)) { ret false; }
     ret true;
 }
@@ -192,6 +196,14 @@ fun handle_job(ctx: ptr, body: str, len: usize) {
     if (parsed.valid) { dispatch(srv, ?parsed.root); }
     or { reply_parse_error(srv); }
     json.release(?srv.rd);
+
+    # a coalesced burst leaves the newest text unanalyzed; the moment the queue
+    # drains is when that debt comes due, whatever the last message happened to
+    # be. deferring analysis must never mean skipping it.
+    if (srv.deferred && jobs.depth(?srv.q) == 0 && srv.status == STATUS_RUNNING) {
+        srv.deferred = false;
+        republish_all(srv);
+    }
     trace.logf("server: handled message in {}ms", (trace.now_ns() - started_ns) / 1000000);
 
     if (srv.status == STATUS_EXITED || transport.write_failed()) {
@@ -460,6 +472,19 @@ fun publish_for(srv: *Server, uri: str, text: str, version: i64, is_open: bool) 
         trace.log("project: failed to mirror document overlay\n");
         ret;
     }
+
+    # The document's text and revision are recorded above; analyzing it is what
+    # costs. While more input is already queued, that analysis would be thrown
+    # away by the very next message, so a burst of keystrokes coalesces into one
+    # analysis of the newest text instead of one per revision. The message that
+    # finds the queue empty is the one that publishes, so the newest state is
+    # always analyzed - deferring is never dropping.
+    if (jobs.depth(?srv.q) > 0) {
+        srv.deferred = true;
+        trace.log("server: newer input queued, deferring analysis\n");
+        ret;
+    }
+    srv.deferred = false;
     republish_root(srv, project.root_for(?srv.ws, doc.uri), doc);
 }
 

--- a/src/server.mach
+++ b/src/server.mach
@@ -32,6 +32,7 @@ use editor: mach.lang.editor;
 
 use transport:   mls.transport;
 use json:        mls.json;
+use sj:          std.data.json;
 use documents:   mls.documents;
 use diagnostics: mls.diagnostics;
 use language:    mls.language;
@@ -43,6 +44,15 @@ pub val STATUS_UNINITIALIZED: u8 = 0;
 pub val STATUS_RUNNING:       u8 = 1;
 pub val STATUS_SHUTTING_DOWN: u8 = 2;
 pub val STATUS_EXITED:        u8 = 3;
+# language features, as dispatch selectors
+val FEATURE_HOVER:           u8 = 0;
+val FEATURE_DEFINITION:      u8 = 1;
+val FEATURE_REFERENCES:      u8 = 2;
+val FEATURE_RENAME:          u8 = 3;
+val FEATURE_PREPARE_RENAME:  u8 = 4;
+val FEATURE_DOCUMENT_SYMBOL: u8 = 5;
+val FEATURE_COMPLETION:      u8 = 6;
+
 val WATCH_FALLBACK: u8 = 0;
 val WATCH_PENDING:  u8 = 1;
 val WATCH_ACTIVE:   u8 = 2;
@@ -56,6 +66,7 @@ val WATCH_ACTIVE:   u8 = 2;
 # es:            editor session over `s` (per-buffer analysis)
 # docs:          URI -> editor buffer registry
 # ws:            per-root project graphs backing cross-module analysis
+# rd:            per-message JSON parse arena
 # watch_dynamic: whether the client supports dynamic file-watch registration
 #                (`workspace/didChangeWatchedFiles`), advertised at initialize
 pub rec Server {
@@ -66,6 +77,7 @@ pub rec Server {
     es:            editor.EditorSession;
     docs:          documents.Store;
     ws:            project.Workspace;
+    rd:            json.Reader;
     watch_dynamic: bool;
     watch_state:   u8;
 }
@@ -90,6 +102,7 @@ pub fun init(srv: *Server, alloc: *Allocator) bool {
     srv.docs = documents.init(?srv.es, alloc);
     srv.ws = project.init(?srv.s, alloc);
     project.attach_documents(?srv.ws, ?srv.docs);
+    if (!json.reader_init(?srv.rd, alloc)) { ret false; }
     ret true;
 }
 
@@ -97,6 +110,7 @@ pub fun init(srv: *Server, alloc: *Allocator) bool {
 # ---
 # srv: server to tear down
 pub fun dnit(srv: *Server) {
+    json.reader_dnit(?srv.rd);
     documents.dnit(?srv.docs);
     project.dnit(?srv.ws);
     editor.dnit(?srv.es);
@@ -132,7 +146,10 @@ pub fun run(srv: *Server) i64 {
         trace.log("\n");
 
         val started_ns: i64 = trace.now_ns();
-        dispatch(srv, ?msg);
+        var parsed: json.Message = json.read(?srv.rd, msg.body, msg.body_len);
+        if (parsed.valid) { dispatch(srv, ?parsed.root); }
+        or { reply_parse_error(srv); }
+        json.release(?srv.rd);
         trace.logf("server: handled message in {}ms", (trace.now_ns() - started_ns) / 1000000);
         transport.message_free(?msg, srv.alloc);
         if (transport.write_failed()) {
@@ -146,136 +163,74 @@ pub fun run(srv: *Server) i64 {
     ret srv.exit_code;
 }
 
-# route one message body by its `method` field
-fun dispatch(srv: *Server, msg: *transport.Message) {
-    val body: str = msg.body;
-    val method: str = json.extract_string(body, "\"method\"", srv.alloc);
-    if (method == nil) { handle_response(srv, body); ret; }
+# route one parsed message by its `method` member
+#
+# a message with no `method` is a response to something the server asked for.
+# an unknown method gets a JSON-RPC method-not-found error when it carries an
+# id, and is dropped when it does not - a notification owes no response.
+fun dispatch(srv: *Server, root: *sj.Value) {
+    val a: *Allocator = srv.alloc;
+    val method_v: *sj.Value = json.member(root, "method");
+    if (method_v == nil) { handle_response(srv, root); ret; }
+    val method: str = json.text(method_v, a);
+    if (method == nil) { reply_invalid_request(srv, root); ret; }
+    val params: *sj.Value = json.member(root, "params");
 
-    if (str_equals(method, "initialize")) {
-        json.free_str(method, srv.alloc);
-        handle_initialize(srv, body);
-        ret;
-    }
-    if (str_equals(method, "initialized")) {
-        json.free_str(method, srv.alloc);
-        handle_initialized(srv);
-        ret;
-    }
-    if (str_equals(method, "shutdown")) {
-        json.free_str(method, srv.alloc);
-        handle_shutdown(srv, body);
-        ret;
-    }
-    if (str_equals(method, "exit")) {
-        json.free_str(method, srv.alloc);
-        handle_exit(srv);
-        ret;
-    }
+    if (str_equals(method, "initialize"))  { json.free_str(method, a); handle_initialize(srv, root, params); ret; }
+    if (str_equals(method, "initialized")) { json.free_str(method, a); handle_initialized(srv); ret; }
+    if (str_equals(method, "shutdown"))    { json.free_str(method, a); handle_shutdown(srv, root); ret; }
+    if (str_equals(method, "exit"))        { json.free_str(method, a); handle_exit(srv); ret; }
 
     if (srv.status != STATUS_RUNNING) {
-        json.free_str(method, srv.alloc);
-        reply_error(srv, body, -32002, "server not initialized");
+        json.free_str(method, a);
+        reply_error(srv, root, -32002, "server not initialized");
         ret;
     }
 
-    if (str_equals(method, "textDocument/didOpen")) {
-        json.free_str(method, srv.alloc);
-        handle_did_open(srv, body);
-        ret;
-    }
-    if (str_equals(method, "textDocument/didChange")) {
-        json.free_str(method, srv.alloc);
-        handle_did_change(srv, body);
-        ret;
-    }
-    if (str_equals(method, "textDocument/didClose")) {
-        json.free_str(method, srv.alloc);
-        handle_did_close(srv, body);
-        ret;
-    }
-    if (str_equals(method, "textDocument/didSave")) {
-        json.free_str(method, srv.alloc);
-        handle_did_save(srv, body);
-        ret;
-    }
-    if (str_equals(method, "workspace/didChangeConfiguration")) {
-        json.free_str(method, srv.alloc);
-        ret;
-    }
-    if (str_equals(method, "workspace/didChangeWatchedFiles")) {
-        json.free_str(method, srv.alloc);
-        handle_did_change_watched_files(srv, body);
-        ret;
-    }
+    if (str_equals(method, "textDocument/didOpen"))   { json.free_str(method, a); handle_did_open(srv, params); ret; }
+    if (str_equals(method, "textDocument/didChange")) { json.free_str(method, a); handle_did_change(srv, params); ret; }
+    if (str_equals(method, "textDocument/didClose"))  { json.free_str(method, a); handle_did_close(srv, params); ret; }
+    if (str_equals(method, "textDocument/didSave"))   { json.free_str(method, a); handle_did_save(srv, params); ret; }
+    if (str_equals(method, "workspace/didChangeConfiguration")) { json.free_str(method, a); ret; }
+    if (str_equals(method, "workspace/didChangeWatchedFiles"))  { json.free_str(method, a); handle_did_change_watched_files(srv, params); ret; }
 
-    if (str_equals(method, "textDocument/hover")) {
-        json.free_str(method, srv.alloc);
-        handle_feature(srv, body, 0);
-        ret;
-    }
-    if (str_equals(method, "textDocument/definition")) {
-        json.free_str(method, srv.alloc);
-        handle_feature(srv, body, 1);
-        ret;
-    }
-    if (str_equals(method, "textDocument/references")) {
-        json.free_str(method, srv.alloc);
-        handle_feature(srv, body, 2);
-        ret;
-    }
-    if (str_equals(method, "textDocument/rename")) {
-        json.free_str(method, srv.alloc);
-        handle_feature(srv, body, 3);
-        ret;
-    }
-    if (str_equals(method, "textDocument/prepareRename")) {
-        json.free_str(method, srv.alloc);
-        handle_feature(srv, body, 4);
-        ret;
-    }
-    if (str_equals(method, "textDocument/documentSymbol")) {
-        json.free_str(method, srv.alloc);
-        handle_feature(srv, body, 5);
-        ret;
-    }
-    if (str_equals(method, "textDocument/completion")) {
-        json.free_str(method, srv.alloc);
-        handle_feature(srv, body, 6);
-        ret;
-    }
+    if (str_equals(method, "textDocument/hover"))          { json.free_str(method, a); handle_feature(srv, root, params, FEATURE_HOVER); ret; }
+    if (str_equals(method, "textDocument/definition"))     { json.free_str(method, a); handle_feature(srv, root, params, FEATURE_DEFINITION); ret; }
+    if (str_equals(method, "textDocument/references"))     { json.free_str(method, a); handle_feature(srv, root, params, FEATURE_REFERENCES); ret; }
+    if (str_equals(method, "textDocument/rename"))         { json.free_str(method, a); handle_feature(srv, root, params, FEATURE_RENAME); ret; }
+    if (str_equals(method, "textDocument/prepareRename"))  { json.free_str(method, a); handle_feature(srv, root, params, FEATURE_PREPARE_RENAME); ret; }
+    if (str_equals(method, "textDocument/documentSymbol")) { json.free_str(method, a); handle_feature(srv, root, params, FEATURE_DOCUMENT_SYMBOL); ret; }
+    if (str_equals(method, "textDocument/completion"))     { json.free_str(method, a); handle_feature(srv, root, params, FEATURE_COMPLETION); ret; }
 
-    trace.log("unhandled method: ");
-    trace.log(method);
-    trace.log("\n");
-    json.free_str(method, srv.alloc);
-    reply_error(srv, body, -32601, "method not found");
+    trace.logf("server: unhandled method {}", method);
+    json.free_str(method, a);
+    if (json.member(root, "id") != nil) { reply_error(srv, root, -32601, "method not found"); }
 }
 
-# answer the initialize request with the server's
-# capabilities (full-text document sync) and mark the server running
-fun handle_initialize(srv: *Server, body: str) {
-    val id: str = json.extract_raw(body, "\"id\"", srv.alloc);
-    if (id == nil) { ret; }
-
+# answer the initialize request with the server's capabilities (full-text
+# document sync) and mark the server running
+fun handle_initialize(srv: *Server, root: *sj.Value, params: *sj.Value) {
     # remember whether the client can accept a dynamic watch registration, so
     # `initialized` only sends one when it will be honoured.
-    srv.watch_dynamic = json.extract_bool_after(body, "\"didChangeWatchedFiles\"", "\"dynamicRegistration\"", srv.alloc);
+    val watched: *sj.Value = json.member(
+        json.member2(params, "capabilities", "workspace"), "didChangeWatchedFiles");
+    srv.watch_dynamic = json.boolean(json.member(watched, "dynamicRegistration"), false);
 
-    val prefix: str = "{\"jsonrpc\":\"2.0\",\"id\":";
-    val result: str = ",\"result\":{\"capabilities\":{\"textDocumentSync\":1,\"hoverProvider\":true,\"definitionProvider\":true,\"referencesProvider\":true,\"renameProvider\":{\"prepareProvider\":true},\"documentSymbolProvider\":true,\"completionProvider\":{\"triggerCharacters\":[\".\"]}},\"serverInfo\":{\"name\":\"mach-lsp\"}}}";
-    send_concat2(srv, prefix, id, result);
-    json.free_str(id, srv.alloc);
+    var b: json.Buf = json.buf_init(srv.alloc);
+    json.buf_push(?b, "{\"jsonrpc\":\"2.0\",\"id\":");
+    json.buf_push_id(?b, json.member(root, "id"));
+    json.buf_push(?b, ",\"result\":{\"capabilities\":{\"textDocumentSync\":1,\"hoverProvider\":true,\"definitionProvider\":true,\"referencesProvider\":true,\"renameProvider\":{\"prepareProvider\":true},\"documentSymbolProvider\":true,\"completionProvider\":{\"triggerCharacters\":[\".\"]}},\"serverInfo\":{\"name\":\"mach-lsp\"}}}");
+    send_buf(srv, ?b);
 
     srv.status = STATUS_RUNNING;
     trace.log("initialized\n");
 }
 
-# once the client signals it is ready, register file
-# watchers for the manifest, lockfile, and source trees so a dep-graph change
-# (pulling deps, editing a dep source) triggers `workspace/didChangeWatchedFiles`
-# and the affected project root is rebuilt. only sent when the client advertised
-# dynamic registration; clients without it fall back to the server's mtime check
+# once the client signals it is ready, register file watchers for the manifest,
+# lockfile, and source trees so a dep-graph change (pulling deps, editing a dep
+# source) triggers `workspace/didChangeWatchedFiles` and the affected project
+# root is rebuilt. only sent when the client advertised dynamic registration;
+# clients without it fall back to the server's fingerprint check
 fun handle_initialized(srv: *Server) {
     if (!srv.watch_dynamic) { ret; }
     val reg: str = "{\"jsonrpc\":\"2.0\",\"id\":\"mls/registerWatchers\",\"method\":\"client/registerCapability\",\"params\":{\"registrations\":[{\"id\":\"mls-watched-files\",\"method\":\"workspace/didChangeWatchedFiles\",\"registerOptions\":{\"watchers\":[{\"globPattern\":\"**/mach.toml\"},{\"globPattern\":\"**/mach.lock\"},{\"globPattern\":\"**/*.mach\"}]}}]}}";
@@ -285,51 +240,46 @@ fun handle_initialized(srv: *Server) {
 
 # accept dynamic watching only after the client acknowledges registration;
 # rejection keeps conservative fallback invalidation enabled
-fun handle_response(srv: *Server, body: str) {
+fun handle_response(srv: *Server, root: *sj.Value) {
     if (srv.watch_state != WATCH_PENDING) { ret; }
-    val id: str = json.extract_raw(body, "\"id\"", srv.alloc);
-    if (id == nil) { ret; }
-    val ours: bool = str_equals(id, "\"mls/registerWatchers\"");
-    json.free_str(id, srv.alloc);
-    if (!ours) { ret; }
-    val er: str = json.extract_raw(body, "\"error\"", srv.alloc);
-    if (er != nil) {
-        json.free_str(er, srv.alloc);
-        srv.watch_state = WATCH_FALLBACK;
-        ret;
-    }
+    if (!json.text_equals(json.member(root, "id"), "mls/registerWatchers", srv.alloc)) { ret; }
+    if (json.member(root, "error") != nil) { srv.watch_state = WATCH_FALLBACK; ret; }
     srv.watch_state = WATCH_ACTIVE;
 }
 
-fun handle_did_save(srv: *Server, body: str) {
-    val uri: str = json.extract_after(body, "\"textDocument\"", "\"uri\"", srv.alloc);
+# a save makes the buffer's disk state authoritative again for its root
+fun handle_did_save(srv: *Server, params: *sj.Value) {
+    val uri: str = json.text(json.member2(params, "textDocument", "uri"), srv.alloc);
     if (uri == nil) { ret; }
     project.invalidate_uri(?srv.ws, uri);
     json.free_str(uri, srv.alloc);
 }
 
-# invalidate every project root whose tree
-# contains a changed file, so the next request rebuilds it from disk. each
-# `uri` in the notification's `changes` array is invalidated in turn
-fun handle_did_change_watched_files(srv: *Server, body: str) {
-    var i: u32 = 0;
-    for (true) {
-        val uri: str = json.extract_string_seq(body, "\"uri\"", i, srv.alloc);
-        if (uri == nil) { brk; }
-        project.invalidate_uri(?srv.ws, uri);
-        json.free_str(uri, srv.alloc);
+# invalidate every project root whose tree contains a changed file, so the next
+# request rebuilds it from disk. each entry of the notification's `changes`
+# array is invalidated in turn
+fun handle_did_change_watched_files(srv: *Server, params: *sj.Value) {
+    val changes: *sj.Value = json.member(params, "changes");
+    val n: usize = json.count(changes);
+    var i: usize = 0;
+    for (i < n) {
+        val uri: str = json.text(json.member(json.element(changes, i), "uri"), srv.alloc);
+        if (uri != nil) {
+            project.invalidate_uri(?srv.ws, uri);
+            json.free_str(uri, srv.alloc);
+        }
         i = i + 1;
     }
 }
 
 # acknowledge a shutdown request and enter the shutting-down phase
-fun handle_shutdown(srv: *Server, body: str) {
-    val id: str = json.extract_raw(body, "\"id\"", srv.alloc);
-    if (id != nil) {
-        val prefix: str = "{\"jsonrpc\":\"2.0\",\"id\":";
-        val result: str = ",\"result\":null}";
-        send_concat2(srv, prefix, id, result);
-        json.free_str(id, srv.alloc);
+fun handle_shutdown(srv: *Server, root: *sj.Value) {
+    if (json.member(root, "id") != nil) {
+        var b: json.Buf = json.buf_init(srv.alloc);
+        json.buf_push(?b, "{\"jsonrpc\":\"2.0\",\"id\":");
+        json.buf_push_id(?b, json.member(root, "id"));
+        json.buf_push(?b, ",\"result\":null}");
+        send_buf(srv, ?b);
     }
     srv.status = STATUS_SHUTTING_DOWN;
 }
@@ -342,51 +292,39 @@ fun handle_exit(srv: *Server) {
 }
 
 # register the opened document and publish its diagnostics
-fun handle_did_open(srv: *Server, body: str) {
-    val uri: str = json.extract_after(body, "\"textDocument\"", "\"uri\"", srv.alloc);
+fun handle_did_open(srv: *Server, params: *sj.Value) {
+    val doc: *sj.Value = json.member(params, "textDocument");
+    val uri: str = json.text(json.member(doc, "uri"), srv.alloc);
     if (uri == nil) { ret; }
-    val text: str = json.extract_after(body, "\"textDocument\"", "\"text\"", srv.alloc);
+    val text: str = json.text(json.member(doc, "text"), srv.alloc);
     if (text == nil) { json.free_str(uri, srv.alloc); ret; }
-
-    var version: i64 = 0;
-    if (!document_version(srv, body, ?version)) { json.free_str(text, srv.alloc); json.free_str(uri, srv.alloc); ret; }
-    publish_for(srv, uri, text, version, true);
-
+    val version_v: *sj.Value = json.member(doc, "version");
+    if (version_v != nil) { publish_for(srv, uri, text, json.number(version_v, 0), true); }
     json.free_str(text, srv.alloc);
     json.free_str(uri, srv.alloc);
 }
 
-# apply the document's new full text and republish diagnostics.
-# only full-document sync (textDocumentSync = 1) is advertised, so the change is
-# the entire new text
-fun handle_did_change(srv: *Server, body: str) {
-    val uri: str = json.extract_after(body, "\"textDocument\"", "\"uri\"", srv.alloc);
+# apply the document's new full text and republish diagnostics. only
+# full-document sync (textDocumentSync = 1) is advertised, so the last change
+# entry carries the entire new text
+fun handle_did_change(srv: *Server, params: *sj.Value) {
+    val doc: *sj.Value = json.member(params, "textDocument");
+    val uri: str = json.text(json.member(doc, "uri"), srv.alloc);
     if (uri == nil) { ret; }
-    val text: str = json.extract_after(body, "\"contentChanges\"", "\"text\"", srv.alloc);
+    val changes: *sj.Value = json.member(params, "contentChanges");
+    val n: usize = json.count(changes);
+    if (n == 0) { json.free_str(uri, srv.alloc); ret; }
+    val text: str = json.text(json.member(json.element(changes, n - 1), "text"), srv.alloc);
     if (text == nil) { json.free_str(uri, srv.alloc); ret; }
-
-    var version: i64 = 0;
-    if (!document_version(srv, body, ?version)) { json.free_str(text, srv.alloc); json.free_str(uri, srv.alloc); ret; }
-    publish_for(srv, uri, text, version, false);
-
+    val version_v: *sj.Value = json.member(doc, "version");
+    if (version_v != nil) { publish_for(srv, uri, text, json.number(version_v, 0), false); }
     json.free_str(text, srv.alloc);
     json.free_str(uri, srv.alloc);
 }
 
-# read the required TextDocumentItem/VersionedTextDocumentIdentifier version,
-# distinguishing a missing field from the valid numeric value zero
-fun document_version(srv: *Server, body: str, out: *i64) bool {
-    val raw: str = json.extract_raw(body, "\"version\"", srv.alloc);
-    if (raw == nil) { ret false; }
-    json.free_str(raw, srv.alloc);
-    @out = json.extract_number_after(body, "\"textDocument\"", "\"version\"", srv.alloc);
-    ret true;
-}
-
-# retire the document, reclaim its cached resolve result, and
-# clear its diagnostics
-fun handle_did_close(srv: *Server, body: str) {
-    val uri: str = json.extract_after(body, "\"textDocument\"", "\"uri\"", srv.alloc);
+# retire the document, reclaim its cached analysis, and clear its diagnostics
+fun handle_did_close(srv: *Server, params: *sj.Value) {
+    val uri: str = json.text(json.member2(params, "textDocument", "uri"), srv.alloc);
     if (uri == nil) { ret; }
     val doc: *documents.Document = documents.closing(?srv.docs, uri);
     if (doc != nil) { project.document_closed(?srv.ws, doc); }
@@ -396,27 +334,27 @@ fun handle_did_close(srv: *Server, body: str) {
     json.free_str(uri, srv.alloc);
 }
 
-# route a language-feature request to its handler in `language`.
-# the document uri is extracted once here and passed through; the feature code
-# resolves the buffer, pivots the cursor, and replies. `which` selects the
-# feature: 0 hover, 1 definition, 2 references, 3 rename, 4 prepareRename,
-# 5 documentSymbol, 6 completion. an unknown / unopened uri still gets a
-# null / empty reply from the feature so the client is never left waiting
-fun handle_feature(srv: *Server, body: str, which: i64) {
-    val uri: str = json.extract_after(body, "\"textDocument\"", "\"uri\"", srv.alloc);
+# route a language-feature request to its handler in `language`
+#
+# the document uri is read once here and passed through; the feature code
+# resolves the buffer, pivots the cursor, and replies. an unknown or unopened
+# uri still gets a null / empty reply, so the client is never left waiting
+fun handle_feature(srv: *Server, root: *sj.Value, params: *sj.Value, which: u8) {
+    val uri: str = json.text(json.member2(params, "textDocument", "uri"), srv.alloc);
+    val id: *sj.Value = json.member(root, "id");
 
     # snapshot compiler epochs so a feature-triggered rebuild republishes the
     # now-current diagnostics for every affected open document
     val epoch_before: u32 = project.load_epoch(?srv.ws);
     val sema_before:  u32 = project.sema_epoch(?srv.ws);
 
-    if (which == 0) { language.hover(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, body, uri); }
-    or (which == 1) { language.definition(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, body, uri); }
-    or (which == 2) { language.references(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, body, uri); }
-    or (which == 3) { language.rename(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, body, uri); }
-    or (which == 4) { language.prepare_rename(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, body, uri); }
-    or (which == 5) { language.document_symbol(?srv.es, srv.alloc, ?srv.docs, body, uri); }
-    or (which == 6) { language.completion(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, body, uri); }
+    if (which == FEATURE_HOVER)           { language.hover(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, id, params, uri); }
+    or (which == FEATURE_DEFINITION)      { language.definition(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, id, params, uri); }
+    or (which == FEATURE_REFERENCES)      { language.references(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, id, params, uri); }
+    or (which == FEATURE_RENAME)          { language.rename(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, id, params, uri); }
+    or (which == FEATURE_PREPARE_RENAME)  { language.prepare_rename(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, id, params, uri); }
+    or (which == FEATURE_DOCUMENT_SYMBOL) { language.document_symbol(?srv.es, srv.alloc, ?srv.docs, id, params, uri); }
+    or (which == FEATURE_COMPLETION)      { language.completion(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, id, params, uri); }
 
     if (uri != nil) { json.free_str(uri, srv.alloc); }
 
@@ -469,63 +407,43 @@ fun publish_for(srv: *Server, uri: str, text: str, version: i64, is_open: bool) 
     republish_loaded(srv);
 }
 
-# send a JSON-RPC error response for a request that carries an id;
-# a no-op for a notification (no id)
-fun reply_error(srv: *Server, body: str, code: i64, message: str) {
-    val id: str = json.extract_raw(body, "\"id\"", srv.alloc);
+# send a JSON-RPC error response for a request that carries an id
+#
+# a notification owes no response, so one without an id is dropped.
+fun reply_error(srv: *Server, root: *sj.Value, code: i64, message: str) {
+    val id: *sj.Value = json.member(root, "id");
     if (id == nil) { ret; }
-
-    val code_str: str = json.format_i64(code, srv.alloc);
-    val qmsg: str = json.quote(message, srv.alloc);
-    val p1: str = "{\"jsonrpc\":\"2.0\",\"id\":";
-    val p2: str = ",\"error\":{\"code\":";
-    val p3: str = ",\"message\":";
-    val p4: str = "}}";
-
-    send_concat(srv, p1, id, p2, code_str, p3, qmsg, p4);
-
-    json.free_str(qmsg, srv.alloc);
-    json.free_str(code_str, srv.alloc);
-    json.free_str(id, srv.alloc);
+    send_error(srv, id, code, message);
 }
 
-# frame and send `a + b + c`
-fun send_concat2(srv: *Server, a: str, b: str, c: str) {
-    send_concat(srv, a, b, c, nil, nil, nil, nil);
+# a parse error names no id: the body never became a tree, so there is nothing
+# to echo. the spec answers this with a null id
+fun reply_parse_error(srv: *Server) {
+    trace.log("server: message body is not valid JSON\n");
+    send_error(srv, nil, -32700, "parse error");
 }
 
-# frame and send the concatenation of up to seven fragments,
-# skipping nil fragments
-fun send_concat(srv: *Server, a: str, b: str, c: str, d: str, e: str, f: str, g: str) {
-    val total: usize = flen(a) + flen(b) + flen(c) + flen(d) + flen(e) + flen(f) + flen(g);
-    val r: Result[*u8, str] = allocate[u8](srv.alloc, total + 1);
-    if (is_err[*u8, str](r)) { ret; }
-    val buf: *u8 = unwrap_ok[*u8, str](r);
-
-    var off: usize = 0;
-    off = fappend(buf, off, a);
-    off = fappend(buf, off, b);
-    off = fappend(buf, off, c);
-    off = fappend(buf, off, d);
-    off = fappend(buf, off, e);
-    off = fappend(buf, off, f);
-    off = fappend(buf, off, g);
-    buf[off] = 0;
-
-    transport.send_message(buf::str, srv.alloc);
-    deallocate[u8](srv.alloc, buf, total + 1);
+# a tree that is not a usable JSON-RPC envelope
+fun reply_invalid_request(srv: *Server, root: *sj.Value) {
+    send_error(srv, json.member(root, "id"), -32600, "invalid request");
 }
 
-# length of `s`, treating nil as 0
-fun flen(s: str) usize {
-    if (s == nil) { ret 0; }
-    ret str_len(s);
+# frame and send one JSON-RPC error object
+fun send_error(srv: *Server, id: *sj.Value, code: i64, message: str) {
+    var b: json.Buf = json.buf_init(srv.alloc);
+    json.buf_push(?b, "{\"jsonrpc\":\"2.0\",\"id\":");
+    json.buf_push_id(?b, id);
+    json.buf_push(?b, ",\"error\":{\"code\":");
+    json.buf_push_i64(?b, code);
+    json.buf_push(?b, ",\"message\":");
+    json.buf_push_quoted(?b, message);
+    json.buf_push(?b, "}}");
+    send_buf(srv, ?b);
 }
 
-# copy `s` into `buf` at `offset`, returning the new offset
-fun fappend(buf: *u8, offset: usize, s: str) usize {
-    if (s == nil) { ret offset; }
-    val n: usize = str_len(s);
-    if (n > 0) { mem.raw_copy((buf::usize + offset)::ptr, s::ptr, n); }
-    ret offset + n;
+# frame and send a buffer's contents, then release it
+fun send_buf(srv: *Server, b: *json.Buf) {
+    val msg: str = json.buf_str(b);
+    if (msg != nil) { transport.send_message(msg, srv.alloc); }
+    json.buf_dnit(b);
 }

--- a/src/server.mach
+++ b/src/server.mach
@@ -35,6 +35,7 @@ use json:        mls.json;
 use sj:          std.data.json;
 use jobs:        mls.jobs;
 use atomic:      std.sync.atomic;
+use exec:        std.process.exec;
 use documents:   mls.documents;
 use diagnostics: mls.diagnostics;
 use language:    mls.language;
@@ -337,6 +338,17 @@ fun handle_exit(srv: *Server) {
     if (srv.status == STATUS_SHUTTING_DOWN) { srv.exit_code = 0; }
     or { srv.exit_code = 1; }
     srv.status = STATUS_EXITED;
+    atomic.store(?srv.stop, 1);
+
+    # `exit` means terminate, and the client is entitled to keep its end of the
+    # pipe open while it waits for that. The reading thread is parked in
+    # `read(2)` on stdin and nothing this thread can do reliably wakes it -
+    # closing the descriptor under a blocked reader does not - so the orderly
+    # return through `run` is not reachable here. Ending the process is what the
+    # notification asked for; responses are written unbuffered, so nothing that
+    # was owed to the client is still pending.
+    trace.log("=== mach-lsp exiting ===\n");
+    exec.exit(srv.exit_code);
 }
 
 # register the opened document and publish its diagnostics

--- a/src/server.mach
+++ b/src/server.mach
@@ -330,7 +330,7 @@ fun handle_did_close(srv: *Server, params: *sj.Value) {
     if (doc != nil) { project.document_closed(?srv.ws, doc); }
     documents.close(?srv.docs, uri);
     diagnostics.clear(srv.alloc, uri);
-    republish_loaded(srv);
+    republish_all(srv);
     json.free_str(uri, srv.alloc);
 }
 
@@ -358,19 +358,39 @@ fun handle_feature(srv: *Server, root: *sj.Value, params: *sj.Value, which: u8) 
 
     if (uri != nil) { json.free_str(uri, srv.alloc); }
 
-    if (project.load_epoch(?srv.ws) != epoch_before || project.sema_epoch(?srv.ws) != sema_before) { republish_loaded(srv); }
+    if (project.load_epoch(?srv.ws) != epoch_before || project.sema_epoch(?srv.ws) != sema_before) { republish_all(srv); }
 }
 
-# re-publish diagnostics for every open document now governed
-# by a loaded project root. run after a feature request triggers a lazy load (#96)
-# or the first whole-closure sema (#113): the buffers under the freshly-loaded root
-# were published parse-only on open, so a load upgrades them to dep-aware
-# resolution diagnostics - including any out-of-closure import the load now flags -
-# and a completed sema further layers their type diagnostics, all without the user
-# touching the file. the publish path is load-free, so a buffer under no loaded
-# root simply re-publishes its parse-only diagnostics (unchanged), and nothing new
-# is built
-fun republish_loaded(srv: *Server) {
+# re-publish diagnostics for every open document the given root governs
+#
+# A rebuild can move diagnostics for any document mirrored into that root's
+# session - an unsaved export change in one module introduces or clears errors
+# in the modules importing it - so the whole root is republished, not just the
+# document that changed. Documents under OTHER roots are untouched: their
+# snapshots did not move, and republishing them would emit one notification per
+# open buffer per keystroke.
+#
+# A nil root is the standalone case, where `only` is the whole set.
+fun republish_root(srv: *Server, root: *project.Root, only: *documents.Document) {
+    val n: usize = documents.slot_count(?srv.docs);
+    var i: usize = 0;
+    for (i < n) {
+        val d: *documents.Document = documents.at(?srv.docs, i);
+        if (d != nil && d.in_use && d.uri != nil) {
+            if (root == nil) {
+                if (d == only) { diagnostics.publish(?srv.ws, ?srv.es, srv.alloc, d); }
+            }
+            or (project.root_covers_document(?srv.ws, root, d)) {
+                diagnostics.publish(?srv.ws, ?srv.es, srv.alloc, d);
+            }
+        }
+        i = i + 1;
+    }
+}
+
+# re-publish every open document, for the events that can move any root at once
+# (a watched-file change, a close that returns a buffer to disk authority)
+fun republish_all(srv: *Server) {
     val n: usize = documents.slot_count(?srv.docs);
     var i: usize = 0;
     for (i < n) {
@@ -404,7 +424,7 @@ fun publish_for(srv: *Server, uri: str, text: str, version: i64, is_open: bool) 
         trace.log("project: failed to mirror document overlay\n");
         ret;
     }
-    republish_loaded(srv);
+    republish_root(srv, project.root_for(?srv.ws, doc.uri), doc);
 }
 
 # send a JSON-RPC error response for a request that carries an id

--- a/src/trace.mach
+++ b/src/trace.mach
@@ -17,9 +17,14 @@ use std.types.size.usize;
 use std.types.bool.bool;
 use std.types.bool.true;
 use std.types.bool.false;
+use std.types.result.Result;
+use std.types.result.ok;
 
-use os:  std.system.os;
-use env: std.process.env;
+use os:     std.system.os;
+use env:    std.process.env;
+use chrono: std.chrono.time;
+use fmtstr: std.format;
+use writer: std.io.writer;
 
 # fixed file the trace log is appended to
 val LOG_PATH: str = "/tmp/mach-lsp.log";
@@ -74,4 +79,42 @@ pub fun log(msg: str) {
     if (len == 0) { ret; }
 
     os.write(LOG_FD::i32, msg::*u8, len);
+}
+
+# whether tracing is on, so a caller can skip building a message it would drop
+# ---
+# ret: true when MLS_TRACE is set and the log is open
+pub fun enabled() bool {
+    if (!LOG_CHECKED) {
+        LOG_CHECKED = true;
+        LOG_ENABLED = trace_enabled();
+        if (LOG_ENABLED) { LOG_FD = trace_open(); }
+    }
+    ret LOG_ENABLED && LOG_FD >= 0;
+}
+
+# monotonic nanoseconds, for span timing
+# ---
+# ret: the monotonic clock reading in nanoseconds
+pub fun now_ns() i64 {
+    ret chrono.time_unix_nsec(chrono.monotonic());
+}
+
+# writer sink appending straight to the open trace descriptor
+fun trace_sink(ctx: ptr, p: *u8, len: usize) Result[usize, str] {
+    os.write(LOG_FD::i32, p, len);
+    ret ok[usize, str](len);
+}
+
+# append one formatted line to the trace log; a no-op when tracing is off
+# ---
+# fmt: std.format hole syntax
+# va:  comptime variadic argument pack
+pub fun logf(fmt: str, va: ...) {
+    if (!enabled()) { ret; }
+    var w: writer.Writer;
+    w.ctx = nil;
+    w.f_write = trace_sink;
+    fmtstr.vformat(?w, fmt, va...);
+    os.write(LOG_FD::i32, "\n"::*u8, 1);
 }

--- a/test/lsp_protocol.py
+++ b/test/lsp_protocol.py
@@ -172,6 +172,35 @@ class LspSession:
             f"diagnostics for {uri}",
         )
 
+    def quiet_diagnostics(self, settle: float = 0.4) -> list[dict[str, Any]]:
+        """Return any diagnostics published since the last wait.
+
+        Diagnostics belong to document state, so a feature request must not
+        produce one. Anything a request republished is already in `pending`
+        (the request's own reply drained the inbox past it); `settle` also
+        catches a publish still in flight behind that reply.
+        """
+        found = [m for m in self.pending
+                 if m.get("method") == "textDocument/publishDiagnostics"]
+        self.pending = [m for m in self.pending
+                        if m.get("method") != "textDocument/publishDiagnostics"]
+        deadline = time.monotonic() + settle
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return found
+            try:
+                item = self.inbox.get(timeout=remaining)
+            except queue.Empty:
+                return found
+            if item is None or isinstance(item, BaseException):
+                return found
+            self.message_count += 1
+            if item.get("method") == "textDocument/publishDiagnostics":
+                found.append(item)
+            else:
+                self.pending.append(item)
+
     def finish(self, send_exit: bool = True) -> tuple[int, float, int]:
         """Perform shutdown/exit and return process telemetry."""
         response = self.request("shutdown")
@@ -595,12 +624,19 @@ def run_smoke(server: Path, timeout: float) -> tuple[tuple[int, float, int], lis
                 {"textDocument": {"uri": alpha_main.as_uri(), "version": 2},
                  "contentChanges": [{"text": main_v2}]},
             )
-            session.diagnostics(alpha_main.as_uri(), 2)
+            # the change itself publishes every open document of the affected
+            # root at its own version: diagnostics follow document state, and
+            # the analysis they need is driven here rather than by whichever
+            # feature request happens to come next
+            assert_diagnostics(session.diagnostics(alpha_main.as_uri(), 2), False, 2)
+            assert_diagnostics(session.diagnostics(alpha_def.as_uri(), 2), False, 2)
+            session.quiet_diagnostics()
             live_result = definition(session, alpha_main, main_v2, "live")
             require(live_result.get("uri") == alpha_def.as_uri(),
                     f"unsaved imported export did not resolve: {live_result!r}")
-            assert_diagnostics(session.diagnostics(alpha_main.as_uri(), 2), False, 2)
-            assert_diagnostics(session.diagnostics(alpha_def.as_uri(), 2), False, 2)
+            republished = session.quiet_diagnostics()
+            require(not republished,
+                    f"a feature request republished diagnostics: {republished!r}")
 
             broken_text = main_v2 + "\nuse alpha.missing.nope;\n"
             session.notify(
@@ -639,9 +675,8 @@ def run_smoke(server: Path, timeout: float) -> tuple[tuple[int, float, int], lis
                 {"textDocument": {"uri": alpha_main.as_uri(), "version": 5},
                  "contentChanges": [{"text": alpha_text}]},
             )
-            session.diagnostics(alpha_main.as_uri(), 5)
-            assert_definition(session, alpha_main, alpha_def, alpha_text)
             assert_diagnostics(session.diagnostics(alpha_main.as_uri(), 5), False, 5)
+            assert_definition(session, alpha_main, alpha_def, alpha_text)
 
             # A dependency opened before its ancestor graph is loaded must still
             # enter that graph through a filesystem overlay. Current `[dep.*]`

--- a/test/lsp_protocol.py
+++ b/test/lsp_protocol.py
@@ -881,6 +881,52 @@ def run_bad_frame(server: Path, frame: bytes, timeout: float, label: str) -> Non
     require(result.stdout == b"", f"{label}: server emitted a partial response")
 
 
+def run_exit_paths(server: Path, timeout: float) -> None:
+    """Every lifecycle ending must terminate, with the documented code.
+
+    `exit` means terminate, and a client may hold its end of the pipe open while
+    it waits. With analysis on a worker the reading thread is parked in read(2),
+    so an `exit` that only set a flag would leave the process alive until the
+    client happened to close stdin.
+    """
+    cases = (
+        (("shutdown", "exit"), False, 0),
+        (("shutdown", "exit"), True, 0),
+        (("exit",), False, 1),
+        (("shutdown",), True, 0),
+        ((), True, 1),
+    )
+    for steps, close_stdin, expected in cases:
+        with tempfile.TemporaryDirectory(prefix="mls-exit-") as directory:
+            root = Path(directory).resolve()
+            session = LspSession(server, root, timeout)
+            try:
+                session.request("initialize", {"rootUri": root.as_uri(), "capabilities": {}})
+                session.notify("initialized", {})
+                if "shutdown" in steps:
+                    response = session.request("shutdown")
+                    require(response.get("result", object()) is None,
+                            f"invalid shutdown response: {response!r}")
+                if "exit" in steps:
+                    session.notify("exit")
+                if close_stdin:
+                    session.proc.stdin.close()
+                try:
+                    code = session.proc.wait(timeout=timeout)
+                except subprocess.TimeoutExpired as error:
+                    session.proc.kill()
+                    session.proc.wait()
+                    raise ProtocolError(
+                        f"server did not terminate for {steps!r} "
+                        f"(stdin closed: {close_stdin})") from error
+                require(code == expected,
+                        f"{steps!r} (stdin closed: {close_stdin}) exited {code}, want {expected}")
+            finally:
+                if session.proc.poll() is None:
+                    session.proc.kill()
+                    session.proc.wait()
+
+
 def run_clean_eof(server: Path, timeout: float) -> None:
     """A clean EOF after shutdown is not a malformed-frame failure."""
     with tempfile.TemporaryDirectory(prefix="mls-protocol-eof-") as directory:
@@ -957,6 +1003,7 @@ def main() -> int:
         run_active_watcher_fallback(server, args.timeout)
         run_same_fqn_reverse(server, args.timeout)
         run_clean_eof(server, args.timeout)
+        run_exit_paths(server, args.timeout)
         run_transport_regressions(server, args.timeout)
         closed_stdout_status = probe_closed_stdout(server, args.timeout, True)
         suppressed_status = probe_closed_stdout(server, args.timeout, False)
@@ -967,6 +1014,7 @@ def main() -> int:
         return 1
     print(f"protocol smoke: PASS ({message_count} messages, exit {exit_code}, {elapsed:.3f}s)")
     print("  clean EOF after shutdown: exit 0")
+    print("  all five lifecycle endings terminate with the documented code")
     print("  malformed/oversized frames: 8 rejected with exit 1")
     print("  closed stdout reader with inherited SIG_IGN: exit 1")
     print("  closed stdout reader: exit 1")


### PR DESCRIPTION
Closes #95. Closes #142. Refs #143, #153, #155, #140.

Six commits, each independently verified. The first is the one that matters most.

## Where the time went

The audit in #140 recorded a 5.6 s first definition request. Measured on this repository (222 modules, the whole compiler in the closure) it was **231 s**, and a second identical request cost **222 s** — no caching benefit at all.

Instrumenting the load path put 225 s of that inside `build_mod_paths`, against 7.4 s for the compiler's own analysis. `file_fingerprint` read and FNV-hashed every module's full source on every snapshot build and every 250 ms scan, and its hash loop called `str_len(text)` as the loop *condition* — `str_len` is a byte scan, so the hash was quadratic in file size.

A probe driving `driver.analyze_project` directly confirmed the compiler was never the problem: cold 7.5 s, warm 155 ms, over the same 222 modules. The retained-session incrementality #141 built on works exactly as documented.

Fingerprints are now stat-only. `(mtime, size)` decides the common case without opening a file, and no content hash is kept: a touch that changes no bytes costs one warm re-analysis, where `Q_FILE_TEXT`'s byte-equality cutoff keeps every module's parse, resolve, and sema entry valid. The compiler already owns content-change detection, so the LSP stopped duplicating it.

| `textDocument/definition` | before | after |
|---|---|---|
| cold | 231 s | 7.4 s |
| warm | 222 s | 0.2 ms |
| after an edit | — | 181 ms |

## Diagnostics stopped depending on what you clicked

`publish` read the snapshot through `document_view_loaded`, which never loads. A document opened with parse-only diagnostics; resolve and sema results appeared only once some unrelated feature request happened to build the project, and vanished again when it was invalidated.

On a two-module project with one deliberate `val x: i64 = "wrong";`:

```
mach build   1 error: type mismatch: expected i64, found *u8
LSP didOpen  0 diagnostics
LSP hover    the same 1 error, with its note
```

Diagnostics now drive the pipeline. Both probes report the same single error, with its note, at `didOpen`; a later hover republishes nothing. Republishing is also scoped to the root that changed — it used to walk every open document in every project on every keystroke.

The protocol suite encoded the old behavior in two places, waiting for a feature request to republish something it had already published. Those became the assertion this change is about.

## Reading JSON instead of scanning for it

Requests were read by scanning the raw body for a quoted key. `find_key` matched that key **anywhere** in the document — and the body it scanned is a `didOpen` payload carrying an opened file's entire source text. Correct dispatch depended on clients ordering `method` before `params`, which JSON does not guarantee; this repository's own sources contain the literal `"method"`.

Messages are now parsed once into a real `std.data.json` tree. The std parser has no free entry and its strings borrow the body, so parsing goes into a per-message arena that resets after handling — which also retired the per-field owned-string bookkeeping. Request ids keep their wire type, malformed bodies get a spec `-32700`, notifications are no longer answered, and escaping is the std emitter's rather than one that replaced control bytes with `?`.

## Analysis off the reading loop

`run` completed all work for one message before reading the next, so a cold analysis stopped the server from seeing anything behind it. Worse, the client could not finish *writing*: a `didChange` carries the whole document, so a few fill the 64 KiB pipe and the editor blocks in `write`. That is the stall an editor reads as a dead server — the restart loop #86 described.

The reading thread now owns stdin and nothing else; one worker owns everything the compiler touches. Exactly one thread reaches compiler state, so none of it needs locking — `mls.jobs`, a bounded futex-blocking queue, is the only shared structure. Only the worker writes, so responses need no output lock.

Then coalescing: a change records text, revision, and overlay, but defers the analysis while newer input is queued, and the debt is paid when the queue drains. Deferring is never dropping — verified on a burst whose *last* edit introduces an error and which ends with a syntax-only `documentSymbol`: exactly one version is published, the final one, carrying the error.

Flooding the server with 60 edits during a cold load:

| | before | after |
|---|---|---|
| 60 change+request pairs written | 18.62 s | 0.00 s |
| worst single client write | 7486 ms | 0.1 ms |
| time to answer all 60 | 19.0 s | 0.9 s |

This exposed a lifecycle regression the suite could not see because it always closed stdin first: with the reader parked in `read(2)`, `exit` no longer terminated the process. `run_exit_paths` now covers all five endings.

## Verification

- 59 unit tests (was 49; `mls.json` and `mls.jobs` replace the removed scanner tests)
- full protocol suite, repeated for stability, plus the new lifecycle coverage
- measurements above reproduced on release builds of this repository

## Not fixed here

Memory grows **~7.4 MiB per analysis, without bound**, whether or not any source changed. It reproduces with a bare `analyze_project` / `dnit_project` loop and no LSP code involved (1 round 229 MiB, 25 rounds 406 MiB), so it is upstream: **briar-systems/mach#3001**. A consumer cannot work around it except by discarding the whole `Session`, which throws away exactly the incremental state that makes the retained path worth using.

Still open from #143: `$/cancelRequest` (#153), stale-output fencing by revision (#155), and hung-worker reclamation (#156). All three needed the worker boundary to exist first; it now does.
