### PR TITLE
chore(release): bump version to 0.11.0 and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,59 +7,59 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-08-20
+
+The server was unusably slow on any project that vendors the compiler, reported
+diagnostics that depended on what the user had clicked, and blocked the client
+mid-write while it worked. This release is those three, plus the architecture
+they needed.
+
 ### Fixed
 - perf: source fingerprints are stat-only. `file_fingerprint` read and FNV-hashed
   every module's full source on every snapshot build and every 250 ms scan, and
   its hash loop re-evaluated `str_len` as the loop condition, making the hash
   quadratic in file size. On this repository (222 modules) that put 225 s of the
-  server's own bookkeeping in front of a 7.4 s compiler analysis and repeated it
-  on every request. `textDocument/definition` cold 231 s → 7.4 s, warm 222 s →
-  0.6 ms, after an edit → 181 ms. (#95)
+  server's own bookkeeping in front of a 7.4 s compiler analysis, and repeated all
+  of it on every later request. `textDocument/definition` cold 231 s → 7.4 s, warm
+  222 s → 0.2 ms, after an edit → 181 ms. (#95)
 - diagnostics: publishing drives the analysis instead of reporting whichever
   snapshot a previous request left behind. A file with a type error opened clean
-  and only started reporting once an unrelated feature request built the project.
-  Editor output now matches `mach build` from `didOpen`, and a hover no longer
-  changes it. Republishing is scoped to the root that changed. (#142)
+  and only started reporting once an unrelated feature request built the project,
+  then went quiet again when that snapshot was invalidated. Editor output now
+  matches `mach build` from `didOpen`, and a hover no longer changes it.
+  Republishing is scoped to the root that changed, rather than every open buffer
+  in every open project. (#142)
 - server: `exit` terminates the process even when the client leaves stdin open,
   which the spec entitles it to do.
+- transport: distinguishes clean EOF from malformed/error input, caps LSP
+  headers at 8 KiB and bodies at 16 MiB with overflow-safe `Content-Length`
+  parsing, and surfaces response-write failures to the server loop. (#149)
+- json / transport: the decimal formatters wrote `('0' + (v % 10))::u8`, mixing
+  a `u8` char literal into `usize` / `i64` arithmetic. Sema types that
+  expression at the wider operand and lowering typed it at the literal's own
+  width, so mach 4.18 refuses it in its IR verifier - the compiler's own defect
+  (mach#2949), but the source was relying on the two passes disagreeing. The
+  width the arithmetic happens at is now stated: `'0'::usize` / `'0'::i64`.
+- hover: a seeded vector type name (`res.SYM_VECTOR`) rendered as `symbol`
+  rather than `type`; `kind_label` enumerated symbol kinds 0..11 and fell
+  through on 12.
 
 ### Added
 - server: analysis runs on a worker thread. The reading thread owns stdin and
-  nothing else, so a cold analysis no longer blocks the client mid-write —
-  flooding the server with 60 edits during a cold load went from 18.6 s of
-  blocked writes (worst single write 7.5 s) to 0.00 s. Document revisions
-  superseded by queued input are coalesced, so the same burst costs one analysis
-  instead of 60: 19.0 s → 0.9 s. (#143, #155)
+  nothing else, so a cold analysis no longer stops the server from seeing the
+  cancellation, edit, or shutdown behind it - and no longer blocks the client
+  mid-write when a `didChange` fills the pipe, which is the stall an editor reads
+  as a dead server. Flooding the server with 60 edits during a cold load went from
+  18.6 s of blocked writes (worst single write 7.5 s) to 0.00 s. (#143)
+- server: document revisions superseded by queued input are coalesced, so a burst
+  of keystrokes costs one analysis of the newest text rather than one per
+  revision. Deferring is never dropping: the debt is paid when the queue drains,
+  whatever the last message was. The same 60-edit burst: 19.0 s → 0.9 s. (#155)
 - jobs: bounded single-consumer message queue, futex-blocking so an idle server
-  costs no CPU.
+  costs no CPU. The bound is memory as much as latency, since the queued bodies
+  are whole documents.
 
 ### Changed
-- deps: **advanced the vendored mach pin to `v4.20.0`** and mach-std to `v0.27.0`,
-  and returned `[dep.mach]` to `branch/main`. Tracking `branch/dev` was a temporary
-  measure while the retained-analysis frontend API (mach#2997) was unreleased; the
-  release convention is `branch/main`. No frontend API drift.
-- project: parsed `mach.toml` tables are torn down. Both reads - the vendoring
-  probe and the document-overlay source-directory lookup - run on the snapshot
-  rebuild path and leaked their whole table on every rebuild, because
-  `std.data.toml` had no teardown to call. mach-std#474 adds one; `get_str` and
-  `table_key` borrow out of the table, so it is released at scope exit rather than
-  at the last read. Per-edit growth halved, ~8 MiB to ~4.2 MiB. (#159)
-- json: JSON-RPC messages are parsed with `std.data.json` instead of scanning the
-  raw body for a quoted key. The scanner matched a key ANYWHERE in the document,
-  including inside an opened file's own source text, and correct dispatch relied
-  on clients ordering `method` before `params`. Request ids now keep their wire
-  type, malformed bodies get a spec parse error, and string escaping is the std
-  emitter's. Messages parse into a per-message arena. (#153)
-
-### Known issues
-- memory still grows ~4.2 MiB per analysis, without bound. briar-systems/mach#3001
-  fixed the manifest-reload half (the LSP reloads the manifest on every rebuild);
-  the residue is in `analyze_project` / `dnit_project` itself and still reproduces
-  with no LSP code involved. Tracked upstream as briar-systems/mach#3012. The LSP
-  side is clean: the server adds no measurable growth over the bare compiler
-  cycle. (#159)
-
-### Changed (#141, earlier in this cycle)
 - project: replaced the shared-session, manually re-resolved graph with one
   stable compiler Session and retained `analyze_project` snapshot per root.
   Open document text is mirrored as filesystem overlays with explicit input and
@@ -70,15 +70,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - documents: now own URI, canonical path, live text, LSP version, and a monotonic
   mutation revision independently of the editor fallback. Published diagnostics
   carry the matching document version.
-- deps: **advanced the vendored mach pin `v4.7.1` → `v4.18.0`** and mach-std
-  `0.22.0` → `0.26.0`. The server analyzes buffers with the vendored compiler
-  frontend, so the pin *is* the language version the editor understands: frozen
-  at 4.7.1 it reported everything added since - `#[packed]`, a declaration-scope
-  `$if` measuring a layout, `$size_of` / `$align_of` / `$length_of` folding in a
-  comptime gate, the `#[handle]` / `#[op]` target-owned type and operation
-  declarations, riscv32 and the `ilp32` ABI family - as an error against source
-  the installed compiler accepts.
-- deps: repairs the one frontend API drift the advance surfaces. `comptime.init`
+- json: JSON-RPC messages are parsed with `std.data.json` instead of scanning the
+  raw body for a quoted key. The scanner matched a key ANYWHERE in the document,
+  including inside an opened file's own source text - which is exactly what a
+  `didOpen` payload carries - and correct dispatch relied on clients ordering
+  `method` before `params`, which JSON does not guarantee. Request ids now keep
+  their wire type, malformed bodies get a spec parse error, notifications are no
+  longer answered, and string escaping is the std emitter's. Messages parse into
+  a per-message arena. (#153)
+- project: parsed `mach.toml` tables are torn down. Both reads - the vendoring
+  probe and the document-overlay source-directory lookup - run on the snapshot
+  rebuild path and leaked their whole table on every rebuild, because
+  `std.data.toml` had no teardown to call. mach-std#474 adds one; `get_str` and
+  `table_key` borrow out of the table, so it is released at scope exit rather
+  than at the last read. (#159)
+- deps: **advanced the vendored mach pin `v4.7.1` → `v4.20.0`** and mach-std
+  `0.22.0` → `0.27.0`, and returned `[dep.mach]` to `branch/main`. The server
+  analyzes buffers with the vendored compiler frontend, so the pin *is* the
+  language version the editor understands: frozen at 4.7.1 it reported everything
+  added since - `#[packed]`, a declaration-scope `$if` measuring a layout,
+  `$size_of` / `$align_of` / `$length_of` folding in a comptime gate, the
+  `#[handle]` / `#[op]` target-owned type and operation declarations, riscv32 and
+  the `ilp32` ABI family - as an error against source the installed compiler
+  accepts. Tracking `branch/dev` was a temporary measure while the
+  retained-analysis frontend API (mach#2997) was unreleased. (#141, #159)
+- deps: repairs the frontend API drift the advance surfaced. `comptime.init`
   takes the target's `vector_bits` between `pointer_width` and the compiler
   name, and the target's operation / type-constructor table now reaches the
   front end as data on the comptime context (mach#2888), so a buffer resolving
@@ -90,21 +106,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   integer register - where it had always emitted hard-float code. The old
   spelling still builds and would have silently changed the emitted calls.
 
-### Fixed
-- transport: distinguishes clean EOF from malformed/error input, caps LSP
-  headers at 8 KiB and bodies at 16 MiB with overflow-safe `Content-Length`
-  parsing, and surfaces response-write failures to the server loop. Portable
-  POSIX SIGPIPE suppression remains blocked on briar-systems/mach-std#468. (#149)
-- json / transport: the decimal formatters wrote `('0' + (v % 10))::u8`, mixing
-  a `u8` char literal into `usize` / `i64` arithmetic. Sema types that
-  expression at the wider operand and lowering typed it at the literal's own
-  width, so mach 4.18 refuses it in its IR verifier (`a conversion's result
-  width contradicts its opcode`) - the compiler's own defect (mach#2949), but the
-  source was relying on the two passes disagreeing. The width the arithmetic happens at is
-  now stated: `'0'::usize` / `'0'::i64`.
-- hover: a seeded vector type name (`res.SYM_VECTOR`) rendered as `symbol`
-  rather than `type`. Pre-existing, unrelated to the pin advance - `kind_label`
-  enumerated symbol kinds 0..11 and fell through on 12.
+### Known issues
+- resident memory grows ~4.2 MiB per analysis, without bound. The tracked leak is
+  61 KiB and ~887 unfreed allocations per analysis; because mach's page allocator
+  is one mmap per allocation and the residue is overwhelmingly 2-16 byte strings,
+  each leaked allocation pins a 4 KiB page, so RSS grows ~67x the byte count.
+  It is entirely inside the compiler's `begin_build` - before any module is
+  loaded, resolved, or type-checked - and reproduces with no LSP code involved.
+  briar-systems/mach#3001 fixed the manifest-reload half of the original leak;
+  briar-systems/mach#3012 tracks the rest. The LSP side is clean: the server adds
+  no measurable growth over the bare compiler cycle. Consumer tracking is #159.
 
 ## [0.10.0] - 2026-08-07
 

--- a/mach.toml
+++ b/mach.toml
@@ -1,6 +1,6 @@
 [project]
 id = "mls"
-version = "0.10.0"
+version = "0.11.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 


### PR DESCRIPTION
Cuts 0.11.0.

The cycle's headline is three defects and the architecture they needed:

- **perf**: a quadratic hash in the LSP's own fingerprint bookkeeping put 225 s in front of a 7.4 s compiler analysis, and repeated it on every request. `definition` cold 231 s → 7.4 s, warm 222 s → 0.2 ms. (#95)
- **diagnostics**: publishing read whichever snapshot a previous request left behind, so a file with a type error opened clean and only reported once you happened to hover. Now matches `mach build` from `didOpen`. (#142)
- **responsiveness**: analysis moved to a worker thread and superseded revisions coalesce. A 60-edit flood during a cold load went from 18.6 s of blocked client writes (worst single write 7.5 s) to 0.00 s, and from 19.0 s to 0.9 s to answer. (#143, #155)

Plus the #141 snapshot architecture, the `std.data.json` reader replacing a key scanner that could match inside an opened file's own source text (#153), and the pin advance to mach v4.20.0 / mach-std v0.27.0 (#159).

**Known issue carried into the release**, documented in the changelog: resident memory grows ~4.2 MiB per analysis. The tracked leak is 61 KiB and ~887 unfreed allocations per analysis, amplified ~67x because mach's page allocator is one mmap per allocation and the residue is 2-16 byte strings. It is entirely inside the compiler's `begin_build`, before any module is loaded, and reproduces with no LSP code involved — briar-systems/mach#3012. The LSP side is clean.

Verification: 59 unit tests, full protocol suite, clean build.