### PR TITLE
release: 0.11.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,11 @@ jobs:
       - name: Pull dependencies
         run: mach dep pull
 
-      - name: Build
-        run: mach build .
+      - name: Build (debug)
+        run: mach build . --target linux-x86_64 --profile debug
 
       - name: Test
         run: mach test .
+
+      - name: Protocol smoke
+        run: python3 test/lsp_protocol.py out/linux-x86_64/debug/bin/mls

--- a/.github/workflows/upstream-drift.yml
+++ b/.github/workflows/upstream-drift.yml
@@ -8,9 +8,9 @@ on:
 permissions:
   contents: read
 
-# this workflow runs only from the default branch, so a failure is an upstream
-# warning rather than a required pull-request check. ci.yml remains the pinned,
-# authoritative merge gate.
+# this workflow has no pull-request trigger, so a failure is an upstream warning
+# rather than a required merge check. ci.yml remains the pinned, authoritative
+# gate.
 jobs:
   live-mach:
     runs-on: ubuntu-latest
@@ -31,20 +31,46 @@ jobs:
           mach info
 
       # mach develops frontend APIs on dev and promotes them to main for
-      # releases. retarget only this disposable checkout so drift is caught
+      # releases. force only this disposable checkout to dev so drift is caught
       # before release without changing the committed pin used by ci.yml.
       - name: Resolve live upstream branches
         run: |
           python3 - <<'PY'
+          import re
+          import tomllib
           from pathlib import Path
 
           path = Path("mach.toml")
           text = path.read_text()
-          pinned = '[dep.mach]\ngit = "https://github.com/briar-systems/mach"\nref = "branch/main"'
-          live = pinned.replace('branch/main', 'branch/dev')
-          if text.count(pinned) != 1:
-              raise SystemExit("mach dependency stanza no longer matches the drift workflow")
-          path.write_text(text.replace(pinned, live))
+          try:
+              manifest = tomllib.loads(text)
+          except tomllib.TOMLDecodeError as error:
+              raise SystemExit(f"invalid mach.toml: {error}") from error
+
+          dependencies = manifest.get("dep")
+          dependency = dependencies.get("mach") if isinstance(dependencies, dict) else None
+          if not isinstance(dependency, dict):
+              raise SystemExit("mach.toml must contain exactly one [dep.mach] stanza")
+          if dependency.get("ref") not in {"branch/main", "branch/dev"}:
+              raise SystemExit("[dep.mach].ref must be branch/main or branch/dev")
+
+          lines = text.splitlines(keepends=True)
+          header = re.compile(r'^\s*\[\s*dep\s*\.\s*mach\s*\]\s*(?:#.*)?$')
+          starts = [index for index, line in enumerate(lines) if header.match(line.rstrip("\r\n"))]
+          if len(starts) != 1:
+              raise SystemExit("mach.toml must contain exactly one [dep.mach] stanza")
+
+          start = starts[0] + 1
+          end = next((index for index in range(start, len(lines)) if lines[index].lstrip().startswith("[")), len(lines))
+          ref = re.compile(r'^(\s*ref\s*=\s*)(["\'])(branch/(?:main|dev))\2(\s*(?:#.*)?)(\r?\n)?$')
+          matches = [index for index in range(start, end) if ref.match(lines[index])]
+          if len(matches) != 1:
+              raise SystemExit("[dep.mach] must contain one simple main/dev ref assignment")
+
+          index = matches[0]
+          match = ref.match(lines[index])
+          lines[index] = f'{match.group(1)}{match.group(2)}branch/dev{match.group(2)}{match.group(4)}{match.group(5) or ""}'
+          path.write_text("".join(lines))
           PY
           mach dep pull
           mach dep update --all

--- a/.github/workflows/upstream-drift.yml
+++ b/.github/workflows/upstream-drift.yml
@@ -1,0 +1,60 @@
+name: Upstream drift
+
+on:
+  schedule:
+    - cron: '17 9 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# this workflow runs only from the default branch, so a failure is an upstream
+# warning rather than a required pull-request check. ci.yml remains the pinned,
+# authoritative merge gate.
+jobs:
+  live-mach:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Install released mach
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p /tmp/machdl
+          gh release download --repo briar-systems/mach \
+            --pattern 'mach-*-x86_64-linux.tar.gz' --dir /tmp/machdl --clobber
+          tar -xzf /tmp/machdl/mach-*-x86_64-linux.tar.gz -C /tmp/machdl
+          install -m 0755 /tmp/machdl/mach /usr/local/bin/mach
+          mach info
+
+      # mach develops frontend APIs on dev and promotes them to main for
+      # releases. retarget only this disposable checkout so drift is caught
+      # before release without changing the committed pin used by ci.yml.
+      - name: Resolve live upstream branches
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+
+          path = Path("mach.toml")
+          text = path.read_text()
+          pinned = '[dep.mach]\ngit = "https://github.com/briar-systems/mach"\nref = "branch/main"'
+          live = pinned.replace('branch/main', 'branch/dev')
+          if text.count(pinned) != 1:
+              raise SystemExit("mach dependency stanza no longer matches the drift workflow")
+          path.write_text(text.replace(pinned, live))
+          PY
+          mach dep pull
+          mach dep update --all
+          mach dep list
+
+      - name: Build
+        run: mach build . --target linux-x86_64 --profile debug
+
+      - name: Test
+        run: mach test .
+
+      - name: Protocol smoke
+        run: python3 test/lsp_protocol.py out/linux-x86_64/debug/bin/mls

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- deps: **advanced the vendored mach pin `v4.7.1` → `v4.18.0`** and mach-std
+  `0.22.0` → `0.26.0`. The server analyzes buffers with the vendored compiler
+  frontend, so the pin *is* the language version the editor understands: frozen
+  at 4.7.1 it reported everything added since - `#[packed]`, a declaration-scope
+  `$if` measuring a layout, `$size_of` / `$align_of` / `$length_of` folding in a
+  comptime gate, the `#[handle]` / `#[op]` target-owned type and operation
+  declarations, riscv32 and the `ilp32` ABI family - as an error against source
+  the installed compiler accepts.
+- deps: repairs the one frontend API drift the advance surfaces. `comptime.init`
+  takes the target's `vector_bits` between `pointer_width` and the compiler
+  name, and the target's operation / type-constructor table now reaches the
+  front end as data on the comptime context (mach#2888), so a buffer resolving
+  under a project seeds `set_target_defs` from its own target the way the
+  compiler's own driver does. Without it a `#[handle]` or `#[op]` declaration
+  resolves against no definitions at all.
+- manifest: `linux-riscv64` moves from `abi = "lp64"` to `abi = "lp64d"`.
+  mach#2777 made `lp64` mean what it says - soft float, every float in an
+  integer register - where it had always emitted hard-float code. The old
+  spelling still builds and would have silently changed the emitted calls.
+- manifest: declares `[project] mach = "4.18.0"` (mach#2714), so a toolchain
+  older than the vendored frontend is named as such when the manifest is read
+  rather than failing later against source it cannot parse.
+
+### Fixed
+- json / transport: the decimal formatters wrote `('0' + (v % 10))::u8`, mixing
+  a `u8` char literal into `usize` / `i64` arithmetic. Sema types that
+  expression at the wider operand and lowering typed it at the literal's own
+  width, so mach 4.18 refuses it in its IR verifier (`a conversion's result
+  width contradicts its opcode`) - the compiler's own defect, but the source was
+  relying on the two passes disagreeing. The width the arithmetic happens at is
+  now stated: `'0'::usize` / `'0'::i64`.
+- hover: a seeded vector type name (`res.SYM_VECTOR`) rendered as `symbol`
+  rather than `type`. Pre-existing, unrelated to the pin advance - `kind_label`
+  enumerated symbol kinds 0..11 and fell through on 12.
+
 ## [0.10.0] - 2026-08-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- project: replaced the shared-session, manually re-resolved graph with one
+  stable compiler Session and retained `analyze_project` snapshot per root.
+  Open document text is mirrored as filesystem overlays with explicit input and
+  snapshot revisions; resolve, sema, generics, diagnostics, target/profile,
+  `$project`, `$bin`, aliases, and dependency exports now come from compiler-owned
+  ModuleEntries. Source content fingerprints, acknowledged watcher registration,
+  `didSave`, and failed-snapshot retry keep snapshots current. (#141)
+- documents: now own URI, canonical path, live text, LSP version, and a monotonic
+  mutation revision independently of the editor fallback. Published diagnostics
+  carry the matching document version.
 - deps: **advanced the vendored mach pin `v4.7.1` → `v4.18.0`** and mach-std
   `0.22.0` → `0.26.0`. The server analyzes buffers with the vendored compiler
   frontend, so the pin *is* the language version the editor understands: frozen

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,59 +7,59 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-08-20
+
+The server was unusably slow on any project that vendors the compiler, reported
+diagnostics that depended on what the user had clicked, and blocked the client
+mid-write while it worked. This release is those three, plus the architecture
+they needed.
+
 ### Fixed
 - perf: source fingerprints are stat-only. `file_fingerprint` read and FNV-hashed
   every module's full source on every snapshot build and every 250 ms scan, and
   its hash loop re-evaluated `str_len` as the loop condition, making the hash
   quadratic in file size. On this repository (222 modules) that put 225 s of the
-  server's own bookkeeping in front of a 7.4 s compiler analysis and repeated it
-  on every request. `textDocument/definition` cold 231 s → 7.4 s, warm 222 s →
-  0.6 ms, after an edit → 181 ms. (#95)
+  server's own bookkeeping in front of a 7.4 s compiler analysis, and repeated all
+  of it on every later request. `textDocument/definition` cold 231 s → 7.4 s, warm
+  222 s → 0.2 ms, after an edit → 181 ms. (#95)
 - diagnostics: publishing drives the analysis instead of reporting whichever
   snapshot a previous request left behind. A file with a type error opened clean
-  and only started reporting once an unrelated feature request built the project.
-  Editor output now matches `mach build` from `didOpen`, and a hover no longer
-  changes it. Republishing is scoped to the root that changed. (#142)
+  and only started reporting once an unrelated feature request built the project,
+  then went quiet again when that snapshot was invalidated. Editor output now
+  matches `mach build` from `didOpen`, and a hover no longer changes it.
+  Republishing is scoped to the root that changed, rather than every open buffer
+  in every open project. (#142)
 - server: `exit` terminates the process even when the client leaves stdin open,
   which the spec entitles it to do.
+- transport: distinguishes clean EOF from malformed/error input, caps LSP
+  headers at 8 KiB and bodies at 16 MiB with overflow-safe `Content-Length`
+  parsing, and surfaces response-write failures to the server loop. (#149)
+- json / transport: the decimal formatters wrote `('0' + (v % 10))::u8`, mixing
+  a `u8` char literal into `usize` / `i64` arithmetic. Sema types that
+  expression at the wider operand and lowering typed it at the literal's own
+  width, so mach 4.18 refuses it in its IR verifier - the compiler's own defect
+  (mach#2949), but the source was relying on the two passes disagreeing. The
+  width the arithmetic happens at is now stated: `'0'::usize` / `'0'::i64`.
+- hover: a seeded vector type name (`res.SYM_VECTOR`) rendered as `symbol`
+  rather than `type`; `kind_label` enumerated symbol kinds 0..11 and fell
+  through on 12.
 
 ### Added
 - server: analysis runs on a worker thread. The reading thread owns stdin and
-  nothing else, so a cold analysis no longer blocks the client mid-write —
-  flooding the server with 60 edits during a cold load went from 18.6 s of
-  blocked writes (worst single write 7.5 s) to 0.00 s. Document revisions
-  superseded by queued input are coalesced, so the same burst costs one analysis
-  instead of 60: 19.0 s → 0.9 s. (#143, #155)
+  nothing else, so a cold analysis no longer stops the server from seeing the
+  cancellation, edit, or shutdown behind it - and no longer blocks the client
+  mid-write when a `didChange` fills the pipe, which is the stall an editor reads
+  as a dead server. Flooding the server with 60 edits during a cold load went from
+  18.6 s of blocked writes (worst single write 7.5 s) to 0.00 s. (#143)
+- server: document revisions superseded by queued input are coalesced, so a burst
+  of keystrokes costs one analysis of the newest text rather than one per
+  revision. Deferring is never dropping: the debt is paid when the queue drains,
+  whatever the last message was. The same 60-edit burst: 19.0 s → 0.9 s. (#155)
 - jobs: bounded single-consumer message queue, futex-blocking so an idle server
-  costs no CPU.
+  costs no CPU. The bound is memory as much as latency, since the queued bodies
+  are whole documents.
 
 ### Changed
-- deps: **advanced the vendored mach pin to `v4.20.0`** and mach-std to `v0.27.0`,
-  and returned `[dep.mach]` to `branch/main`. Tracking `branch/dev` was a temporary
-  measure while the retained-analysis frontend API (mach#2997) was unreleased; the
-  release convention is `branch/main`. No frontend API drift.
-- project: parsed `mach.toml` tables are torn down. Both reads - the vendoring
-  probe and the document-overlay source-directory lookup - run on the snapshot
-  rebuild path and leaked their whole table on every rebuild, because
-  `std.data.toml` had no teardown to call. mach-std#474 adds one; `get_str` and
-  `table_key` borrow out of the table, so it is released at scope exit rather than
-  at the last read. Per-edit growth halved, ~8 MiB to ~4.2 MiB. (#159)
-- json: JSON-RPC messages are parsed with `std.data.json` instead of scanning the
-  raw body for a quoted key. The scanner matched a key ANYWHERE in the document,
-  including inside an opened file's own source text, and correct dispatch relied
-  on clients ordering `method` before `params`. Request ids now keep their wire
-  type, malformed bodies get a spec parse error, and string escaping is the std
-  emitter's. Messages parse into a per-message arena. (#153)
-
-### Known issues
-- memory still grows ~4.2 MiB per analysis, without bound. briar-systems/mach#3001
-  fixed the manifest-reload half (the LSP reloads the manifest on every rebuild);
-  the residue is in `analyze_project` / `dnit_project` itself and still reproduces
-  with no LSP code involved. Tracked upstream as briar-systems/mach#3012. The LSP
-  side is clean: the server adds no measurable growth over the bare compiler
-  cycle. (#159)
-
-### Changed (#141, earlier in this cycle)
 - project: replaced the shared-session, manually re-resolved graph with one
   stable compiler Session and retained `analyze_project` snapshot per root.
   Open document text is mirrored as filesystem overlays with explicit input and
@@ -70,15 +70,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - documents: now own URI, canonical path, live text, LSP version, and a monotonic
   mutation revision independently of the editor fallback. Published diagnostics
   carry the matching document version.
-- deps: **advanced the vendored mach pin `v4.7.1` → `v4.18.0`** and mach-std
-  `0.22.0` → `0.26.0`. The server analyzes buffers with the vendored compiler
-  frontend, so the pin *is* the language version the editor understands: frozen
-  at 4.7.1 it reported everything added since - `#[packed]`, a declaration-scope
-  `$if` measuring a layout, `$size_of` / `$align_of` / `$length_of` folding in a
-  comptime gate, the `#[handle]` / `#[op]` target-owned type and operation
-  declarations, riscv32 and the `ilp32` ABI family - as an error against source
-  the installed compiler accepts.
-- deps: repairs the one frontend API drift the advance surfaces. `comptime.init`
+- json: JSON-RPC messages are parsed with `std.data.json` instead of scanning the
+  raw body for a quoted key. The scanner matched a key ANYWHERE in the document,
+  including inside an opened file's own source text - which is exactly what a
+  `didOpen` payload carries - and correct dispatch relied on clients ordering
+  `method` before `params`, which JSON does not guarantee. Request ids now keep
+  their wire type, malformed bodies get a spec parse error, notifications are no
+  longer answered, and string escaping is the std emitter's. Messages parse into
+  a per-message arena. (#153)
+- project: parsed `mach.toml` tables are torn down. Both reads - the vendoring
+  probe and the document-overlay source-directory lookup - run on the snapshot
+  rebuild path and leaked their whole table on every rebuild, because
+  `std.data.toml` had no teardown to call. mach-std#474 adds one; `get_str` and
+  `table_key` borrow out of the table, so it is released at scope exit rather
+  than at the last read. (#159)
+- deps: **advanced the vendored mach pin `v4.7.1` → `v4.20.0`** and mach-std
+  `0.22.0` → `0.27.0`, and returned `[dep.mach]` to `branch/main`. The server
+  analyzes buffers with the vendored compiler frontend, so the pin *is* the
+  language version the editor understands: frozen at 4.7.1 it reported everything
+  added since - `#[packed]`, a declaration-scope `$if` measuring a layout,
+  `$size_of` / `$align_of` / `$length_of` folding in a comptime gate, the
+  `#[handle]` / `#[op]` target-owned type and operation declarations, riscv32 and
+  the `ilp32` ABI family - as an error against source the installed compiler
+  accepts. Tracking `branch/dev` was a temporary measure while the
+  retained-analysis frontend API (mach#2997) was unreleased. (#141, #159)
+- deps: repairs the frontend API drift the advance surfaced. `comptime.init`
   takes the target's `vector_bits` between `pointer_width` and the compiler
   name, and the target's operation / type-constructor table now reaches the
   front end as data on the comptime context (mach#2888), so a buffer resolving
@@ -90,21 +106,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   integer register - where it had always emitted hard-float code. The old
   spelling still builds and would have silently changed the emitted calls.
 
-### Fixed
-- transport: distinguishes clean EOF from malformed/error input, caps LSP
-  headers at 8 KiB and bodies at 16 MiB with overflow-safe `Content-Length`
-  parsing, and surfaces response-write failures to the server loop. Portable
-  POSIX SIGPIPE suppression remains blocked on briar-systems/mach-std#468. (#149)
-- json / transport: the decimal formatters wrote `('0' + (v % 10))::u8`, mixing
-  a `u8` char literal into `usize` / `i64` arithmetic. Sema types that
-  expression at the wider operand and lowering typed it at the literal's own
-  width, so mach 4.18 refuses it in its IR verifier (`a conversion's result
-  width contradicts its opcode`) - the compiler's own defect (mach#2949), but the
-  source was relying on the two passes disagreeing. The width the arithmetic happens at is
-  now stated: `'0'::usize` / `'0'::i64`.
-- hover: a seeded vector type name (`res.SYM_VECTOR`) rendered as `symbol`
-  rather than `type`. Pre-existing, unrelated to the pin advance - `kind_label`
-  enumerated symbol kinds 0..11 and fell through on 12.
+### Known issues
+- resident memory grows ~4.2 MiB per analysis, without bound. The tracked leak is
+  61 KiB and ~887 unfreed allocations per analysis; because mach's page allocator
+  is one mmap per allocation and the residue is overwhelmingly 2-16 byte strings,
+  each leaked allocation pins a 4 KiB page, so RSS grows ~67x the byte count.
+  It is entirely inside the compiler's `begin_build` - before any module is
+  loaded, resolved, or type-checked - and reproduces with no LSP code involved.
+  briar-systems/mach#3001 fixed the manifest-reload half of the original leak;
+  briar-systems/mach#3012 tracks the rest. The LSP side is clean: the server adds
+  no measurable growth over the bare compiler cycle. Consumer tracking is #159.
 
 ## [0.10.0] - 2026-08-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- transport: distinguishes clean EOF from malformed/error input, caps LSP
+  headers at 8 KiB and bodies at 16 MiB with overflow-safe `Content-Length`
+  parsing, and surfaces response-write failures to the server loop. Portable
+  POSIX SIGPIPE suppression remains blocked on briar-systems/mach-std#468. (#149)
+
 ## [0.10.0] - 2026-08-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,17 +40,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rather than `type`. Pre-existing, unrelated to the pin advance - `kind_label`
   enumerated symbol kinds 0..11 and fell through on 12.
 
-### Known issues
-- project: a manifest declaring `[project] mach = "..."` (mach#2714, new in
-  4.15) **fails to load in the editor**, disabling every cross-module feature
-  with `this project requires mach <X> or newer; running 0.10.0`. The vendored
-  frontend reads its own toolchain version from `MACH_VERSION`, which is
-  `$project.version` - the *embedding* project's version - so compiled into
-  mls it reports mls's version rather than mach's. Since mach is 4.x and mls is
-  0.x, essentially any project adopting the key is refused. The fix belongs
-  upstream (mach#2950): mach must carry its own version independently of whoever
-  compiles the frontend. mls therefore does not declare the key on itself.
-
 ## [0.10.0] - 2026-08-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   mach#2777 made `lp64` mean what it says - soft float, every float in an
   integer register - where it had always emitted hard-float code. The old
   spelling still builds and would have silently changed the emitted calls.
-- manifest: declares `[project] mach = "4.18.0"` (mach#2714), so a toolchain
-  older than the vendored frontend is named as such when the manifest is read
-  rather than failing later against source it cannot parse.
 
 ### Fixed
 - json / transport: the decimal formatters wrote `('0' + (v % 10))::u8`, mixing
@@ -42,6 +39,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - hover: a seeded vector type name (`res.SYM_VECTOR`) rendered as `symbol`
   rather than `type`. Pre-existing, unrelated to the pin advance - `kind_label`
   enumerated symbol kinds 0..11 and fell through on 12.
+
+### Known issues
+- project: a manifest declaring `[project] mach = "..."` (mach#2714, new in
+  4.15) **fails to load in the editor**, disabling every cross-module feature
+  with `this project requires mach <X> or newer; running 0.10.0`. The vendored
+  frontend reads its own toolchain version from `MACH_VERSION`, which is
+  `$project.version` - the *embedding* project's version - so compiled into
+  mls it reports mls's version rather than mach's. Since mach is 4.x and mls is
+  0.x, essentially any project adopting the key is refused. The fix belongs
+  upstream: mach must carry its own version independently of whoever compiles
+  the frontend. mls therefore does not declare the key on itself.
 
 ## [0.10.0] - 2026-08-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a `u8` char literal into `usize` / `i64` arithmetic. Sema types that
   expression at the wider operand and lowering typed it at the literal's own
   width, so mach 4.18 refuses it in its IR verifier (`a conversion's result
-  width contradicts its opcode`) - the compiler's own defect, but the source was
-  relying on the two passes disagreeing. The width the arithmetic happens at is
+  width contradicts its opcode`) - the compiler's own defect (mach#2949), but the
+  source was relying on the two passes disagreeing. The width the arithmetic happens at is
   now stated: `'0'::usize` / `'0'::i64`.
 - hover: a seeded vector type name (`res.SYM_VECTOR`) rendered as `symbol`
   rather than `type`. Pre-existing, unrelated to the pin advance - `kind_label`
@@ -48,8 +48,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `$project.version` - the *embedding* project's version - so compiled into
   mls it reports mls's version rather than mach's. Since mach is 4.x and mls is
   0.x, essentially any project adopting the key is refused. The fix belongs
-  upstream: mach must carry its own version independently of whoever compiles
-  the frontend. mls therefore does not declare the key on itself.
+  upstream (mach#2950): mach must carry its own version independently of whoever
+  compiles the frontend. mls therefore does not declare the key on itself.
 
 ## [0.10.0] - 2026-08-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   costs no CPU.
 
 ### Changed
+- deps: **advanced the vendored mach pin to `v4.20.0`** and mach-std to `v0.27.0`,
+  and returned `[dep.mach]` to `branch/main`. Tracking `branch/dev` was a temporary
+  measure while the retained-analysis frontend API (mach#2997) was unreleased; the
+  release convention is `branch/main`. No frontend API drift.
+- project: parsed `mach.toml` tables are torn down. Both reads - the vendoring
+  probe and the document-overlay source-directory lookup - run on the snapshot
+  rebuild path and leaked their whole table on every rebuild, because
+  `std.data.toml` had no teardown to call. mach-std#474 adds one; `get_str` and
+  `table_key` borrow out of the table, so it is released at scope exit rather than
+  at the last read. Per-edit growth halved, ~8 MiB to ~4.2 MiB. (#159)
 - json: JSON-RPC messages are parsed with `std.data.json` instead of scanning the
   raw body for a quoted key. The scanner matched a key ANYWHERE in the document,
   including inside an opened file's own source text, and correct dispatch relied
@@ -42,10 +52,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   emitter's. Messages parse into a per-message arena. (#153)
 
 ### Known issues
-- memory grows ~7.4 MiB per analysis, without bound, whether or not any source
-  changed. The leak is inside the compiler's `analyze_project` / `dnit_project`
-  cycle and reproduces with no LSP code involved; tracked upstream as
-  briar-systems/mach#3001.
+- memory still grows ~4.2 MiB per analysis, without bound. briar-systems/mach#3001
+  fixed the manifest-reload half (the LSP reloads the manifest on every rebuild);
+  the residue is in `analyze_project` / `dnit_project` itself and still reproduces
+  with no LSP code involved. Tracked upstream as briar-systems/mach#3012. The LSP
+  side is clean: the server adds no measurable growth over the bare compiler
+  cycle. (#159)
 
 ### Changed (#141, earlier in this cycle)
 - project: replaced the shared-session, manually re-resolved graph with one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- perf: source fingerprints are stat-only. `file_fingerprint` read and FNV-hashed
+  every module's full source on every snapshot build and every 250 ms scan, and
+  its hash loop re-evaluated `str_len` as the loop condition, making the hash
+  quadratic in file size. On this repository (222 modules) that put 225 s of the
+  server's own bookkeeping in front of a 7.4 s compiler analysis and repeated it
+  on every request. `textDocument/definition` cold 231 s → 7.4 s, warm 222 s →
+  0.6 ms, after an edit → 181 ms. (#95)
+- diagnostics: publishing drives the analysis instead of reporting whichever
+  snapshot a previous request left behind. A file with a type error opened clean
+  and only started reporting once an unrelated feature request built the project.
+  Editor output now matches `mach build` from `didOpen`, and a hover no longer
+  changes it. Republishing is scoped to the root that changed. (#142)
+- server: `exit` terminates the process even when the client leaves stdin open,
+  which the spec entitles it to do.
+
+### Added
+- server: analysis runs on a worker thread. The reading thread owns stdin and
+  nothing else, so a cold analysis no longer blocks the client mid-write —
+  flooding the server with 60 edits during a cold load went from 18.6 s of
+  blocked writes (worst single write 7.5 s) to 0.00 s. Document revisions
+  superseded by queued input are coalesced, so the same burst costs one analysis
+  instead of 60: 19.0 s → 0.9 s. (#143, #155)
+- jobs: bounded single-consumer message queue, futex-blocking so an idle server
+  costs no CPU.
+
 ### Changed
+- json: JSON-RPC messages are parsed with `std.data.json` instead of scanning the
+  raw body for a quoted key. The scanner matched a key ANYWHERE in the document,
+  including inside an opened file's own source text, and correct dispatch relied
+  on clients ordering `method` before `params`. Request ids now keep their wire
+  type, malformed bodies get a spec parse error, and string escaping is the std
+  emitter's. Messages parse into a per-message arena. (#153)
+
+### Known issues
+- memory grows ~7.4 MiB per analysis, without bound, whether or not any source
+  changed. The leak is inside the compiler's `analyze_project` / `dnit_project`
+  cycle and reproduces with no LSP code involved; tracked upstream as
+  briar-systems/mach#3001.
+
+### Changed (#141, earlier in this cycle)
 - project: replaced the shared-session, manually re-resolved graph with one
   stable compiler Session and retained `analyze_project` snapshot per root.
   Open document text is mirrored as filesystem overlays with explicit input and

--- a/README.md
+++ b/README.md
@@ -18,14 +18,29 @@ selected primary artifact supplies the target, profile, defines, `$project`, and
 come from the same compiler-owned ModuleEntry rather than LSP copies of compiler
 internals.
 
+The reading thread owns stdin and nothing else. Every message, parsing
+included, is handled on one worker thread that owns the sessions, snapshots,
+document registry, and feature handlers, so compiler state has exactly one owner
+and needs no locking. A cold analysis therefore cannot stop the server from
+reading the cancellation, edit, or shutdown behind it, and cannot block the
+client mid-write when a `didChange` fills the pipe. A change whose analysis is
+superseded by input already queued is coalesced: the text and revision are
+recorded, the analysis is deferred, and the debt is paid when the queue drains,
+so a burst of keystrokes costs one analysis of the newest text rather than one
+per revision.
+
 Roots are independent identity domains, so projects with colliding FQNs can be
 queried and rebuilt in either order. Dependency modules already present in an
 ancestor graph route to that graph read-only; unrelated nested projects remain
 isolated. Files outside a project use the upstream single-file editor API.
 
-Open/change notifications publish fast standalone parse diagnostics when no
-current project snapshot exists. A feature request rebuilds a stale snapshot and
-the server republishes compiler diagnostics afterward. Watch registration is
+Diagnostics own the analysis rather than reporting whichever snapshot a previous
+request happened to leave behind: open and change drive the load, so what the
+editor shows matches `mach build` from the first notification and does not move
+because hover or definition was requested. Documents outside any project fall
+back to standalone parse diagnostics. Republishing is scoped to the root that
+changed, so an edit in one project does not emit a notification for every open
+buffer in another. Watch registration is
 considered active only after the client acknowledges it; `didSave`, watched-file
 notifications, manifest/lock mtimes, and exact content fingerprints of previously
 loaded source paths all drive invalidation and retry. Fingerprint scans are
@@ -88,9 +103,10 @@ and fetched by `mach dep pull`; Mach tracks `branch/dev` while mach-std tracks
 | Module | Responsibility |
 |---|---|
 | `main` | entry point; page allocator + server loop |
-| `server` | lifecycle state, message loop, method dispatch |
+| `server` | lifecycle state, reading loop, and the analysis-thread dispatch |
+| `jobs` | bounded message queue feeding the single analysis thread |
 | `transport` | LSP base-protocol framing over stdin/stdout |
-| `json` | minimal JSON field extraction and response assembly |
+| `json` | JSON-RPC reading over `std.data.json`, plus LSP payload assembly |
 | `documents` | live URI/path/text/version/revision ownership plus fallback `FileId` |
 | `diagnostics` | publish compiler snapshot diagnostics, with single-file fallback |
 | `positions` | byte offset ⇄ LSP `(line, character)` (UTF-16 columns ⇄ bytes) and span text — the single conversion point |

--- a/README.md
+++ b/README.md
@@ -1,119 +1,48 @@
 # mach-lsp
 
 A language server for the [Mach](https://github.com/briar-systems/mach) programming
-language, built directly on the compiler-as-library editor surface
-(`mach.lang.editor`).
+language, built directly on Mach's retained compiler frontend and single-file
+editor APIs.
 
 ## Status
 
-This server implements the **diagnostics** vertical slice plus the
-**language features** end-to-end, all on the `mach.lang.editor` surface:
+mach-lsp implements lifecycle, full-text synchronization, diagnostics, hover,
+definition, references, rename/prepareRename, document symbols, and completion.
 
-- LSP lifecycle: `initialize`, `initialized`, `shutdown`, `exit`.
-- Document synchronization (full-text): `textDocument/didOpen`,
-  `didChange`, `didClose`.
-- Workspace file watching: `workspace/didChangeWatchedFiles` invalidates the
-  affected project root's graph, registered via `client/registerCapability`.
-- Diagnostics: on open/change the buffer text is fed to `mach.lang.editor`
-  (`open` / `update` / `diagnostics`); every reported `diagnostic.Diagnostic`
-  is mapped — its byte span through `positions.range_of` to a 0-based LSP range
-  (UTF-16 columns), its severity to the LSP scale — and published via
-  `textDocument/publishDiagnostics`.
-- Language features over the buffer's resolved analysis (`project.resolve_doc`
-  + `ast.offset_to_*` + the `resolve.ResolveResult` side tables):
-  - `textDocument/hover` — the declaration header (or kind + name) of the
-    symbol at the cursor, as a fenced `mach` code block, with the decl's doc
-    comment as trailing prose.
-  - `textDocument/definition` — the resolved symbol's declaration `Location`.
-  - `textDocument/references` — the symbol's declaration (which may live in a
-    dependency file) plus every use-site **across the loaded project graph**
-    (the requesting buffer and every other module that references the symbol).
-  - `textDocument/rename` / `prepareRename` — a **cross-file** `WorkspaceEdit`
-    renaming the declaration, every importer's references, and each importer's
-    `use` path leaf; confined to symbols declared in the user's own project.
-    `prepareRename` returns the name range for a renameable symbol, null for a
-    dependency-declared one.
-  - `textDocument/documentSymbol` — the module's top-level declarations as a
-    `DocumentSymbol` list.
-  - `textDocument/completion` — the file's named declarations, `use` aliases,
-    and the primitive type names.
+Project documents are analyzed by the compiler's retained frontend API. Each
+manifest root owns a stable long-lived compiler Session and one current Project
+snapshot; open filesystem documents retain their own text and monotonic revision
+and enter the compiler load walk as path overlays and extra module roots. The
+selected primary artifact supplies the target, profile, defines, `$project`, and
+`$bin` context. Resolve, sema, generic instantiation, and diagnostics therefore
+come from the same compiler-owned ModuleEntry rather than LSP copies of compiler
+internals.
 
-### Cross-module scope
+Roots are independent identity domains, so projects with colliding FQNs can be
+queried and rebuilt in either order. Dependency modules already present in an
+ancestor graph route to that graph read-only; unrelated nested projects remain
+isolated. Files outside a project use the upstream single-file editor API.
 
-The server keeps a **per-root** map of project graphs: each open document is
-routed to the project root that governs its path (the nearest ancestor
-`mach.toml`), and that root's module graph is loaded from disk on first use
-(`mls.project` runs the compiler's own `driver.build_project_union` over the
-manifest and `dep/` tree — the union of every declared target's import closure —
-snapshotting every loaded module's exports into a dependency set). The buffer is then re-resolved against its root's dep set, so several
-projects open in one session resolve independently. A document that is a
-dependency module of another root — one already loaded (e.g. a dep source opened
-via go-to-definition), or the project whose manifest declares the document's own
-nested root as a dep vendor dir, loaded on demand when the dep file is opened
-first — is bound to that root read-only rather than spun up as its own project,
-regardless of document open order. A symbol imported through a `use` binds to
-its declaration in a dependency module, and:
+Open/change notifications publish fast standalone parse diagnostics when no
+current project snapshot exists. A feature request rebuilds a stale snapshot and
+the server republishes compiler diagnostics afterward. Watch registration is
+considered active only after the client acknowledges it; `didSave`, watched-file
+notifications, manifest/lock mtimes, and exact content fingerprints of previously
+loaded source paths all drive invalidation and retry. Fingerprint scans are
+coalesced to at most once per 250 ms per root, bounding missed-event detection
+without hashing a graph on every request. Source overlays are mirrored
+under canonical and manifest-raw POSIX spellings (including `src = "./src"`).
+Portable Windows/UNC canonicalization is tracked by #157, mach#2998, and
+mach-std#472.
 
-- hover / definition reach **cross-module and cross-file** symbols, pointing at
-  the defining module's source file on disk (a `file://` location);
-- references and rename walk a shared use-site index over the document's root
-  graph (`build_refs` over `mls.project`'s `module_view`): references reports
-  every use-site across that root's modules; rename rewrites the declaring file,
-  every importer's body references, and each importer's `use` path leaf (guarded
-  by the declared name, so an aliased import's references are left intact).
-  Cross-file rename is confined to symbols declared in the user's own project —
-  a dependency's declaration is not the editor's to rewrite, whether referenced
-  cross-module or opened directly as the buffer — and reflects the on-disk state
-  of files other than the active buffer (the project graph is a load-time
-  snapshot, not rebuilt on `didChange`). When a module-scope `pub` symbol's
-  cross-file identity cannot be recovered from its stale on-disk twin (unsaved
-  edits renamed the declaration), rename refuses with an empty edit rather than
-  emit a partial, compile-breaking one;
-- completion is a flat list of the file's named symbols and the primitives, not
-  a lexically scoped view (the resolver's scope chain is not exposed by the
-  side tables);
-- a document outside any project (no ancestor `mach.toml`) resolves single-file
-  with an empty dependency set — references and rename then stay buffer-local.
+Cross-module references and rename walk the retained graph. Rename is restricted
+to project-owned declarations, so vendored dependency sources remain read-only.
+Completion is currently a flat list of module names, import aliases, and primitive
+types rather than a lexical scope view.
 
-A root's graph is **invalidated and rebuilt** when its sources change on disk:
-the server registers `workspace/didChangeWatchedFiles` watchers (via
-`client/registerCapability` when the client supports dynamic registration) for
-the manifest, lockfile, and source trees, and a change to any file under a root
-drops that root so the next request reloads it. With watching active, editing a
-dependency source or pulling updated deps serves the new positions and text
-rather than the as-of-first-load snapshot. For clients that do not deliver watch
-notifications, a manifest/lockfile mtime check on each access reloads the root —
-and retries a previously failed load once the manifest is fixed — but bare
-source edits are only picked up through a watch notification (or a manifest /
-lockfile touch).
-
-Reloads are **bounded**: one compiler session is reused for the whole editor
-session, and each rebuild follows the driver's reload contract — sources dedup
-by path (re-reading a root's closure reuses `FileId`s instead of growing the
-session source map) and `driver.dnit_project` frees the dropped graph and resets
-the session's per-build registries, so a long-lived session with frequent saves
-does not grow without bound. Each reload still re-parses and re-resolves the
-whole closure; incremental (per-module) rebuild is an upstream follow-up.
-
-> **Module-id namespacing:** `driver.build_project_union` numbers modules from 0
-> and writes them into the session's global module registries, so a second build
-> over the same session clobbers the first there. The server sidesteps this by
-> never reading those session registries — every cross-module lookup reads the
-> per-root `driver.Project.modules` array, whose ids are private to that project
-> — so several graphs coexist in one shared session (and one source map /
-> interner) without collision, and no per-root sessions are needed.
-
-> **Scope note:** each root's graph is the **union of every declared target's**
-> import closure (`driver.build_project_union`), so a module reachable only under
-> a non-default target's `$if` gate — a windows-only import while the host builds
-> for linux, say — is in the graph, and references / rename cover its use-sites
-> (modules are deduplicated by FQN, so one shared between targets yields no
-> duplicate locations or edits). Two residual limits: resolution runs under the
-> **default** target's comptime context, so a use-site behind a *non-default*
-> target's `$if` *inside* a module is present but not in the resolve index until
-> per-target resolution lands upstream; and a module reachable from no declared
-> target at all — imported by nothing — stays outside, having no entry to
-> analyze it through.
+The first semantic request still performs a synchronous whole-project frontend
+analysis. Syntax-only document symbols do not pay that cost; moving semantic work
+off the request path is tracked by #143.
 
 ## Building
 
@@ -126,14 +55,14 @@ mach dep pull   # vendor dep/mach and dep/mach-std
 mach build .    # compile the server
 ```
 
-The server binary is produced at `out/linux/debug/bin/mls`.
+The server binary is produced at `out/linux-x86_64/debug/bin/mls`.
 
 ## Installing
 
 Copy the built binary onto your `PATH`:
 
 ```sh
-install -Dm755 out/linux/debug/bin/mls ~/.local/bin/mls
+install -Dm755 out/linux-x86_64/debug/bin/mls ~/.local/bin/mls
 ```
 
 Then point your editor's LSP client at `mls`; the server speaks the LSP base
@@ -148,10 +77,11 @@ logging.
 
 ## How the compiler dependency is wired
 
-`dep/mach` (id `mach`) provides the `mach.lang.*` namespace, including the
-`mach.lang.editor` query surface this server binds to; `dep/mach-std` (id
+`dep/mach` (id `mach`) provides the `mach.lang.*` compiler and retained frontend
+surfaces this server binds to; `dep/mach-std` (id
 `std`) provides `std.*`. Both are declared as git dependencies in `mach.toml`
-and fetched by `mach dep pull`; both track `branch/main`.
+and fetched by `mach dep pull`; Mach tracks `branch/dev` while mach-std tracks
+`branch/main` to match Mach's dependency identity.
 
 ## Architecture
 
@@ -161,11 +91,11 @@ and fetched by `mach dep pull`; both track `branch/main`.
 | `server` | lifecycle state, message loop, method dispatch |
 | `transport` | LSP base-protocol framing over stdin/stdout |
 | `json` | minimal JSON field extraction and response assembly |
-| `documents` | URI ⇄ editor `FileId` registry |
-| `diagnostics` | run `editor.diagnostics`, map spans, publish |
+| `documents` | live URI/path/text/version/revision ownership plus fallback `FileId` |
+| `diagnostics` | publish compiler snapshot diagnostics, with single-file fallback |
 | `positions` | byte offset ⇄ LSP `(line, character)` (UTF-16 columns ⇄ bytes) and span text — the single conversion point |
 | `features` | offset → id → symbol query core over the resolve side tables |
-| `project` | per-root project graphs: route a document to its governing root, load each root's module graph, re-resolve a buffer against its root's dependency set, map a symbol to its declaring file's `file://` URI, expose a root's loaded modules for the use-site walk, and invalidate a root on a watched-file change |
+| `project` | stable per-root compiler Sessions and retained Project snapshots, overlays, routing, fingerprints, module views, and invalidation |
 | `language` | hover / definition / references / rename / documentSymbol / completion request bodies |
 | `trace` | append-only debug trace log (`/tmp/mach-lsp.log`) |
 

--- a/mach.lock
+++ b/mach.lock
@@ -3,9 +3,9 @@
 [dep.mach-std]
 url = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"
-commit = "c500b97631ada14579eb29f305f780c961d8ee0a"
+commit = "f6967775d79eb780207140596581abbf7bf78be3"
 
 [dep.mach]
 url = "https://github.com/briar-systems/mach"
 ref = "branch/main"
-commit = "9b0c669dcf141ea65c9fb360f8ec78dd5e6aef7a"
+commit = "7a17a7cd96de065acf3e442737a0aa967411f0fb"

--- a/mach.lock
+++ b/mach.lock
@@ -3,9 +3,9 @@
 [dep.mach-std]
 url = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"
-commit = "f6967775d79eb780207140596581abbf7bf78be3"
+commit = "43e8cb7af860b21ff8ce22a61d1335ecb5f5ea05"
 
 [dep.mach]
 url = "https://github.com/briar-systems/mach"
 ref = "branch/dev"
-commit = "291c5975d95914779bb56b1f55ede1677ff2a992"
+commit = "66a56e1c95a17af8e88fc8d828a709acb094abc2"

--- a/mach.lock
+++ b/mach.lock
@@ -7,5 +7,5 @@ commit = "f6967775d79eb780207140596581abbf7bf78be3"
 
 [dep.mach]
 url = "https://github.com/briar-systems/mach"
-ref = "branch/main"
-commit = "7a17a7cd96de065acf3e442737a0aa967411f0fb"
+ref = "branch/dev"
+commit = "291c5975d95914779bb56b1f55ede1677ff2a992"

--- a/mach.lock
+++ b/mach.lock
@@ -3,9 +3,9 @@
 [dep.mach-std]
 url = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"
-commit = "43e8cb7af860b21ff8ce22a61d1335ecb5f5ea05"
+commit = "fce25b528bafa3a8392df9e0ad62409f85335183"
 
 [dep.mach]
 url = "https://github.com/briar-systems/mach"
-ref = "branch/dev"
-commit = "66a56e1c95a17af8e88fc8d828a709acb094abc2"
+ref = "branch/main"
+commit = "81ff7efdaffe019663017a7de718e82d876acd07"

--- a/mach.toml
+++ b/mach.toml
@@ -58,4 +58,4 @@ ref = "branch/main"
 
 [dep.mach]
 git = "https://github.com/briar-systems/mach"
-ref = "branch/dev"
+ref = "branch/main"

--- a/mach.toml
+++ b/mach.toml
@@ -58,4 +58,4 @@ ref = "branch/main"
 
 [dep.mach]
 git = "https://github.com/briar-systems/mach"
-ref = "branch/main"
+ref = "branch/dev"

--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,6 @@
 [project]
 id = "mls"
 version = "0.10.0"
-mach = "4.18.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 

--- a/mach.toml
+++ b/mach.toml
@@ -1,6 +1,7 @@
 [project]
 id = "mls"
 version = "0.10.0"
+mach = "4.18.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 
@@ -17,7 +18,7 @@ abi = "aapcs64"
 [target.linux-riscv64]
 isa = "riscv64"
 os  = "linux"
-abi = "lp64"
+abi = "lp64d"
 
 [target.windows-x86_64]
 isa  = "x86_64"

--- a/mach.toml
+++ b/mach.toml
@@ -1,6 +1,6 @@
 [project]
 id = "mls"
-version = "0.10.0"
+version = "0.11.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 

--- a/src/diagnostics.mach
+++ b/src/diagnostics.mach
@@ -32,6 +32,7 @@ use transport: mls.transport;
 use json:      mls.json;
 use positions: mls.positions;
 use project:   mls.project;
+use documents: mls.documents;
 
 # LSP diagnostic severities (1 = Error ... 4 = Hint)
 val LSP_ERROR:   i64 = 1;
@@ -42,63 +43,47 @@ val LSP_HINT:    i64 = 4;
 # cap on diagnostics published per document, to bound message size
 val MAX_DIAGNOSTICS: usize = 200;
 
-# analyze `uri`'s buffer and send its current diagnostics. a document
-# governed by an already-loaded project root is analyzed dep-aware
-# (`project.diagnose_doc`) so its name-resolution diagnostics - including an
-# import of a module outside the project's dep closure - are surfaced, keeping
-# the published diagnostics consistent with what go-to-definition can resolve
-# (#78). a document under no loaded project resolves single-file
-# (`editor.diagnostics`, parse-only), so its cross-module `use`s are not flagged
-# against an empty dep set. the governing-root lookup is load-free
-# (`root_for_loaded`): publishing must never trigger a project build, so opening
-# or editing a buffer stays instant - the project loads lazily on the first
-# feature request, after which the server re-publishes the now-loaded buffers
-# (#96).
-# semantic (type) diagnostics are layered on when - and only when - the governing
-# root's dep closure has already been sema'd (`project.sema_ready`, a load-free
-# check that never triggers a build or the heavy whole-closure `ensure_sema`).
-# `sema_doc` then types the active buffer against the closure's retained dep typing
-# (bounded - one module) and emits its type diagnostics onto the same session
-# DiagList `diagnose_doc` populated, so parse + resolve + type diagnostics publish
-# together. a loaded-but-un-sema'd root publishes parse + resolve only (instant);
-# the server re-publishes with types once a feature request sema's the closure (the
-# sema epoch) (#113)
+# publish compiler-owned diagnostics for a document's exact snapshot, falling
+# back to isolated editor diagnostics outside a project
 # ---
-# w:       the workspace, for routing the document to its governing root
-# es:      editor session holding the buffer
-# sources: source map whose SourceFiles resolve spans to positions
-# alloc:   allocator for the message buffers
-# uri:     document URI to report on
-# fid:     editor FileId of the document's buffer
-pub fun publish(w: *project.Workspace, es: *editor.EditorSession, sources: *src.SourceMap, alloc: *Allocator, uri: str, fid: src.FileId) {
-    val root: *project.Root = project.root_for_loaded(w, uri);
-    var dr: Result[*diag.DiagList, str];
-    if (root != nil) { dr = project.diagnose_doc(w, root, fid); }
-    or              { dr = editor.diagnostics(es, fid); }
-    if (is_err[*diag.DiagList, str](dr)) {
-        clear(alloc, uri);
-        ret;
+# w:     project workspace
+# es:    standalone editor fallback
+# alloc: message allocator
+# d:     live document and version
+pub fun publish(w: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, d: *documents.Document) {
+    var list: *diag.DiagList = nil;
+    var sources: *src.SourceMap = nil;
+    var own: src.FileId = d.file_id;
+    val vr: Result[project.DocumentView, str] = project.document_view_loaded(w, d);
+    if (!is_err[project.DocumentView, str](vr)) {
+        val v: project.DocumentView = unwrap_ok[project.DocumentView, str](vr);
+        list = ?v.root.s.diags;
+        sources = ?v.root.s.sources;
+        own = v.file_id;
     }
-    val list: *diag.DiagList = unwrap_ok[*diag.DiagList, str](dr);
-
-    # append the buffer's type diagnostics when the closure is already sema'd. the
-    # gate is load-free (never `ensure_sema`), so this stays off the build/whole-
-    # closure path - `sema_doc`'s internal `ensure_sema` is a no-op on a ready root.
-    # the type diagnostics land on the same session DiagList `list` points into;
-    # `sema_doc`'s returned typing is the feature layer's, discarded here.
-    if (project.sema_ready(root)) { project.sema_doc(w, root, fid); }
-
-    var count: usize = list.len;
-    if (count > MAX_DIAGNOSTICS) { count = MAX_DIAGNOSTICS; }
+    or {
+        val dr: Result[*diag.DiagList, str] = editor.diagnostics(es, d.file_id);
+        if (is_err[*diag.DiagList, str](dr)) { clear(alloc, d.uri); ret; }
+        list = unwrap_ok[*diag.DiagList, str](dr);
+        sources = ?es.s.sources;
+    }
 
     var b: json.Buf = json.buf_init(alloc);
     json.buf_push(?b, "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/publishDiagnostics\",\"params\":{\"uri\":");
-    json.buf_push_quoted(?b, uri);
+    json.buf_push_quoted(?b, d.uri);
+    if (d.version >= 0) {
+        json.buf_push(?b, ",\"version\":");
+        json.buf_push_i64(?b, d.version);
+    }
     json.buf_push(?b, ",\"diagnostics\":[");
     var i: usize = 0;
-    for (i < count) {
-        if (i > 0) { json.buf_push_byte(?b, ','); }
-        push_entry(?b, sources, ?list.items[i], alloc);
+    var written: usize = 0;
+    for (i < list.len && written < MAX_DIAGNOSTICS) {
+        if (list.items[i].loc.file_id == own) {
+            if (written > 0) { json.buf_push_byte(?b, ','); }
+            push_entry(?b, sources, ?list.items[i], alloc);
+            written = written + 1;
+        }
         i = i + 1;
     }
     json.buf_push(?b, "]}}");
@@ -108,7 +93,8 @@ pub fun publish(w: *project.Workspace, es: *editor.EditorSession, sources: *src.
     json.buf_dnit(?b);
 }
 
-# publish an empty diagnostics array for `uri` (e.g. on close)
+# publish an unversioned empty diagnostics array for `uri` on close; omitting a
+# version prevents the client from rejecting the final clear as an older snapshot
 # ---
 # alloc: allocator for the message buffer
 # uri:   document URI to clear

--- a/src/diagnostics.mach
+++ b/src/diagnostics.mach
@@ -45,6 +45,19 @@ val MAX_DIAGNOSTICS: usize = 200;
 
 # publish compiler-owned diagnostics for a document's exact snapshot, falling
 # back to isolated editor diagnostics outside a project
+#
+# The analysis is DRIVEN here rather than merely read. Publishing used to take
+# whatever snapshot a previous request happened to leave behind, so a file with
+# a type error opened clean and only started reporting once some unrelated
+# hover or definition request built the project - and stopped again when that
+# snapshot was invalidated. Diagnostics are the one output that must not depend
+# on what the user asked for, so they own the pipeline: `document_view` loads
+# or refreshes the root, and the result is parse, resolve, and sema at the same
+# fidelity `mach build` reports.
+#
+# `project.refresh_inputs` makes this a revision check once the snapshot is
+# current, so republishing every open document after a change costs one
+# comparison per document rather than one analysis.
 # ---
 # w:     project workspace
 # es:    standalone editor fallback
@@ -54,7 +67,7 @@ pub fun publish(w: *project.Workspace, es: *editor.EditorSession, alloc: *Alloca
     var list: *diag.DiagList = nil;
     var sources: *src.SourceMap = nil;
     var own: src.FileId = d.file_id;
-    val vr: Result[project.DocumentView, str] = project.document_view_loaded(w, d);
+    val vr: Result[project.DocumentView, str] = project.document_view(w, d);
     if (!is_err[project.DocumentView, str](vr)) {
         val v: project.DocumentView = unwrap_ok[project.DocumentView, str](vr);
         list = ?v.root.s.diags;

--- a/src/documents.mach
+++ b/src/documents.mach
@@ -1,10 +1,8 @@
 # the open-document registry bridging LSP URIs to editor buffers
 #
-# the LSP identifies documents by URI; the editor surface identifies buffers by
-# `source.FileId`. this module owns that mapping. `didOpen` registers a URI's
-# text as an editor buffer and records the assigned FileId; `didChange`
-# replaces the buffer text in place; `didClose` retires the entry. each entry
-# keeps its own owned URI copy so it survives the request that created it.
+# the LSP identifies documents by URI while compiler overlays are keyed by
+# canonical filesystem paths. this module owns the live document text, path,
+# and revision; the editor FileId is only the single-file fallback.
 #
 # the editor session is borrowed from the server and reused across documents -
 # it owns the per-buffer analysis and the underlying session owns the source
@@ -16,6 +14,7 @@ use std.types.bool.false;
 use std.types.size.usize;
 use std.types.string.str;
 use std.types.string.str_equals;
+use std.types.string.str_len;
 use std.types.result.Result;
 use std.types.result.ok;
 use std.types.result.err;
@@ -35,13 +34,21 @@ use editor: mach.lang.editor;
 
 # one tracked open document
 # ---
-# uri:     owned document URI
-# file_id: editor FileId the buffer is registered under
-# in_use:  whether this slot holds a live document
+# uri:       owned document URI
+# path:      owned canonical filesystem path
+# text:      owned current buffer text
+# file_id:   editor FileId used only for the single-file fallback
+# revision:  server-assigned monotonic input revision
+# version:   latest client document version, or -1 when omitted
+# in_use:    whether this slot holds a live document
 pub rec Document {
-    uri:     str;
-    file_id: src.FileId;
-    in_use:  bool;
+    uri:      str;
+    path:     str;
+    text:     str;
+    file_id:  src.FileId;
+    revision: u64;
+    version:  i64;
+    in_use:   bool;
 }
 
 # the registry of tracked documents over a borrowed editor session
@@ -55,6 +62,7 @@ pub rec Store {
     alloc: *Allocator;
     docs:  *Document;
     len:   usize;
+    revision: u64;
 }
 
 # construct an empty document store over an editor session
@@ -68,6 +76,7 @@ pub fun init(es: *editor.EditorSession, alloc: *Allocator) Store {
     st.alloc = alloc;
     st.docs = nil;
     st.len = 0;
+    st.revision = 0;
     ret st;
 }
 
@@ -80,13 +89,14 @@ pub fun dnit(st: *Store) {
         var i: usize = 0;
         for (i < st.len) {
             val d: *Document = ?st.docs[i];
-            if (d.uri != nil) { strutil.str_free(st.alloc, d.uri); }
+            free_owned(st, d);
             i = i + 1;
         }
         deallocate[Document](st.alloc, st.docs, st.len);
     }
     st.docs = nil;
     st.len = 0;
+    st.revision = 0;
 }
 
 # register a document's text as an editor buffer, returning its entry.
@@ -96,26 +106,44 @@ pub fun dnit(st: *Store) {
 # uri:  document URI
 # text: full document text
 # ret:  the tracked Document on success, or an error string
-pub fun open(st: *Store, uri: str, text: str) Result[*Document, str] {
+pub fun open(st: *Store, uri: str, path: str, text: str, version: i64) Result[*Document, str] {
     val existing: *Document = find(st, uri);
     if (existing != nil) {
-        val ur: Result[bool, str] = editor.update(st.es, existing.file_id, text);
-        if (is_err[bool, str](ur)) { ret err[*Document, str](unwrap_err[bool, str](ur)); }
-        ret ok[*Document, str](existing);
+        ret replace(st, existing, path, text, version);
     }
-
-    val fr: Result[src.FileId, str] = editor.open(st.es, uri, text);
-    if (is_err[src.FileId, str](fr)) { ret err[*Document, str](unwrap_err[src.FileId, str](fr)); }
-    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
 
     val slot_r: Result[*Document, str] = ensure_slot(st);
     if (is_err[*Document, str](slot_r)) { ret slot_r; }
     val d: *Document = unwrap_ok[*Document, str](slot_r);
 
-    val dup: Result[str, str] = strutil.str_dup(st.alloc, uri);
-    if (is_err[str, str](dup)) { ret err[*Document, str]("documents: failed to copy uri"); }
-    d.uri = unwrap_ok[str, str](dup);
+    val dup_uri: Result[str, str] = strutil.str_dup(st.alloc, uri);
+    if (is_err[str, str](dup_uri)) { ret err[*Document, str]("documents: failed to copy uri"); }
+    val dup_path: Result[str, str] = strutil.str_dup(st.alloc, path);
+    if (is_err[str, str](dup_path)) {
+        strutil.str_free(st.alloc, unwrap_ok[str, str](dup_uri));
+        ret err[*Document, str]("documents: failed to copy path");
+    }
+    val dup_text: Result[str, str] = strutil.str_dup(st.alloc, text);
+    if (is_err[str, str](dup_text)) {
+        strutil.str_free(st.alloc, unwrap_ok[str, str](dup_uri));
+        strutil.str_free(st.alloc, unwrap_ok[str, str](dup_path));
+        ret err[*Document, str]("documents: failed to copy text");
+    }
+    val fr: Result[src.FileId, str] = editor.open(st.es, uri, text);
+    if (is_err[src.FileId, str](fr)) {
+        strutil.str_free(st.alloc, unwrap_ok[str, str](dup_uri));
+        strutil.str_free(st.alloc, unwrap_ok[str, str](dup_path));
+        strutil.str_free(st.alloc, unwrap_ok[str, str](dup_text));
+        ret err[*Document, str](unwrap_err[src.FileId, str](fr));
+    }
+    val fid: src.FileId = unwrap_ok[src.FileId, str](fr);
+    d.uri = unwrap_ok[str, str](dup_uri);
+    d.path = unwrap_ok[str, str](dup_path);
+    d.text = unwrap_ok[str, str](dup_text);
     d.file_id = fid;
+    st.revision = st.revision + 1;
+    d.revision = st.revision;
+    d.version = version;
     d.in_use = true;
     ret ok[*Document, str](d);
 }
@@ -126,11 +154,50 @@ pub fun open(st: *Store, uri: str, text: str) Result[*Document, str] {
 # uri:  document URI; must already be open
 # text: replacement text
 # ret:  the tracked Document on success, or an error string
-pub fun change(st: *Store, uri: str, text: str) Result[*Document, str] {
+pub fun change(st: *Store, uri: str, text: str, version: i64) Result[*Document, str] {
     val d: *Document = find(st, uri);
     if (d == nil) { ret err[*Document, str]("documents: change of unopened document"); }
+    if (version >= 0 && d.version >= 0 && version <= d.version) {
+        ret err[*Document, str]("documents: stale document version");
+    }
+    val dup: Result[str, str] = strutil.str_dup(st.alloc, text);
+    if (is_err[str, str](dup)) { ret err[*Document, str]("documents: failed to copy text"); }
     val ur: Result[bool, str] = editor.update(st.es, d.file_id, text);
-    if (is_err[bool, str](ur)) { ret err[*Document, str](unwrap_err[bool, str](ur)); }
+    if (is_err[bool, str](ur)) {
+        strutil.str_free(st.alloc, unwrap_ok[str, str](dup));
+        ret err[*Document, str](unwrap_err[bool, str](ur));
+    }
+    strutil.str_free(st.alloc, d.text);
+    d.text = unwrap_ok[str, str](dup);
+    st.revision = st.revision + 1;
+    d.revision = st.revision;
+    d.version = version;
+    ret ok[*Document, str](d);
+}
+
+# replace a reopened document's owned path and text after updating the fallback
+# editor buffer
+fun replace(st: *Store, d: *Document, path: str, text: str, version: i64) Result[*Document, str] {
+    val dp: Result[str, str] = strutil.str_dup(st.alloc, path);
+    if (is_err[str, str](dp)) { ret err[*Document, str]("documents: failed to copy path"); }
+    val dt: Result[str, str] = strutil.str_dup(st.alloc, text);
+    if (is_err[str, str](dt)) {
+        strutil.str_free(st.alloc, unwrap_ok[str, str](dp));
+        ret err[*Document, str]("documents: failed to copy text");
+    }
+    val ur: Result[bool, str] = editor.update(st.es, d.file_id, text);
+    if (is_err[bool, str](ur)) {
+        strutil.str_free(st.alloc, unwrap_ok[str, str](dp));
+        strutil.str_free(st.alloc, unwrap_ok[str, str](dt));
+        ret err[*Document, str](unwrap_err[bool, str](ur));
+    }
+    strutil.str_free(st.alloc, d.path);
+    strutil.str_free(st.alloc, d.text);
+    d.path = unwrap_ok[str, str](dp);
+    d.text = unwrap_ok[str, str](dt);
+    st.revision = st.revision + 1;
+    d.revision = st.revision;
+    d.version = version;
     ret ok[*Document, str](d);
 }
 
@@ -143,9 +210,31 @@ pub fun change(st: *Store, uri: str, text: str) Result[*Document, str] {
 pub fun close(st: *Store, uri: str) {
     val d: *Document = find(st, uri);
     if (d == nil) { ret; }
-    if (d.uri != nil) { strutil.str_free(st.alloc, d.uri); }
-    d.uri = nil;
+    free_owned(st, d);
     d.in_use = false;
+}
+
+# stamp a close in the store's monotonic mutation domain while the document's
+# path is still available for compiler-overlay removal
+# ---
+# st:  document store
+# uri: closing document URI
+# ret: live document stamped with the close revision, or nil
+pub fun closing(st: *Store, uri: str) *Document {
+    val d: *Document = find(st, uri);
+    if (d == nil) { ret nil; }
+    st.revision = st.revision + 1;
+    d.revision = st.revision;
+    ret d;
+}
+
+fun free_owned(st: *Store, d: *Document) {
+    if (d.uri != nil) { strutil.str_free(st.alloc, d.uri); }
+    if (d.path != nil) { strutil.str_free(st.alloc, d.path); }
+    if (d.text != nil) { strutil.str_free(st.alloc, d.text); }
+    d.uri = nil;
+    d.path = nil;
+    d.text = nil;
 }
 
 # the number of Document slots in the store. paired with `at` to
@@ -211,7 +300,11 @@ fun ensure_slot(st: *Store) Result[*Document, str] {
     for (z < new_len) {
         val nb: *Document = ?st.docs[z];
         nb.uri = nil;
+        nb.path = nil;
+        nb.text = nil;
         nb.file_id = 0::src.FileId;
+        nb.revision = 0;
+        nb.version = 0 - 1;
         nb.in_use = false;
         z = z + 1;
     }

--- a/src/features.mach
+++ b/src/features.mach
@@ -266,28 +266,6 @@ pub fun symbol_by_decl(rr: *res.ResolveResult, origin: sess.ModuleId, decl: id.D
     ret res.SYMBOL_NIL;
 }
 
-# the DeclId of the pub symbol in `rr` named `name` with kind
-# `kind`, or DECL_NIL. translates a buffer-local pub declaration to the canonical
-# (origin, decl) identity in the on-disk module the buffer mirrors, so the
-# workspace walk can locate importers of that symbol. pub symbols occupy the
-# front of the table ([0, pub_count)); a non-pub symbol has no cross-file
-# use-sites and yields DECL_NIL
-# ---
-# rr:   the on-disk module's resolve side tables
-# name: interned identifier of the declaration
-# kind: the declaration's symbol kind
-# ret:  the declaration's DeclId, or DECL_NIL
-pub fun export_decl_of(rr: *res.ResolveResult, name: intern.StrId, kind: res.SymKind) id.DeclId {
-    if (name == intern.STR_NIL) { ret id.DECL_NIL; }
-    var i: u32 = 0;
-    for (i < rr.pub_count) {
-        val sym: *res.Symbol = ?rr.symbols[i];
-        if (sym.name == name && sym.kind == kind && sym.decl != id.DECL_NIL) { ret sym.decl; }
-        i = i + 1;
-    }
-    ret id.DECL_NIL;
-}
-
 # the number of declarations at the buffer's module scope -
 # the count documentSymbol enumerates. zero when the Ast has no root module
 # ---

--- a/src/features.mach
+++ b/src/features.mach
@@ -517,6 +517,7 @@ pub fun kind_label(kind: res.SymKind) str {
     if (kind == res.SYM_IMPORTED) { ret "import"; }
     if (kind == res.SYM_TEST)     { ret "test"; }
     if (kind == res.SYM_PRIM)     { ret "type"; }
+    if (kind == res.SYM_VECTOR)   { ret "type"; }
     ret "symbol";
 }
 

--- a/src/jobs.mach
+++ b/src/jobs.mach
@@ -1,0 +1,415 @@
+# a single-consumer job queue handing message bodies to an analysis thread
+#
+# the protocol loop must keep reading while the compiler works. a cold project
+# analysis takes seconds, and running it on the reading thread means the server
+# cannot see a cancellation, a newer edit, or a shutdown until it finishes -
+# which is how an editor concludes the server is dead and restarts it, only to
+# pay the same cost again.
+#
+# so the reading thread owns stdin and this queue, and one worker thread owns
+# everything the compiler touches: the sessions, the snapshots, the document
+# registry, and the feature handlers. exactly one thread ever reaches compiler
+# state, so nothing there needs locking; the queue is the only shared structure
+# and the only thing a lock protects.
+#
+# the worker blocks on a futex rather than polling, so an idle server costs no
+# CPU: `seq` advances on every push and on stop, and a waiter that saw the old
+# value sleeps until someone bumps it.
+
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.size.usize;
+use std.types.string.str;
+use std.types.string.str_len;
+use std.types.result.Result;
+use std.types.result.is_err;
+use std.types.result.unwrap_ok;
+
+use std.allocator.Allocator;
+use std.allocator.allocate;
+use std.allocator.deallocate;
+
+use mem:    std.memory;
+use os:     std.system.os;
+use atomic: std.sync.atomic;
+use mutex:  std.sync.mutex;
+use thread: std.sync.thread;
+
+# what the worker does with one dequeued body
+#
+# ctx is the opaque pointer handed to `start`; body is owned by the callback
+# for the duration of the call and released by the queue afterwards.
+pub def JobFn: fun(ptr, str, usize);
+
+# one queued message body, owned by the queue
+# ---
+# body: nul-terminated copy of the message body
+# len:  body length in bytes, excluding the terminator
+rec Job {
+    body: str;
+    len:  usize;
+}
+
+# the queue and the worker thread draining it
+#
+# `lock` guards `jobs`, `head`, `count`, and `closed`. `seq` is the futex word
+# the worker sleeps on and is written under the lock but read without it, so a
+# waiter can compare against a value it sampled before locking.
+# ---
+# alloc:  allocator backing the ring and every queued body
+# lock:   guards the ring and `closed`
+# jobs:   ring of `cap` slots
+# cap:    ring length
+# head:   index of the next job to pop
+# count:  queued jobs
+# seq:    futex word, advanced on every push and on close
+# closed: no further pushes are accepted and the worker should drain and exit
+# th:     the worker thread handle
+# live:   whether `th` was spawned and still needs joining
+pub rec Queue {
+    alloc:  *Allocator;
+    lock:   mutex.Mutex;
+    jobs:   *Job;
+    cap:    usize;
+    head:   usize;
+    count:  usize;
+    seq:    i64;
+    closed: bool;
+    th:     thread.Thread;
+    live:   bool;
+}
+
+# the queue a spawned worker drains
+#
+# `thread.spawn_with` hands the entry a single opaque pointer and std has no
+# thread-local storage, so the callback and its context ride the queue itself.
+# ---
+# q:  the queue to drain
+# f:  the callback to run per job
+# fx: opaque context handed to `f`
+rec Bound {
+    q:  *Queue;
+    f:  JobFn;
+    fx: ptr;
+}
+
+# bound state for the single worker, addressed by the spawned thread
+#
+# The handle must outlive the thread and std threads take one pointer, so the
+# binding lives here rather than in a caller frame. One server runs one queue.
+var BOUND: Bound;
+
+# how many messages may wait before a push is refused
+#
+# The queue holds whole message bodies, and `didChange` carries a document's
+# full text, so this bounds memory as well as latency. A client that outruns
+# the worker by more than this is answered rather than buffered without limit.
+pub val CAPACITY: usize = 256;
+
+# construct an empty queue over `alloc`
+# ---
+# q:     queue to initialize
+# alloc: allocator backing the ring and queued bodies; must outlive the queue
+# ret:   true on success
+pub fun init(q: *Queue, alloc: *Allocator) bool {
+    q.alloc  = alloc;
+    q.lock   = mutex.make();
+    q.jobs   = nil;
+    q.cap    = 0;
+    q.head   = 0;
+    q.count  = 0;
+    q.seq    = 0;
+    q.closed = false;
+    q.live   = false;
+
+    val r: Result[*Job, str] = allocate[Job](alloc, CAPACITY);
+    if (is_err[*Job, str](r)) { ret false; }
+    q.jobs = unwrap_ok[*Job, str](r);
+    q.cap  = CAPACITY;
+    var i: usize = 0;
+    for (i < q.cap) {
+        q.jobs[i].body = nil;
+        q.jobs[i].len  = 0;
+        i = i + 1;
+    }
+    ret true;
+}
+
+# spawn the worker thread draining `q` into `f`
+#
+# `f` runs on the worker for every pushed body, in push order, one at a time.
+# ---
+# q:   the initialized queue
+# f:   per-job callback
+# fx:  opaque context handed to `f`
+# ret: true when the thread started
+pub fun start(q: *Queue, f: JobFn, fx: ptr) bool {
+    if (q.jobs == nil || q.live) { ret false; }
+    BOUND.q  = q;
+    BOUND.f  = f;
+    BOUND.fx = fx;
+    thread.spawn_with(worker_main, (?BOUND)::*u8, ?q.th);
+    if (q.th.tid < 0) { ret false; }
+    q.live = true;
+    ret true;
+}
+
+# copy `body` onto the queue and wake the worker
+#
+# The body is copied because the caller's frame owns the transport buffer and
+# reuses it for the next frame.
+# ---
+# q:    the queue
+# body: nul-terminated message body
+# len:  body length in bytes
+# ret:  true when queued; false when closed, full, or out of memory
+pub fun push(q: *Queue, body: str, len: usize) bool {
+    if (body == nil) { ret false; }
+
+    val r: Result[*u8, str] = allocate[u8](q.alloc, len + 1);
+    if (is_err[*u8, str](r)) { ret false; }
+    val copy: *u8 = unwrap_ok[*u8, str](r);
+    if (len > 0) { mem.raw_copy(copy::ptr, body::ptr, len); }
+    copy[len] = 0;
+
+    mutex.lock(?q.lock);
+    if (q.closed || q.count == q.cap) {
+        mutex.unlock(?q.lock);
+        deallocate[u8](q.alloc, copy, len + 1);
+        ret false;
+    }
+    val slot: usize = (q.head + q.count) % q.cap;
+    q.jobs[slot].body = copy::str;
+    q.jobs[slot].len  = len;
+    q.count = q.count + 1;
+    atomic.store(?q.seq, atomic.load(?q.seq) + 1);
+    mutex.unlock(?q.lock);
+
+    os.thread_wake(?q.seq);
+    ret true;
+}
+
+# refuse further pushes and wake the worker so it drains and exits
+pub fun close(q: *Queue) {
+    mutex.lock(?q.lock);
+    q.closed = true;
+    atomic.store(?q.seq, atomic.load(?q.seq) + 1);
+    mutex.unlock(?q.lock);
+    os.thread_wake(?q.seq);
+}
+
+# close the queue and wait for the worker to finish the jobs already queued
+#
+# Every accepted message is handled before this returns, so a shutdown does not
+# strand a reply the client is waiting for.
+pub fun join(q: *Queue) {
+    close(q);
+    if (q.live) {
+        thread.join(?q.th);
+        q.live = false;
+    }
+}
+
+# release the ring and any body still queued
+pub fun dnit(q: *Queue) {
+    if (q.live) { join(q); }
+    if (q.jobs == nil) { ret; }
+    var i: usize = 0;
+    for (i < q.count) {
+        val slot: usize = (q.head + i) % q.cap;
+        free_job(q, ?q.jobs[slot]);
+        i = i + 1;
+    }
+    deallocate[Job](q.alloc, q.jobs, q.cap);
+    q.jobs  = nil;
+    q.cap   = 0;
+    q.count = 0;
+}
+
+# how many messages are waiting
+#
+# A sample, not a reservation: the worker may pop between the read and its use.
+pub fun depth(q: *Queue) usize {
+    mutex.lock(?q.lock);
+    val n: usize = q.count;
+    mutex.unlock(?q.lock);
+    ret n;
+}
+
+# release one job's owned body
+fun free_job(q: *Queue, j: *Job) {
+    if (j.body != nil) { deallocate[u8](q.alloc, j.body::*u8, j.len + 1); }
+    j.body = nil;
+    j.len  = 0;
+}
+
+# take the next job, blocking until one arrives or the queue closes
+#
+# The futex word is sampled before locking so a push that lands between the
+# empty check and the sleep changes the value the sleep compares against, and
+# the sleep returns immediately instead of missing the wake.
+# ---
+# q:   the queue
+# out: receives the popped job on success
+# ret: true when a job was taken; false once the queue is closed and drained
+fun pop_blocking(q: *Queue, out: *Job) bool {
+    for (true) {
+        val sampled: i64 = atomic.load(?q.seq);
+
+        mutex.lock(?q.lock);
+        if (q.count > 0) {
+            @out = q.jobs[q.head];
+            q.jobs[q.head].body = nil;
+            q.jobs[q.head].len  = 0;
+            q.head  = (q.head + 1) % q.cap;
+            q.count = q.count - 1;
+            mutex.unlock(?q.lock);
+            ret true;
+        }
+        val done: bool = q.closed;
+        mutex.unlock(?q.lock);
+
+        if (done) { ret false; }
+        os.thread_wait(?q.seq, sampled);
+    }
+    ret false;
+}
+
+# the worker thread entry: drain the queue into the bound callback until close
+fun worker_main(arg: *u8) {
+    val b: *Bound = arg::*Bound;
+    val q: *Queue = b.q;
+    for (true) {
+        var j: Job;
+        j.body = nil;
+        j.len  = 0;
+        if (!pop_blocking(q, ?j)) { brk; }
+        if (j.body != nil) { b.f(b.fx, j.body, j.len); }
+        free_job(q, ?j);
+    }
+}
+
+use page: std.allocator.page;
+use std.types.string.str_equals;
+
+# the queue's contract is that every accepted body reaches the callback exactly
+# once and in push order, so the tests assert the sequence rather than a count
+
+var SEEN:     [64]u8;
+var SEEN_LEN: i64 = 0;
+var SEEN_SUM: i64 = 0;
+
+fun record(ctx: ptr, body: str, len: usize) {
+    if (SEEN_LEN < 64) {
+        SEEN[SEEN_LEN::usize] = body[0];
+        SEEN_LEN = SEEN_LEN + 1;
+    }
+    SEEN_SUM = SEEN_SUM + len::i64;
+}
+
+test "jobs: every pushed body reaches the worker once, in order" {
+    var pa: Allocator;
+    page.make(?pa);
+    var q: Queue;
+    if (!init(?q, ?pa)) { ret 1; }
+    SEEN_LEN = 0;
+    SEEN_SUM = 0;
+    if (!start(?q, record, nil)) { dnit(?q); ret 1; }
+
+    if (!push(?q, "a1", 2)) { dnit(?q); ret 1; }
+    if (!push(?q, "b22", 3)) { dnit(?q); ret 1; }
+    if (!push(?q, "c333", 4)) { dnit(?q); ret 1; }
+    join(?q);
+
+    var fail: bool = false;
+    if (SEEN_LEN != 3)   { fail = true; }
+    or {
+        if (SEEN[0] != 'a') { fail = true; }
+        if (SEEN[1] != 'b') { fail = true; }
+        if (SEEN[2] != 'c') { fail = true; }
+    }
+    if (SEEN_SUM != 9) { fail = true; }
+    dnit(?q);
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+# the worker must sleep on the futex rather than spin, so a queue that is
+# started and immediately joined without work still terminates
+test "jobs: an idle worker joins without any job" {
+    var pa: Allocator;
+    page.make(?pa);
+    var q: Queue;
+    if (!init(?q, ?pa)) { ret 1; }
+    SEEN_LEN = 0;
+    if (!start(?q, record, nil)) { dnit(?q); ret 1; }
+    join(?q);
+    var fail: bool = false;
+    if (SEEN_LEN != 0) { fail = true; }
+    dnit(?q);
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+# a body is copied on push, so the caller's buffer may be reused immediately
+test "jobs: a pushed body is copied, not borrowed" {
+    var pa: Allocator;
+    page.make(?pa);
+    var q: Queue;
+    if (!init(?q, ?pa)) { ret 1; }
+    SEEN_LEN = 0;
+    SEEN_SUM = 0;
+
+    var scratch: [8]u8;
+    scratch[0] = 'x';
+    scratch[1] = 'y';
+    scratch[2] = 0;
+    if (!push(?q, (?scratch[0])::str, 2)) { dnit(?q); ret 1; }
+    scratch[0] = 'z';
+
+    if (!start(?q, record, nil)) { dnit(?q); ret 1; }
+    join(?q);
+
+    var fail: bool = false;
+    if (SEEN_LEN != 1)  { fail = true; }
+    or { if (SEEN[0] != 'x') { fail = true; } }
+    dnit(?q);
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+# the bound is what stops a client from buying unbounded memory with didChange
+test "jobs: a full queue refuses a push instead of growing" {
+    var pa: Allocator;
+    page.make(?pa);
+    var q: Queue;
+    if (!init(?q, ?pa)) { ret 1; }
+
+    var fail: bool = false;
+    var i: usize = 0;
+    for (i < CAPACITY) {
+        if (!push(?q, "j", 1)) { fail = true; }
+        i = i + 1;
+    }
+    if (push(?q, "overflow", 8)) { fail = true; }
+    if (depth(?q) != CAPACITY)   { fail = true; }
+
+    dnit(?q);
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+# a closed queue accepts nothing further, so a shutdown cannot be overtaken
+test "jobs: a closed queue refuses further pushes" {
+    var pa: Allocator;
+    page.make(?pa);
+    var q: Queue;
+    if (!init(?q, ?pa)) { ret 1; }
+    close(?q);
+    var fail: bool = false;
+    if (push(?q, "late", 4)) { fail = true; }
+    dnit(?q);
+    if (fail) { ret 1; }
+    ret 0;
+}

--- a/src/json.mach
+++ b/src/json.mach
@@ -150,7 +150,7 @@ pub fun buf_push_usize(b: *Buf, value: usize) {
     or {
         for (v > 0 && pos > 0) {
             pos = pos - 1;
-            tmp[pos] = ('0' + (v % 10))::u8;
+            tmp[pos] = ('0'::usize + (v % 10))::u8;
             v = v / 10;
         }
     }
@@ -487,7 +487,7 @@ pub fun format_usize(value: usize, alloc: *Allocator) str {
     or {
         for (v > 0 && pos > 0) {
             pos = pos - 1;
-            tmp[pos] = ('0' + (v % 10))::u8;
+            tmp[pos] = ('0'::usize + (v % 10))::u8;
             v = v / 10;
         }
     }
@@ -515,7 +515,7 @@ pub fun format_i64(value: i64, alloc: *Allocator) str {
     or {
         for (v > 0 && pos > 0) {
             pos = pos - 1;
-            tmp[pos] = ('0' + (v % 10))::u8;
+            tmp[pos] = ('0'::i64 + (v % 10))::u8;
             v = v / 10;
         }
     }

--- a/src/json.mach
+++ b/src/json.mach
@@ -1,13 +1,21 @@
-# minimal JSON extraction and construction for LSP messages
+# JSON-RPC message reading and LSP payload construction
 #
-# the server never builds a full JSON tree: requests are small, flat objects
-# and the fields it needs (method, id, uri, text, version, position) are read
-# by key with a forgiving string scanner, and responses are assembled from
-# string fragments. this keeps the protocol layer dependency-free and avoids a
-# general parser the diagnostics slice does not need.
+# reading goes through `std.data.json`: a message is parsed once into a real
+# Value tree and every field is reached by navigating it. the server used to
+# scan the raw body for a quoted key, which matched that key ANYWHERE in the
+# document - including inside an opened file's own source text, which for a
+# language server is attacker-shaped input. structure, ordering, nesting, and
+# escapes are now the parser's problem, not a scanner's.
 #
-# every accessor returns owned `str` allocated from the caller's allocator (or
-# nil on miss / allocation failure); callers free with `free_str`.
+# a parsed tree borrows its string bytes from the message body and the std
+# parser has no free entry, so a message is parsed into a per-message arena
+# that `Reader` resets once the message is handled. that also retires the
+# per-field owned-string bookkeeping the scanner required.
+#
+# writing stays a `Buf` append sink: LSP payloads are shaped by the data
+# (a diagnostic's related locations, a rename's per-file edits), so the
+# fragment count is only known while emitting. string escaping is the std
+# emitter's, so a control byte or a non-ASCII identifier survives the trip.
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -20,14 +28,20 @@ use std.types.string.str_equals;
 use std.types.result.Result;
 use std.types.result.is_err;
 use std.types.result.unwrap_ok;
+use std.types.result.ok;
+use std.types.option.Option;
+use std.types.option.is_some;
 
 use std.allocator.Allocator;
 use std.allocator.allocate;
 use std.allocator.deallocate;
 use std.allocator.reallocate;
 
-use mem:  std.memory;
-use page: std.allocator.page;
+use mem:   std.memory;
+use page:  std.allocator.page;
+use arena: std.allocator.arena;
+use sj:    std.data.json;
+use writer: std.io.writer;
 
 # a growable byte buffer for assembling one JSON payload
 #
@@ -121,24 +135,33 @@ pub fun buf_push_byte(b: *Buf, ch: u8) {
     b.len = b.len + 1;
 }
 
-# append `s` as a quoted, escaped JSON string. nil renders as `""`
+# writer callback appending into the Buf behind `ctx`
+fun buf_write(ctx: ptr, p: *u8, len: usize) Result[usize, str] {
+    val b: *Buf = ctx::*Buf;
+    if (!buf_reserve(b, len)) { ret ok[usize, str](len); }
+    mem.raw_copy((b.data::usize + b.len)::ptr, p::ptr, len);
+    b.len = b.len + len;
+    ret ok[usize, str](len);
+}
+
+# a `std.io.writer` view over `b`, so the std JSON escaper can emit into it
+# ---
+# b: the buffer to wrap
+# w: writer initialized in place; borrows `b`, which must outlive it
+pub fun buf_writer(b: *Buf, w: *writer.Writer) {
+    w.ctx     = b::ptr;
+    w.f_write = buf_write;
+}
+
+# append `s` as a quoted JSON string, escaped by the std emitter
+#
+# escaping is `ESCAPE_ENSURE_ASCII`, so every emitted byte is printable ASCII
+# and a non-ASCII identifier or path survives as a `\uXXXX` escape rather than
+# raw bytes. nil renders as `""`.
 pub fun buf_push_quoted(b: *Buf, s: str) {
-    buf_push_byte(b, '"');
-    if (s == nil) { buf_push_byte(b, '"'); ret; }
-    val n: usize = str_len(s);
-    var i: usize = 0;
-    for (i < n) {
-        val ch: u8 = s[i];
-        if (ch == '"')  { buf_push(b, "\\\""); }
-        or (ch == '\\') { buf_push(b, "\\\\"); }
-        or (ch == '\n') { buf_push(b, "\\n"); }
-        or (ch == '\r') { buf_push(b, "\\r"); }
-        or (ch == '\t') { buf_push(b, "\\t"); }
-        or (ch < 32)    { buf_push_byte(b, '?'); }
-        or              { buf_push_byte(b, ch); }
-        i = i + 1;
-    }
-    buf_push_byte(b, '"');
+    var w: writer.Writer;
+    buf_writer(b, ?w);
+    sj.write_json_string(?w, s::*u8);
 }
 
 # append `value` in base 10
@@ -179,458 +202,283 @@ pub fun buf_str(b: *Buf) str {
     ret b.data::str;
 }
 
-# read the string value of `key` in `data`, decoding JSON
-# escapes. returns owned text, or nil when the key is absent or not a string
+
+# one parsed JSON-RPC message and the arena its tree lives in
+#
+# `root` borrows string bytes from the body the caller still owns, so the body
+# must outlive the Message. `arena_reset` releases the tree.
 # ---
-# data:  JSON text to scan
-# key:   quoted key to find, e.g. `"method"`
-# alloc: allocator backing the returned string
-# ret:   owned decoded value, or nil
-pub fun extract_string(data: str, key: str, alloc: *Allocator) str {
-    val idx: isize = find_key(data, key);
-    if (idx < 0) { ret nil; }
-
-    val data_len: usize = str_len(data);
-    val key_len: usize = str_len(key);
-    var pos: usize = (idx::usize) + key_len;
-
-    pos = skip_ws(data, pos);
-    if (pos >= data_len || data[pos] != ':') { ret nil; }
-    pos = pos + 1;
-
-    pos = skip_ws(data, pos);
-    if (pos >= data_len || data[pos] != '"') { ret nil; }
-    pos = pos + 1;
-
-    var scan: usize = pos;
-    var out_len: usize = 0;
-    for (scan < data_len) {
-        val ch: u8 = data[scan];
-        if (ch == '\\') { scan = scan + 2; out_len = out_len + 1; }
-        or (ch == '"') { brk; }
-        or { scan = scan + 1; out_len = out_len + 1; }
-    }
-    if (scan >= data_len) { ret nil; }
-    if (out_len == 0) { ret nil; }
-
-    val r: Result[*u8, str] = allocate[u8](alloc, out_len + 1);
-    if (is_err[*u8, str](r)) { ret nil; }
-    val buf: *u8 = unwrap_ok[*u8, str](r);
-
-    scan = pos;
-    var w: usize = 0;
-    for (scan < data_len && w < out_len) {
-        val ch: u8 = data[scan];
-        if (ch == '\\') {
-            scan = scan + 1;
-            if (scan >= data_len) { brk; }
-            val esc: u8 = data[scan];
-            if (esc == 'n')  { buf[w] = '\n'; }
-            or (esc == 'r')  { buf[w] = '\r'; }
-            or (esc == 't')  { buf[w] = '\t'; }
-            or (esc == '"')  { buf[w] = '"'; }
-            or (esc == '\\') { buf[w] = '\\'; }
-            or (esc == '/')  { buf[w] = '/'; }
-            or               { buf[w] = esc; }
-            scan = scan + 1;
-            w = w + 1;
-        }
-        or (ch == '"') { brk; }
-        or { buf[w] = ch; scan = scan + 1; w = w + 1; }
-    }
-
-    buf[w] = 0;
-    ret buf::str;
+# root:   parsed root value; an object for any well-formed message
+# valid:  whether the body parsed at all
+pub rec Message {
+    root:  sj.Value;
+    valid: bool;
 }
 
-# read the raw token of `key` (a quoted string copied verbatim, or
-# a bare number / literal). returns owned text, or nil on miss
+# a reusable per-message parse arena
+#
+# one server owns one Reader. `read` parses a body into it, `release` rolls the
+# arena back so the next message reuses the same chunks instead of allocating.
 # ---
-# data:  JSON text to scan
-# key:   quoted key to find
-# alloc: allocator backing the returned string
-# ret:   owned raw token, or nil
-pub fun extract_raw(data: str, key: str, alloc: *Allocator) str {
-    val idx: isize = find_key(data, key);
-    if (idx < 0) { ret nil; }
-
-    val data_len: usize = str_len(data);
-    val key_len: usize = str_len(key);
-    var pos: usize = (idx::usize) + key_len;
-
-    pos = skip_ws(data, pos);
-    if (pos >= data_len || data[pos] != ':') { ret nil; }
-    pos = pos + 1;
-
-    pos = skip_ws(data, pos);
-    if (pos >= data_len) { ret nil; }
-    val start: usize = pos;
-
-    if (data[pos] == '"') {
-        pos = pos + 1;
-        for (pos < data_len) {
-            val ch: u8 = data[pos];
-            if (ch == '\\') { pos = pos + 2; }
-            or (ch == '"') { pos = pos + 1; brk; }
-            or { pos = pos + 1; }
-        }
-        ret copy_range(data, start, pos, alloc);
-    }
-
-    for (pos < data_len) {
-        val ch: u8 = data[pos];
-        if (ch == ',' || ch == '}' || ch == ']' ||
-            ch == ' ' || ch == '\t' || ch == '\r' || ch == '\n') { brk; }
-        pos = pos + 1;
-    }
-    if (pos == start) { ret nil; }
-    ret copy_range(data, start, pos, alloc);
+# ar:    the arena backing every parsed tree
+# ready: whether `ar` was initialized
+pub rec Reader {
+    ar:    arena.Arena;
+    ready: bool;
 }
 
-# read the integer value of `key`, or 0 when absent
+# seed capacity for the message arena, sized so an ordinary request parses
+# without growing
+val READER_ARENA_CAP: usize = 64 * 1024;
+
+# construct a message reader over `backing`
 # ---
-# data:  JSON text to scan
-# key:   quoted key to find
-# alloc: scratch allocator (the raw token is freed before return)
-# ret:   the parsed integer, or 0
-pub fun extract_number_i64(data: str, key: str, alloc: *Allocator) i64 {
-    val raw: str = extract_raw(data, key, alloc);
-    if (raw == nil) { ret 0; }
-    val result: i64 = parse_i64(raw);
-    free_str(raw, alloc);
-    ret result;
-}
-
-# the tail of `data` starting just past the first occurrence of
-# `anchor` as an object key, or nil when the anchor is absent or ends the text.
-# the shared prologue of the *_after accessors; the returned pointer borrows
-# `data`
-fun seek_after(data: str, anchor: str) str {
-    val idx: isize = find_key(data, anchor);
-    if (idx < 0) { ret nil; }
-    val offset: usize = (idx::usize) + str_len(anchor);
-    if (offset >= str_len(data)) { ret nil; }
-    ret (data::usize + offset)::str;
-}
-
-# read string `key` that appears after the first occurrence of
-# `anchor` (scopes a key lookup to a nested object whose opening key is known)
-# ---
-# data:   JSON text to scan
-# anchor: quoted key marking where to start scanning
-# key:    quoted key to read after the anchor
-# alloc:  allocator backing the returned string
-# ret:    owned decoded value, or nil
-pub fun extract_after(data: str, anchor: str, key: str, alloc: *Allocator) str {
-    val sub: str = seek_after(data, anchor);
-    if (sub == nil) { ret nil; }
-    ret extract_string(sub, key, alloc);
-}
-
-# read integer `key` after `anchor`, or 0 on miss
-# ---
-# data:   JSON text to scan
-# anchor: quoted key marking where to start scanning
-# key:    quoted key to read after the anchor
-# alloc:  scratch allocator
-# ret:    the parsed integer, or 0
-pub fun extract_number_after(data: str, anchor: str, key: str, alloc: *Allocator) i64 {
-    val sub: str = seek_after(data, anchor);
-    if (sub == nil) { ret 0; }
-    ret extract_number_i64(sub, key, alloc);
-}
-
-# decode the string value of the `index`-th occurrence of
-# `key` in `data` (0-based), or nil when there are fewer than index+1
-# occurrences. lets a caller iterate a repeated key - e.g. every `"uri"` in a
-# `workspace/didChangeWatchedFiles` changes array - by bumping `index` until nil
-# ---
-# data:  JSON text to scan
-# key:   quoted key to find, e.g. `"uri"`
-# index: zero-based occurrence to read
-# alloc: allocator backing the returned string
-# ret:   owned decoded value, or nil
-pub fun extract_string_seq(data: str, key: str, index: u32, alloc: *Allocator) str {
-    var sub: str = data;
-    var i: u32 = 0;
-    for (i < index) {
-        sub = seek_after(sub, key);
-        if (sub == nil) { ret nil; }
-        i = i + 1;
-    }
-    ret extract_string(sub, key, alloc);
-}
-
-# whether the boolean `key` inside the object value of
-# `anchor` is the literal `true`. the scan is scoped to the anchor's balanced
-# object, so an equally-named key in a later sibling object is never misread -
-# e.g. another capability's `dynamicRegistration` after an empty
-# `"didChangeWatchedFiles":{}`. false when the anchor is absent, its value is
-# not an object, or the key is absent / non-true, so a missing capability reads
-# as unsupported
-# ---
-# data:   JSON text to scan
-# anchor: quoted key whose object value scopes the lookup
-# key:    quoted boolean key to read inside the anchor's object
-# alloc:  scratch allocator (the window and raw token are freed before return)
-# ret:    true only when the value is the literal `true`
-pub fun extract_bool_after(data: str, anchor: str, key: str, alloc: *Allocator) bool {
-    val sub: str = seek_after(data, anchor);
-    if (sub == nil) { ret false; }
-    val sub_len: usize = str_len(sub);
-    var pos: usize = skip_ws(sub, 0);
-    if (pos >= sub_len || sub[pos] != ':') { ret false; }
-    pos = skip_ws(sub, pos + 1);
-    if (pos >= sub_len || sub[pos] != '{') { ret false; }
-    val end: usize = object_end(sub, pos);
-    if (end == 0) { ret false; }
-
-    val window: str = copy_range(sub, pos, end, alloc);
-    if (window == nil) { ret false; }
-    val raw: str = extract_raw(window, key, alloc);
-    var is_true: bool = false;
-    if (raw != nil) {
-        is_true = str_equals(raw, "true");
-        free_str(raw, alloc);
-    }
-    free_str(window, alloc);
-    ret is_true;
-}
-
-# the index one past the matching `}` of the `{` at `start`,
-# skipping string contents, or 0 when the object is unbalanced
-fun object_end(data: str, start: usize) usize {
-    val n: usize = str_len(data);
-    var depth: usize = 0;
-    var in_str: bool = false;
-    var i: usize = start;
-    for (i < n) {
-        val c: u8 = data[i];
-        if (in_str) {
-            if (c == '\\') { i = i + 2; }
-            or {
-                if (c == '"') { in_str = false; }
-                i = i + 1;
-            }
-        }
-        or {
-            if (c == '"')  { in_str = true; }
-            or (c == '{')  { depth = depth + 1; }
-            or (c == '}')  {
-                depth = depth - 1;
-                if (depth == 0) { ret i + 1; }
-            }
-            i = i + 1;
-        }
-    }
-    ret 0;
-}
-
-# JSON-encode `s` as a quoted, escaped string literal (including the
-# surrounding quotes). returns owned text, or nil on allocation failure
-# ---
-# s:     raw text to encode
-# alloc: allocator backing the returned string
-# ret:   owned quoted literal, or nil
-pub fun quote(s: str, alloc: *Allocator) str {
-    var s_len: usize = 0;
-    if (s != nil) { s_len = str_len(s); }
-
-    var encoded_len: usize = 2;
-    var i: usize = 0;
-    for (i < s_len) {
-        val ch: u8 = s[i];
-        if (ch == '"' || ch == '\\' || ch == '\n' || ch == '\r' || ch == '\t') {
-            encoded_len = encoded_len + 2;
-        }
-        or { encoded_len = encoded_len + 1; }
-        i = i + 1;
-    }
-
-    val r: Result[*u8, str] = allocate[u8](alloc, encoded_len + 1);
-    if (is_err[*u8, str](r)) { ret nil; }
-    val buf: *u8 = unwrap_ok[*u8, str](r);
-
-    var pos: usize = 0;
-    buf[pos] = '"';
-    pos = pos + 1;
-
-    i = 0;
-    for (i < s_len) {
-        val ch: u8 = s[i];
-        if (ch == '"')        { buf[pos] = '\\'; buf[pos + 1] = '"';  pos = pos + 2; }
-        or (ch == '\\')       { buf[pos] = '\\'; buf[pos + 1] = '\\'; pos = pos + 2; }
-        or (ch == '\n')       { buf[pos] = '\\'; buf[pos + 1] = 'n';  pos = pos + 2; }
-        or (ch == '\r')       { buf[pos] = '\\'; buf[pos + 1] = 'r';  pos = pos + 2; }
-        or (ch == '\t')       { buf[pos] = '\\'; buf[pos + 1] = 't';  pos = pos + 2; }
-        or (ch < 32)          { buf[pos] = '?';  pos = pos + 1; }
-        or                    { buf[pos] = ch;   pos = pos + 1; }
-        i = i + 1;
-    }
-
-    buf[pos] = '"';
-    pos = pos + 1;
-    buf[pos] = 0;
-    ret buf::str;
-}
-
-# render `value` in base 10. returns owned text, or nil on failure
-# ---
-# value: number to render
-# alloc: allocator backing the returned string
-# ret:   owned decimal text, or nil
-pub fun format_usize(value: usize, alloc: *Allocator) str {
-    var tmp: [20]u8;
-    var pos: usize = 20;
-    var v: usize = value;
-    if (v == 0) { pos = pos - 1; tmp[pos] = '0'; }
-    or {
-        for (v > 0 && pos > 0) {
-            pos = pos - 1;
-            tmp[pos] = ('0'::usize + (v % 10))::u8;
-            v = v / 10;
-        }
-    }
-    val len: usize = 20 - pos;
-    val r: Result[*u8, str] = allocate[u8](alloc, len + 1);
-    if (is_err[*u8, str](r)) { ret nil; }
-    val buf: *u8 = unwrap_ok[*u8, str](r);
-    mem.raw_copy(buf::ptr, (?tmp[pos])::ptr, len);
-    buf[len] = 0;
-    ret buf::str;
-}
-
-# render `value` in base 10 with a leading sign for negatives
-# ---
-# value: number to render
-# alloc: allocator backing the returned string
-# ret:   owned decimal text, or nil
-pub fun format_i64(value: i64, alloc: *Allocator) str {
-    var tmp: [21]u8;
-    var pos: usize = 21;
-    var negative: bool = false;
-    var v: i64 = value;
-    if (v < 0) { negative = true; v = -v; }
-    if (v == 0) { pos = pos - 1; tmp[pos] = '0'; }
-    or {
-        for (v > 0 && pos > 0) {
-            pos = pos - 1;
-            tmp[pos] = ('0'::i64 + (v % 10))::u8;
-            v = v / 10;
-        }
-    }
-    if (negative && pos > 0) { pos = pos - 1; tmp[pos] = '-'; }
-    val len: usize = 21 - pos;
-    val r: Result[*u8, str] = allocate[u8](alloc, len + 1);
-    if (is_err[*u8, str](r)) { ret nil; }
-    val buf: *u8 = unwrap_ok[*u8, str](r);
-    mem.raw_copy(buf::ptr, (?tmp[pos])::ptr, len);
-    buf[len] = 0;
-    ret buf::str;
-}
-
-# release a string returned by this module
-# ---
-# s:     string to free; nil is a no-op
-# alloc: allocator the string was allocated from
-pub fun free_str(s: str, alloc: *Allocator) {
-    if (s == nil) { ret; }
-    val len: usize = str_len(s);
-    deallocate[u8](alloc, s::*u8, len + 1);
-}
-
-# byte offset of the opening quote of `key` as an object key in
-# `data` (a `"key"` token outside any string value), or -1 when absent
-fun find_key(data: str, key: str) isize {
-    val key_len: usize = str_len(key);
-    val data_len: usize = str_len(data);
-    if (key_len == 0 || key_len > data_len) { ret -1; }
-
-    var in_string: bool = false;
-    var i: usize = 0;
-    val limit: usize = data_len - key_len;
-    for (i <= limit) {
-        val ch: u8 = data[i];
-        if (ch == '"' && !is_escaped(data, i)) {
-            if (!in_string) {
-                if (match_at(data, i, key)) { ret i::isize; }
-                in_string = true;
-            }
-            or { in_string = false; }
-        }
-        i = i + 1;
-    }
-    ret -1;
-}
-
-# whether the byte at `index` is preceded by an odd run of backslashes
-fun is_escaped(data: str, index: usize) bool {
-    if (index == 0) { ret false; }
-    var back: usize = index - 1;
-    var count: usize = 0;
-    for {
-        if (data[back] != '\\') { brk; }
-        count = count + 1;
-        if (back == 0) { brk; }
-        back = back - 1;
-    }
-    ret (count & 1) == 1;
-}
-
-# whether `pattern` occurs verbatim at `offset` in `data`
-fun match_at(data: str, offset: usize, pattern: str) bool {
-    val pattern_len: usize = str_len(pattern);
-    val data_len: usize = str_len(data);
-    if (offset + pattern_len > data_len) { ret false; }
-    var i: usize = 0;
-    for (i < pattern_len) {
-        if (data[offset + i] != pattern[i]) { ret false; }
-        i = i + 1;
-    }
+# rd:      reader to initialize
+# backing: allocator the arena draws chunks from; must outlive the reader
+# ret:     true when the arena was created
+pub fun reader_init(rd: *Reader, backing: *Allocator) bool {
+    rd.ready = false;
+    var opt: Option[*u8] = arena.init(?rd.ar, backing, READER_ARENA_CAP);
+    if (is_some[*u8](opt)) { ret false; }
+    rd.ready = true;
     ret true;
 }
 
-# advance past JSON whitespace starting at `pos`
-fun skip_ws(data: str, pos: usize) usize {
-    val data_len: usize = str_len(data);
-    var p: usize = pos;
-    for (p < data_len) {
-        val ch: u8 = data[p];
-        if (ch != ' ' && ch != '\t' && ch != '\r' && ch != '\n') { brk; }
-        p = p + 1;
-    }
-    ret p;
+# release the reader's arena
+pub fun reader_dnit(rd: *Reader) {
+    if (!rd.ready) { ret; }
+    arena.dnit(?rd.ar);
+    rd.ready = false;
 }
 
-# parse a leading optionally-signed decimal integer from `s`
-fun parse_i64(s: str) i64 {
-    if (s == nil) { ret 0; }
-    val s_len: usize = str_len(s);
-    if (s_len == 0) { ret 0; }
-    var pos: usize = 0;
-    var negative: bool = false;
-    if (s[pos] == '-') { negative = true; pos = pos + 1; }
-    var result: i64 = 0;
-    for (pos < s_len) {
-        val ch: u8 = s[pos];
-        if (ch >= '0' && ch <= '9') { result = result * 10 + ((ch - '0')::i64); }
-        or { brk; }
-        pos = pos + 1;
-    }
-    if (negative) { ret -result; }
-    ret result;
+# the reader's arena as an Allocator, for values that live as long as the message
+# ---
+# rd:  the reader
+# ret: the arena allocator, or nil when the reader failed to initialize
+pub fun reader_alloc(rd: *Reader) *Allocator {
+    if (!rd.ready) { ret nil; }
+    ret ?rd.ar.backing;
 }
 
-# owned copy of `data[start..end)`, nil-terminated
-fun copy_range(data: str, start: usize, end: usize, alloc: *Allocator) str {
-    val len: usize = end - start;
-    if (len == 0) { ret nil; }
-    val r: Result[*u8, str] = allocate[u8](alloc, len + 1);
-    if (is_err[*u8, str](r)) { ret nil; }
-    val buf: *u8 = unwrap_ok[*u8, str](r);
-    mem.raw_copy(buf::ptr, (data::usize + start)::ptr, len);
-    buf[len] = 0;
+# parse one message body into the reader's arena
+#
+# `body` is borrowed: the returned tree points into it and stays valid until
+# `release`. an unparseable body yields a Message with `valid` false, which the
+# caller answers with a JSON-RPC parse error rather than ignoring.
+# ---
+# rd:   the reader owning the arena
+# body: nul-terminated message body, retained by the caller
+# len:  body length in bytes
+# ret:  the parsed message
+pub fun read(rd: *Reader, body: str, len: usize) Message {
+    var m: Message;
+    m.valid = false;
+    if (!rd.ready || body == nil) { ret m; }
+    var a: Allocator;
+    arena.make(?a, ?rd.ar);
+    val r: Result[sj.Value, str] = sj.parse(body::*u8, len, ?a);
+    if (is_err[sj.Value, str](r)) { ret m; }
+    m.root  = unwrap_ok[sj.Value, str](r);
+    m.valid = true;
+    ret m;
+}
+
+# roll the arena back, retiring every tree parsed since the last release
+pub fun release(rd: *Reader) {
+    if (!rd.ready) { ret; }
+    arena.reset(?rd.ar);
+}
+
+# the object member `key` of `v`, or nil when absent or `v` is not an object
+# ---
+# v:   value to read
+# key: member name
+# ret: borrowed member value, or nil
+pub fun member(v: *sj.Value, key: str) *sj.Value {
+    if (v == nil) { ret nil; }
+    ret sj.value_find(v, key);
+}
+
+# the member `key` of the member `outer` of `v`, or nil at any miss
+# ---
+# v:     value to read
+# outer: outer member name
+# key:   inner member name
+# ret:   borrowed member value, or nil
+pub fun member2(v: *sj.Value, outer: str, key: str) *sj.Value {
+    ret member(member(v, outer), key);
+}
+
+# the `index`-th element of array `v`, or nil when out of range
+pub fun element(v: *sj.Value, index: usize) *sj.Value {
+    if (v == nil || !sj.value_is_array(v)) { ret nil; }
+    ret sj.value_get(v, index);
+}
+
+# the number of elements in array or object `v`, 0 for anything else
+pub fun count(v: *sj.Value) usize {
+    if (v == nil) { ret 0; }
+    ret sj.value_count(v);
+}
+
+# whether `v` is present and JSON null
+pub fun is_null(v: *sj.Value) bool {
+    if (v == nil) { ret false; }
+    ret sj.value_is_null(v);
+}
+
+# the decoded text of string value `v`, allocated from `alloc`
+#
+# JSON escapes are resolved, so the result is the logical text the client sent.
+# nil when `v` is absent or not a string.
+# ---
+# v:     value to decode
+# alloc: allocator backing the returned string
+# ret:   owned nul-terminated text, or nil
+pub fun text(v: *sj.Value, alloc: *Allocator) str {
+    if (v == nil || !sj.value_is_string(v)) { ret nil; }
+    val sr: Result[usize, str] = sj.value_string_decode(v, nil, 0);
+    if (is_err[usize, str](sr)) { ret nil; }
+    val n: usize = unwrap_ok[usize, str](sr);
+    val br: Result[*u8, str] = allocate[u8](alloc, n + 1);
+    if (is_err[*u8, str](br)) { ret nil; }
+    val buf: *u8 = unwrap_ok[*u8, str](br);
+    val dr: Result[usize, str] = sj.value_string_decode(v, buf, n);
+    if (is_err[usize, str](dr)) { deallocate[u8](alloc, buf, n + 1); ret nil; }
+    buf[n] = 0;
     ret buf::str;
+}
+
+# the integer value of number `v`, or `fallback` when absent or not a number
+pub fun number(v: *sj.Value, fallback: i64) i64 {
+    if (v == nil || !sj.value_is_number(v)) { ret fallback; }
+    ret sj.value_number(v);
+}
+
+# the boolean value of `v`, or `fallback` when absent or not a boolean
+pub fun boolean(v: *sj.Value, fallback: bool) bool {
+    if (v == nil || !sj.value_is_bool(v)) { ret fallback; }
+    ret sj.value_bool(v);
+}
+
+# whether string value `v` equals `s` after decoding
+#
+# compares against the DECODED text, so a client that escapes an ASCII byte in
+# a method name still matches.
+# ---
+# v:     value to compare
+# s:     expected text
+# alloc: scratch allocator for the decode
+# ret:   true when `v` is a string equal to `s`
+pub fun text_equals(v: *sj.Value, s: str, alloc: *Allocator) bool {
+    val got: str = text(v, alloc);
+    if (got == nil) { ret false; }
+    val eq: bool = str_equals(got, s);
+    free_str(got, alloc);
+    ret eq;
+}
+
+# append a JSON-RPC id verbatim, preserving its wire type
+#
+# an id is a string, an integer, or null, and the response MUST echo the type
+# the request used. a parsed string's bytes are already wire-escaped, so they
+# are re-emitted as-is rather than decoded and re-escaped.
+# ---
+# b:  buffer to append to
+# id: the request's id value, or nil for a message that carried none
+pub fun buf_push_id(b: *Buf, id: *sj.Value) {
+    if (id == nil) { buf_push(b, "null"); ret; }
+    if (sj.value_is_string(id)) {
+        var n: usize = 0;
+        val raw: *u8 = sj.value_string(id, ?n);
+        buf_push_byte(b, '"');
+        if (raw != nil && n > 0) {
+            if (buf_reserve(b, n)) {
+                mem.raw_copy((b.data::usize + b.len)::ptr, raw::ptr, n);
+                b.len = b.len + n;
+            }
+        }
+        buf_push_byte(b, '"');
+        ret;
+    }
+    if (sj.value_is_number(id)) { buf_push_i64(b, sj.value_number(id)); ret; }
+    buf_push(b, "null");
+}
+
+# release a string returned by `text`
+# ---
+# s:     the string to release; nil is a no-op
+# alloc: the allocator it was taken from
+pub fun free_str(s: str, alloc: *Allocator) {
+    if (s == nil) { ret; }
+    deallocate[u8](alloc, s::*u8, str_len(s) + 1);
+}
+
+# `s` as an owned, quoted, escaped JSON string literal
+#
+# the allocating counterpart to `buf_push_quoted`, for the fragment-assembled
+# payloads that still size themselves before filling.
+# ---
+# s:     the text to quote; nil renders as `""`
+# alloc: allocator backing the result
+# ret:   owned nul-terminated literal including its quotes, or nil
+pub fun quote(s: str, alloc: *Allocator) str {
+    var b: Buf = buf_init(alloc);
+    buf_push_quoted(?b, s);
+    val view: str = buf_str(?b);
+    if (view == nil) { buf_dnit(?b); ret nil; }
+    val n: usize = str_len(view);
+    val r: Result[*u8, str] = allocate[u8](alloc, n + 1);
+    if (is_err[*u8, str](r)) { buf_dnit(?b); ret nil; }
+    val out: *u8 = unwrap_ok[*u8, str](r);
+    if (n > 0) { mem.raw_copy(out::ptr, view::ptr, n); }
+    out[n] = 0;
+    buf_dnit(?b);
+    ret out::str;
+}
+
+# `value` rendered in base 10 as an owned string
+pub fun format_usize(value: usize, alloc: *Allocator) str {
+    var b: Buf = buf_init(alloc);
+    buf_push_usize(?b, value);
+    ret buf_take(?b, alloc);
+}
+
+# `value` rendered in base 10 as an owned string, with a sign for negatives
+pub fun format_i64(value: i64, alloc: *Allocator) str {
+    var b: Buf = buf_init(alloc);
+    buf_push_i64(?b, value);
+    ret buf_take(?b, alloc);
+}
+
+# copy a buffer's contents into a fresh owned string and release the buffer
+fun buf_take(b: *Buf, alloc: *Allocator) str {
+    val view: str = buf_str(b);
+    if (view == nil) { buf_dnit(b); ret nil; }
+    val n: usize = str_len(view);
+    val r: Result[*u8, str] = allocate[u8](alloc, n + 1);
+    if (is_err[*u8, str](r)) { buf_dnit(b); ret nil; }
+    val out: *u8 = unwrap_ok[*u8, str](r);
+    if (n > 0) { mem.raw_copy(out::ptr, view::ptr, n); }
+    out[n] = 0;
+    buf_dnit(b);
+    ret out::str;
+}
+
+# a request id rendered as its JSON token text, owned by `alloc`
+#
+# the response must echo the id with the wire type the request used, and the
+# fragment-assembled replies splice it in as text. nil when the message carried
+# no id, which marks a notification the server owes no response.
+# ---
+# id:    the request's id value, or nil
+# alloc: allocator backing the result
+# ret:   owned token text (`"abc"`, `7`, `null`), or nil when there is no id
+pub fun id_text(id: *sj.Value, alloc: *Allocator) str {
+    if (id == nil) { ret nil; }
+    var b: Buf = buf_init(alloc);
+    buf_push_id(?b, id);
+    ret buf_take(?b, alloc);
 }
 
 # --- Buf ---
@@ -680,7 +528,6 @@ test "json: content survives growth past the initial capacity" {
     if (s == nil)               { fail = true; }
     or {
         if (str_len(s) != 2000) { fail = true; }
-        # spot-check both ends and the first doubling boundary
         if (s[0] != 'x')        { fail = true; }
         if (s[1] != 'y')        { fail = true; }
         if (s[256] != 'x')      { fail = true; }
@@ -691,7 +538,9 @@ test "json: content survives growth past the initial capacity" {
     ret 0;
 }
 
-test "json: buf_push_quoted escapes the JSON control set" {
+# escaping is the std emitter's, so a control byte survives as an escape rather
+# than the `?` placeholder the hand-rolled escaper substituted
+test "json: buf_push_quoted escapes the JSON control set losslessly" {
     var pa: Allocator;
     page.make(?pa);
     var b: Buf = buf_init(?pa);
@@ -703,8 +552,6 @@ test "json: buf_push_quoted escapes the JSON control set" {
     ret 0;
 }
 
-# a nil string is a valid JSON value only as `""` - a diagnostic's optional
-# `related` label arrives nil and the protocol requires a string there
 test "json: buf_push_quoted renders nil as an empty JSON string" {
     var pa: Allocator;
     page.make(?pa);
@@ -722,32 +569,168 @@ test "json: numbers render in base 10 with a sign only where negative" {
     page.make(?pa);
     var b: Buf = buf_init(?pa);
     buf_push_usize(?b, 0);
-    buf_push_byte(?b, ',');
-    buf_push_usize(?b, 1234);
-    buf_push_byte(?b, ',');
-    buf_push_i64(?b, -7);
-    buf_push_byte(?b, ',');
+    buf_push_byte(?b, ' ');
+    buf_push_i64(?b, -42);
+    buf_push_byte(?b, ' ');
     buf_push_i64(?b, 42);
     var fail: bool = false;
-    if (!str_equals(buf_str(?b), "0,1234,-7,42")) { fail = true; }
+    if (!str_equals(buf_str(?b), "0 -42 42")) { fail = true; }
     buf_dnit(?b);
     if (fail) { ret 1; }
     ret 0;
 }
 
-# the failure latch is what lets callers check once at the end instead of at
-# every push, so a latched buffer must stay latched and read as nil
-test "json: a failed Buf latches and reads nil" {
+# --- reading ---
+
+# the scanner this replaced looked for a quoted key ANYWHERE in the body, so a
+# key spelled inside an opened file's own source text could win over the real
+# envelope member. a language server is handed exactly that input on didOpen
+test "json: a key spelled inside a string value never shadows a real member" {
     var pa: Allocator;
     page.make(?pa);
-    var b: Buf = buf_init(?pa);
-    buf_push(?b, "kept");
-    b.failed = true;
-    buf_push(?b, "dropped");
+    var rd: Reader;
+    if (!reader_init(?rd, ?pa)) { ret 1; }
+    val body: str = "{\"jsonrpc\":\"2.0\",\"params\":{\"text\":\"val s = \\\"method\\\": fake;\"},\"method\":\"textDocument/didOpen\"}";
+    var m: Message = read(?rd, body, str_len(body));
     var fail: bool = false;
-    if (b.len != 4)          { fail = true; }
-    if (buf_str(?b) != nil)  { fail = true; }
-    buf_dnit(?b);
+    if (!m.valid) { fail = true; }
+    or {
+        val method: str = text(member(?m.root, "method"), ?pa);
+        if (method == nil)                                    { fail = true; }
+        or {
+            if (!str_equals(method, "textDocument/didOpen"))  { fail = true; }
+            free_str(method, ?pa);
+        }
+    }
+    release(?rd);
+    reader_dnit(?rd);
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+test "json: member2 walks one level and misses report nil" {
+    var pa: Allocator;
+    page.make(?pa);
+    var rd: Reader;
+    if (!reader_init(?rd, ?pa)) { ret 1; }
+    val body: str = "{\"textDocument\":{\"uri\":\"file:///a.mach\",\"version\":7}}";
+    var m: Message = read(?rd, body, str_len(body));
+    var fail: bool = false;
+    if (!m.valid) { fail = true; }
+    or {
+        val uri: str = text(member2(?m.root, "textDocument", "uri"), ?pa);
+        if (uri == nil)                                 { fail = true; }
+        or {
+            if (!str_equals(uri, "file:///a.mach"))     { fail = true; }
+            free_str(uri, ?pa);
+        }
+        if (number(member2(?m.root, "textDocument", "version"), -1) != 7) { fail = true; }
+        if (member2(?m.root, "textDocument", "absent") != nil)            { fail = true; }
+        if (member2(?m.root, "absent", "uri") != nil)                     { fail = true; }
+    }
+    release(?rd);
+    reader_dnit(?rd);
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+test "json: string escapes in a value decode to their logical bytes" {
+    var pa: Allocator;
+    page.make(?pa);
+    var rd: Reader;
+    if (!reader_init(?rd, ?pa)) { ret 1; }
+    val body: str = "{\"text\":\"a\\nb\\tc\\\"d\"}";
+    var m: Message = read(?rd, body, str_len(body));
+    var fail: bool = false;
+    if (!m.valid) { fail = true; }
+    or {
+        val v: str = text(member(?m.root, "text"), ?pa);
+        if (v == nil)                        { fail = true; }
+        or {
+            if (!str_equals(v, "a\nb\tc\"d")) { fail = true; }
+            free_str(v, ?pa);
+        }
+    }
+    release(?rd);
+    reader_dnit(?rd);
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+# a response must echo the request id with the type it arrived as; a string id
+# is re-emitted from its wire bytes rather than decoded and re-escaped
+test "json: an id round-trips with its wire type preserved" {
+    var pa: Allocator;
+    page.make(?pa);
+    var rd: Reader;
+    if (!reader_init(?rd, ?pa)) { ret 1; }
+    var fail: bool = false;
+
+    val numeric: str = "{\"id\":12}";
+    var mn: Message = read(?rd, numeric, str_len(numeric));
+    val tn: str = id_text(member(?mn.root, "id"), ?pa);
+    if (tn == nil)                { fail = true; }
+    or { if (!str_equals(tn, "12")) { fail = true; } free_str(tn, ?pa); }
+
+    val quoted: str = "{\"id\":\"mls/registerWatchers\"}";
+    var mq: Message = read(?rd, quoted, str_len(quoted));
+    val tq: str = id_text(member(?mq.root, "id"), ?pa);
+    if (tq == nil)                { fail = true; }
+    or { if (!str_equals(tq, "\"mls/registerWatchers\"")) { fail = true; } free_str(tq, ?pa); }
+
+    val nulled: str = "{\"id\":null}";
+    var mz: Message = read(?rd, nulled, str_len(nulled));
+    val tz: str = id_text(member(?mz.root, "id"), ?pa);
+    if (tz == nil)                  { fail = true; }
+    or { if (!str_equals(tz, "null")) { fail = true; } free_str(tz, ?pa); }
+
+    # a notification carries no id and must not be answered
+    val notif: str = "{\"method\":\"exit\"}";
+    var mv: Message = read(?rd, notif, str_len(notif));
+    if (id_text(member(?mv.root, "id"), ?pa) != nil) { fail = true; }
+
+    release(?rd);
+    reader_dnit(?rd);
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+test "json: a malformed body reports invalid rather than a partial tree" {
+    var pa: Allocator;
+    page.make(?pa);
+    var rd: Reader;
+    if (!reader_init(?rd, ?pa)) { ret 1; }
+    var fail: bool = false;
+    val truncated: str = "{\"method\":\"initialize\"";
+    var m: Message = read(?rd, truncated, str_len(truncated));
+    if (m.valid) { fail = true; }
+    val trailing: str = "{\"a\":1} garbage";
+    var m2: Message = read(?rd, trailing, str_len(trailing));
+    if (m2.valid) { fail = true; }
+    release(?rd);
+    reader_dnit(?rd);
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+# the arena is what makes per-message parsing affordable: releasing must return
+# the chunks rather than grow without bound across a session's messages
+test "json: releasing a message reuses the arena instead of growing it" {
+    var pa: Allocator;
+    page.make(?pa);
+    var rd: Reader;
+    if (!reader_init(?rd, ?pa)) { ret 1; }
+    val body: str = "{\"method\":\"textDocument/didChange\",\"params\":{\"a\":[1,2,3,4,5,6,7,8]}}";
+    var i: usize = 0;
+    for (i < 200) {
+        var m: Message = read(?rd, body, str_len(body));
+        if (!m.valid) { release(?rd); reader_dnit(?rd); ret 1; }
+        release(?rd);
+        i = i + 1;
+    }
+    var fail: bool = false;
+    if (rd.ar.first_chunk != rd.ar.chunk) { fail = true; }
+    reader_dnit(?rd);
     if (fail) { ret 1; }
     ret 0;
 }

--- a/src/language.mach
+++ b/src/language.mach
@@ -67,7 +67,7 @@ use project:   mls.project;
 # ---
 # interner: the session's string interner, for resolving symbol-name StrIds
 # file:     the document's SourceFile (text + line index for offset/position)
-# fid:      the document's FileId (for the type-aware field path's sema_doc)
+# sr:       compiler-owned semantic result for this exact module snapshot
 # a:        the buffer's parsed Ast
 # rr:       the buffer's ResolveResult side tables
 # own:      this buffer's module id (Symbol.origin equals it for local symbols)
@@ -75,7 +75,7 @@ use project:   mls.project;
 rec Analyzed {
     interner: *intern.Interner;
     file:     *src.SourceFile;
-    fid:      src.FileId;
+    sr:       *sema.SemaResult;
     a:        *ast.Ast;
     rr:       *res.ResolveResult;
     own:      sess.ModuleId;
@@ -159,9 +159,8 @@ fun field_hover(ws: *project.Workspace, alloc: *Allocator, an: *Analyzed, offset
     if (!is_some[features.FieldRef](fo)) { ret false; }
     val fr: features.FieldRef = unwrap[features.FieldRef](fo);
 
-    val sr_r: Result[*sema.SemaResult, str] = project.sema_doc(ws, an.root, an.fid);
-    if (is_err[*sema.SemaResult, str](sr_r)) { ret false; }
-    val sr: *sema.SemaResult = unwrap_ok[*sema.SemaResult, str](sr_r);
+    val sr: *sema.SemaResult = an.sr;
+    if (sr == nil) { ret false; }
 
     val tid: type.TypeId = project.type_of(sr, fr.host);
     val rso: Option[project.RecordSite] = project.record_decl_in(ws, an.root, an.own, an.a, an.file, tid);
@@ -531,9 +530,8 @@ fun field_definition(ws: *project.Workspace, alloc: *Allocator, an: *Analyzed, u
     if (is_some[features.FieldRef](fo)) {
         val fr: features.FieldRef = unwrap[features.FieldRef](fo);
 
-        val sr_r: Result[*sema.SemaResult, str] = project.sema_doc(ws, an.root, an.fid);
-        if (is_err[*sema.SemaResult, str](sr_r)) { ret false; }
-        val sr: *sema.SemaResult = unwrap_ok[*sema.SemaResult, str](sr_r);
+        val sr: *sema.SemaResult = an.sr;
+        if (sr == nil) { ret false; }
 
         val tid: type.TypeId = project.type_of(sr, fr.host);
         val rso: Option[project.RecordSite] = project.record_decl_in(ws, an.root, an.own, an.a, an.file, tid);
@@ -667,9 +665,8 @@ fun field_target_at(ws: *project.Workspace, an: *Analyzed, offset: usize) Option
     val fo: Option[features.FieldRef] = features.field_ref_at(an.a, offset);
     if (is_some[features.FieldRef](fo)) {
         val fr: features.FieldRef = unwrap[features.FieldRef](fo);
-        val sr_r: Result[*sema.SemaResult, str] = project.sema_doc(ws, an.root, an.fid);
-        if (is_err[*sema.SemaResult, str](sr_r)) { ret none[FieldTarget](); }
-        val tid: type.TypeId = project.type_of(unwrap_ok[*sema.SemaResult, str](sr_r), fr.host);
+        if (an.sr == nil) { ret none[FieldTarget](); }
+        val tid: type.TypeId = project.type_of(an.sr, fr.host);
         val rso: Option[project.RecordSite] = project.record_decl_in(ws, an.root, an.own, an.a, an.file, tid);
         if (!is_some[project.RecordSite](rso)) { ret none[FieldTarget](); }
         val rs: project.RecordSite = unwrap[project.RecordSite](rso);
@@ -736,10 +733,9 @@ rec FieldXRef {
 # cap:   capacity of `out` (module_count + 1)
 # ret:   number of populated entries (>= 1), or 0 when the buffer cannot be typed
 fun build_field_refs(ws: *project.Workspace, an: Analyzed, uri: str, t: FieldTarget, out: *FieldXRef, cap: usize) usize {
-    val sr_r: Result[*sema.SemaResult, str] = project.sema_doc(ws, an.root, an.fid);
-    if (is_err[*sema.SemaResult, str](sr_r)) { ret 0; }
+    if (an.sr == nil) { ret 0; }
     out[0].a         = an.a;
-    out[0].sr        = unwrap_ok[*sema.SemaResult, str](sr_r);
+    out[0].sr        = an.sr;
     out[0].file      = an.file;
     out[0].uri       = uri;
     out[0].declaring = t.decl_in_buffer;
@@ -827,7 +823,7 @@ fun field_references(ws: *project.Workspace, alloc: *Allocator, an: *Analyzed, u
     val n: usize = build_field_refs(ws, @an, uri, t, refs, cap);
     if (n == 0) { deallocate[FieldXRef](alloc, refs, cap); ret false; }
 
-    emit_field_locations(ws, alloc, id_raw, refs, n, t);
+    emit_field_locations(ws, an.root, alloc, id_raw, refs, n, t);
     free_field_refs(ws, refs, n);
     deallocate[FieldXRef](alloc, refs, cap);
     ret true;
@@ -855,7 +851,7 @@ fun field_rename(ws: *project.Workspace, alloc: *Allocator, an: *Analyzed, uri: 
     val n: usize = build_field_refs(ws, @an, uri, t, refs, cap);
     if (n == 0) { deallocate[FieldXRef](alloc, refs, cap); reply_empty_edit(alloc, id_raw); ret true; }
 
-    emit_field_rename(ws, alloc, id_raw, refs, n, t, new_name);
+    emit_field_rename(ws, an.root, alloc, id_raw, refs, n, t, new_name);
     free_field_refs(ws, refs, n);
     deallocate[FieldXRef](alloc, refs, cap);
     ret true;
@@ -895,8 +891,8 @@ fun field_prepare_span(ws: *project.Workspace, an: *Analyzed, uri: str, offset: 
 # send a Location[] of every field site across `refs` (each
 # module's member-access / struct-literal sites plus the field declaration). takes
 # ownership of `id_raw` and frees it
-fun emit_field_locations(ws: *project.Workspace, alloc: *Allocator, id_raw: str, refs: *FieldXRef, nref: usize, t: FieldTarget) {
-    val ti: *type.TypeInterner = project.type_interner(ws);
+fun emit_field_locations(ws: *project.Workspace, root: *project.Root, alloc: *Allocator, id_raw: str, refs: *FieldXRef, nref: usize, t: FieldTarget) {
+    val ti: *type.TypeInterner = project.type_interner(ws, root);
     val prefix: str = "{\"jsonrpc\":\"2.0\",\"id\":";
     val mid:    str = ",\"result\":[";
     val suffix: str = "]}";
@@ -932,8 +928,8 @@ fun emit_field_locations(ws: *project.Workspace, alloc: *Allocator, id_raw: str,
 # member-access / struct-literal sites; the declaring module's entry also rewrites
 # the field declaration and the record's matching doc component. takes ownership of
 # `id_raw` and frees it
-fun emit_field_rename(ws: *project.Workspace, alloc: *Allocator, id_raw: str, refs: *FieldXRef, nref: usize, t: FieldTarget, new_name: str) {
-    val ti: *type.TypeInterner = project.type_interner(ws);
+fun emit_field_rename(ws: *project.Workspace, root: *project.Root, alloc: *Allocator, id_raw: str, refs: *FieldXRef, nref: usize, t: FieldTarget, new_name: str) {
+    val ti: *type.TypeInterner = project.type_interner(ws, root);
     val qname: str = json.quote(new_name, alloc);
     if (qname == nil) { reply_empty_edit(alloc, id_raw); ret; }
 
@@ -1388,20 +1384,34 @@ fun analyze(ws: *project.Workspace, es: *editor.EditorSession, docs: *documents.
     val doc: *documents.Document = documents.find(docs, uri);
     if (doc == nil) { ret false; }
 
-    val root: *project.Root = project.root_for(ws, uri);
-    val rr_r: Result[*res.ResolveResult, str] = project.resolve_doc(ws, root, doc.file_id);
-    if (is_err[*res.ResolveResult, str](rr_r)) { ret false; }
-    out.rr = unwrap_ok[*res.ResolveResult, str](rr_r);
-    out.a  = editor.ast_of(es, doc.file_id);
-    if (out.a == nil) { ret false; }
+    val vr: Result[project.DocumentView, str] = project.document_view(ws, doc);
+    if (!is_err[project.DocumentView, str](vr)) {
+        val v: project.DocumentView = unwrap_ok[project.DocumentView, str](vr);
+        out.rr       = v.rr;
+        out.a        = v.a;
+        out.sr       = v.sr;
+        out.interner = v.interner;
+        out.file     = v.file;
+        out.root     = v.root;
+        out.own      = v.module;
+        ret true;
+    }
+    if (project.has_project(ws, uri)) { ret false; }
 
-    val fo: Option[*src.SourceFile] = src.get(project.sources(ws), doc.file_id);
+    val rr: Result[*res.ResolveResult, str] = editor.resolve(es, doc.file_id);
+    if (is_err[*res.ResolveResult, str](rr)) { ret false; }
+    out.rr = unwrap_ok[*res.ResolveResult, str](rr);
+    out.a = editor.ast_of(es, doc.file_id);
+    if (out.a == nil) { ret false; }
+    val fo: Option[*src.SourceFile] = src.get(?es.s.sources, doc.file_id);
     if (!is_some[*src.SourceFile](fo)) { ret false; }
-    out.interner = project.interner(ws);
-    out.file     = unwrap[*src.SourceFile](fo);
-    out.fid      = doc.file_id;
-    out.root     = root;
-    out.own      = project.own_module(root, doc.file_id);
+    out.sr = nil;
+    val sr: Result[*sema.SemaResult, str] = editor.analyze(es, doc.file_id);
+    if (!is_err[*sema.SemaResult, str](sr)) { out.sr = unwrap_ok[*sema.SemaResult, str](sr); }
+    out.interner = ?es.s.interner;
+    out.file = unwrap[*src.SourceFile](fo);
+    out.root = nil;
+    out.own = doc.file_id::sess.ModuleId;
     ret true;
 }
 
@@ -2070,4 +2080,3 @@ fun free4(a: str, b: str, c: str, d: str, alloc: *Allocator) {
     json.free_str(c, alloc);
     json.free_str(d, alloc);
 }
-

--- a/src/language.mach
+++ b/src/language.mach
@@ -58,6 +58,7 @@ use sema:   mach.lang.fe.sema;
 
 use transport: mls.transport;
 use json:      mls.json;
+use sj:        std.data.json;
 use documents: mls.documents;
 use features:  mls.features;
 use positions: mls.positions;
@@ -84,12 +85,12 @@ rec Analyzed {
 
 # answer textDocument/hover with the type / declaration of the symbol at
 # the cursor, or null when the position is not on a resolved symbol
-pub fun hover(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
-    val id_raw: str = json.extract_raw(body, "\"id\"", alloc);
+pub fun hover(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, id: *sj.Value, params: *sj.Value, uri: str) {
+    val id_raw: str = json.id_text(id, alloc);
     if (id_raw == nil) { ret; }
 
     var an: Analyzed;
-    val off_o: Option[usize] = locate(ws, es, alloc, docs, body, uri, ?an);
+    val off_o: Option[usize] = locate(ws, es, alloc, docs, params, uri, ?an);
     if (!is_some[usize](off_o)) { reply_null(alloc, id_raw); ret; }
     val offset: usize = unwrap[usize](off_o);
 
@@ -462,12 +463,12 @@ fun compose_kind_name(sym: *res.Symbol, interner: *intern.Interner, alloc: *Allo
 # symbol's declaration. lands in the buffer for a local symbol and in the
 # defining dependency module's on-disk file for a cross-module one; null when
 # the position is not on a resolved symbol or its declaration cannot be located
-pub fun definition(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
-    val id_raw: str = json.extract_raw(body, "\"id\"", alloc);
+pub fun definition(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, id: *sj.Value, params: *sj.Value, uri: str) {
+    val id_raw: str = json.id_text(id, alloc);
     if (id_raw == nil) { ret; }
 
     var an: Analyzed;
-    val off_o: Option[usize] = locate(ws, es, alloc, docs, body, uri, ?an);
+    val off_o: Option[usize] = locate(ws, es, alloc, docs, params, uri, ?an);
     if (!is_some[usize](off_o)) { reply_null(alloc, id_raw); ret; }
     val offset: usize = unwrap[usize](off_o);
 
@@ -1011,12 +1012,12 @@ fun field_rename_group_json(s: *FieldXRef, ti: *type.TypeInterner, t: FieldTarge
 # the symbol at the cursor - its declaration plus every use-site across the
 # loaded project graph (the requesting buffer and every other module that
 # references the symbol). empty when the position is not on a resolved symbol
-pub fun references(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
-    val id_raw: str = json.extract_raw(body, "\"id\"", alloc);
+pub fun references(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, id: *sj.Value, params: *sj.Value, uri: str) {
+    val id_raw: str = json.id_text(id, alloc);
     if (id_raw == nil) { ret; }
 
     var an: Analyzed;
-    val off_o: Option[usize] = locate(ws, es, alloc, docs, body, uri, ?an);
+    val off_o: Option[usize] = locate(ws, es, alloc, docs, params, uri, ?an);
     if (!is_some[usize](off_o)) { reply_empty_array(alloc, id_raw); ret; }
     val offset: usize = unwrap[usize](off_o);
 
@@ -1056,15 +1057,15 @@ pub fun references(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Al
 # editor's to rewrite (whether referenced cross-module or opened as the buffer
 # itself), so those yield an empty edit. an empty edit is also returned when a
 # module-scope symbol resolves to a dependency owned by the user
-pub fun rename(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
-    val id_raw: str = json.extract_raw(body, "\"id\"", alloc);
+pub fun rename(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, id: *sj.Value, params: *sj.Value, uri: str) {
+    val id_raw: str = json.id_text(id, alloc);
     if (id_raw == nil) { ret; }
 
-    val new_name: str = json.extract_string(body, "\"newName\"", alloc);
+    val new_name: str = json.text(json.member(params, "newName"), alloc);
     if (new_name == nil) { reply_null(alloc, id_raw); ret; }
 
     var an: Analyzed;
-    val off_o: Option[usize] = locate(ws, es, alloc, docs, body, uri, ?an);
+    val off_o: Option[usize] = locate(ws, es, alloc, docs, params, uri, ?an);
     if (!is_some[usize](off_o)) { reply_empty_edit(alloc, id_raw); json.free_str(new_name, alloc); ret; }
     val offset: usize = unwrap[usize](off_o);
 
@@ -1140,12 +1141,12 @@ fun param_generic_doc_span(an: Analyzed, sym: *res.Symbol, name: str, out: *toke
 # project-owned cross-module one) or a field of a known, project-owned record, or
 # null when it is not the editor's to rename (an unresolved position, a dependency
 # symbol, or a field of a vendored record)
-pub fun prepare_rename(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
-    val id_raw: str = json.extract_raw(body, "\"id\"", alloc);
+pub fun prepare_rename(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, id: *sj.Value, params: *sj.Value, uri: str) {
+    val id_raw: str = json.id_text(id, alloc);
     if (id_raw == nil) { ret; }
 
     var an: Analyzed;
-    val off_o: Option[usize] = locate(ws, es, alloc, docs, body, uri, ?an);
+    val off_o: Option[usize] = locate(ws, es, alloc, docs, params, uri, ?an);
     if (!is_some[usize](off_o)) { reply_null(alloc, id_raw); ret; }
     val offset: usize = unwrap[usize](off_o);
 
@@ -1183,8 +1184,8 @@ fun reply_range(alloc: *Allocator, id_raw: str, file: *src.SourceFile, span: tok
 # answer textDocument/documentSymbol with a flat list of the
 # file's top-level declarations as DocumentSymbol nodes (name, kind, range,
 # selectionRange)
-pub fun document_symbol(es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
-    val id_raw: str = json.extract_raw(body, "\"id\"", alloc);
+pub fun document_symbol(es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, id: *sj.Value, params: *sj.Value, uri: str) {
+    val id_raw: str = json.id_text(id, alloc);
     if (id_raw == nil) { ret; }
 
     val d: *documents.Document = documents.find(docs, uri);
@@ -1202,8 +1203,8 @@ pub fun document_symbol(es: *editor.EditorSession, alloc: *Allocator, docs: *doc
 
 # answer textDocument/completion with the in-scope top-level names
 # (module decls, `use` aliases / imports, primitives) as CompletionItems
-pub fun completion(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
-    val id_raw: str = json.extract_raw(body, "\"id\"", alloc);
+pub fun completion(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, id: *sj.Value, params: *sj.Value, uri: str) {
+    val id_raw: str = json.id_text(id, alloc);
     if (id_raw == nil) { ret; }
 
     var an: Analyzed;
@@ -1340,11 +1341,12 @@ fun analyze(ws: *project.Workspace, es: *editor.EditorSession, docs: *documents.
 # analyze the target document and resolve the request's cursor position
 # to a byte offset, or none when the document is unknown / unresolvable or the
 # position is invalid (callers fall back to a null / empty reply)
-fun locate(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, body: str, uri: str, out: *Analyzed) Option[usize] {
+fun locate(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, params: *sj.Value, uri: str, out: *Analyzed) Option[usize] {
     if (!analyze(ws, es, docs, uri, out)) { ret none[usize](); }
 
-    val line: i64 = json.extract_number_after(body, "\"position\"", "\"line\"", alloc);
-    val ch:   i64 = json.extract_number_after(body, "\"position\"", "\"character\"", alloc);
+    val pos: *sj.Value = json.member(params, "position");
+    val line: i64 = json.number(json.member(pos, "line"), -1);
+    val ch:   i64 = json.number(json.member(pos, "character"), -1);
     if (line < 0 || ch < 0) { ret none[usize](); }
 
     ret positions.offset_at(out.file, line::usize, ch::usize);

--- a/src/language.mach
+++ b/src/language.mach
@@ -1,11 +1,11 @@
 # the rich language-feature request handlers
 #
 # hover, definition, references, rename, prepareRename, documentSymbol, and
-# completion. every request resolves the document's buffer against the loaded
-# project dependency graph (`project.resolve_doc`), pivots the cursor position
-# to a byte offset, joins it against the resolve side tables through `features`,
-# and shapes the LSP result with `json`. lifecycle and dispatch stay in
-# `server`; this module is the request bodies it routes to.
+# completion. semantic requests read the document's exact compiler-owned
+# ModuleEntry from a retained project snapshot, pivot the cursor position to a
+# byte offset, join it against the resolve side tables through `features`, and
+# shape the LSP result with `json`. documentSymbol stays on the syntax-only
+# editor parse path. lifecycle and dispatch stay in `server`.
 #
 # cross-module scope: the buffer is resolved with a populated dependency set, so
 # a symbol imported through a `use` binds to its declaration in a dependency Ast.
@@ -715,46 +715,43 @@ rec FieldXRef {
     file:      *src.SourceFile;
     uri:       str;
     declaring: bool;
+    owned:     bool;
 }
 
-# populate `out` with the modules that reference the keyed field
-# and return the count. `out[0]` is always the active buffer (live SemaResult);
-# each subsequent entry is a loaded module whose SemaResult types at least one
-# reference to the field, skipping the buffer's on-disk twin so its live edits are
-# not double-counted. every module is walked (a field is reachable wherever its
-# record is imported), so this is not gated on project ownership - the rename gate
-# is applied separately by the caller
+# populate `out` with each compiler-owned module exactly once. The active module
+# borrows the request URI; all other modules own their generated file URI. A
+# standalone buffer contributes its editor semantic result as the sole entry.
 # ---
 # ws:    the workspace
 # an:    the active buffer's analysis
 # uri:   the active buffer's document URI
 # t:     the resolved field target
 # out:   array of at least `cap` FieldXRef slots
-# cap:   capacity of `out` (module_count + 1)
+# cap:   capacity of `out` (module_count, or one for a standalone file)
 # ret:   number of populated entries (>= 1), or 0 when the buffer cannot be typed
 fun build_field_refs(ws: *project.Workspace, an: Analyzed, uri: str, t: FieldTarget, out: *FieldXRef, cap: usize) usize {
     if (an.sr == nil) { ret 0; }
-    out[0].a         = an.a;
-    out[0].sr        = an.sr;
-    out[0].file      = an.file;
-    out[0].uri       = uri;
-    out[0].declaring = t.decl_in_buffer;
-    var n: usize = 1;
+    if (an.root == nil) {
+        out[0].a = an.a;
+        out[0].sr = an.sr;
+        out[0].file = an.file;
+        out[0].uri = uri;
+        out[0].declaring = t.decl_in_buffer;
+        out[0].owned = false;
+        ret 1;
+    }
 
-    val self_o: Option[sess.ModuleId] = project.module_for_uri(ws, an.root, uri);
-    val have_self: bool = is_some[sess.ModuleId](self_o);
-    var self_mid: sess.ModuleId = 0::sess.ModuleId;
-    if (have_self) { self_mid = unwrap[sess.ModuleId](self_o); }
-
+    var n: usize = 0;
     val mc: u32 = project.module_count(an.root);
     var mid: u32 = 0;
     for (mid < mc && n < cap) {
         val cur: sess.ModuleId = mid::sess.ModuleId;
-        if (have_self && cur == self_mid) { mid = mid + 1; cnt; }
         val mv_o: Option[project.ModuleView] = project.module_view(ws, an.root, cur);
         val ms_o: Option[*sema.SemaResult] = project.module_sema(ws, an.root, cur);
         if (!is_some[project.ModuleView](mv_o) || !is_some[*sema.SemaResult](ms_o)) { mid = mid + 1; cnt; }
-        val muri: str = project.module_uri(ws, an.root, cur);
+        var muri: str = nil;
+        if (cur == an.own) { muri = uri; }
+        or { muri = project.module_uri(ws, an.root, cur); }
         if (muri == nil) { mid = mid + 1; cnt; }
         val mv: project.ModuleView = unwrap[project.ModuleView](mv_o);
         out[n].a         = mv.a;
@@ -762,18 +759,18 @@ fun build_field_refs(ws: *project.Workspace, an: Analyzed, uri: str, t: FieldTar
         out[n].file      = mv.file;
         out[n].uri       = muri;
         out[n].declaring = cur == t.key.origin;
+        out[n].owned     = cur != an.own;
         n = n + 1;
         mid = mid + 1;
     }
     ret n;
 }
 
-# release the owned `file://` URIs of the graph-module entries.
-# refs[0] borrows the request URI and is skipped
+# release generated graph-module URIs; the active request URI is borrowed
 fun free_field_refs(ws: *project.Workspace, refs: *FieldXRef, n: usize) {
-    var i: usize = 1;
+    var i: usize = 0;
     for (i < n) {
-        if (refs[i].uri != nil) { json.free_str(refs[i].uri, ws.alloc); }
+        if (refs[i].owned && refs[i].uri != nil) { json.free_str(refs[i].uri, ws.alloc); }
         i = i + 1;
     }
 }
@@ -815,7 +812,8 @@ fun field_references(ws: *project.Workspace, alloc: *Allocator, an: *Analyzed, u
     if (!is_some[FieldTarget](to)) { ret false; }
     val t: FieldTarget = unwrap[FieldTarget](to);
 
-    val cap: usize = (project.module_count(an.root) + 1)::usize;
+    var cap: usize = project.module_count(an.root)::usize;
+    if (cap == 0) { cap = 1; }
     val ra: Result[*FieldXRef, str] = allocate[FieldXRef](alloc, cap);
     if (is_err[*FieldXRef, str](ra)) { ret false; }
     val refs: *FieldXRef = unwrap_ok[*FieldXRef, str](ra);
@@ -841,9 +839,10 @@ fun field_rename(ws: *project.Workspace, alloc: *Allocator, an: *Analyzed, uri: 
     if (!is_some[FieldTarget](to)) { ret false; }
     val t: FieldTarget = unwrap[FieldTarget](to);
 
-    if (!field_record_renameable(ws, an.root, uri, t)) { reply_empty_edit(alloc, id_raw); ret true; }
+    if (!field_record_renameable(ws, an.root, t)) { reply_empty_edit(alloc, id_raw); ret true; }
 
-    val cap: usize = (project.module_count(an.root) + 1)::usize;
+    var cap: usize = project.module_count(an.root)::usize;
+    if (cap == 0) { cap = 1; }
     val ra: Result[*FieldXRef, str] = allocate[FieldXRef](alloc, cap);
     if (is_err[*FieldXRef, str](ra)) { ret false; }
     val refs: *FieldXRef = unwrap_ok[*FieldXRef, str](ra);
@@ -857,18 +856,10 @@ fun field_rename(ws: *project.Workspace, alloc: *Allocator, an: *Analyzed, uri: 
     ret true;
 }
 
-# whether the field's record is the editor's to rewrite -
-# the same gate the symbol rename `renameable` applies, keyed on the record's
-# declaring module. a record declared in a loaded module keys directly on
-# `is_project_module`; a record declared in the active buffer keys on the buffer's
-# on-disk twin (a dependency source opened for editing has a loaded twin that is
-# not project-owned), and on the buffer's governing root not being a vendored
-# dependency project when it has no twin
-fun field_record_renameable(ws: *project.Workspace, root: *project.Root, uri: str, t: FieldTarget) bool {
-    if (!t.decl_in_buffer) { ret project.is_project_module(ws, root, t.key.origin); }
-    val twin_o: Option[sess.ModuleId] = project.module_for_uri(ws, root, uri);
-    if (!is_some[sess.ModuleId](twin_o)) { ret !project.root_vendored(root); }
-    ret project.is_project_module(ws, root, unwrap[sess.ModuleId](twin_o));
+# whether the field's canonical declaring module is owned by the user
+fun field_record_renameable(ws: *project.Workspace, root: *project.Root, t: FieldTarget) bool {
+    if (root == nil) { ret true; }
+    ret project.is_project_module(ws, root, t.key.origin);
 }
 
 # write the field-name span the cursor sits on into `out` and
@@ -878,7 +869,7 @@ fun field_prepare_span(ws: *project.Workspace, an: *Analyzed, uri: str, offset: 
     val to: Option[FieldTarget] = field_target_at(ws, an, offset);
     if (!is_some[FieldTarget](to)) { ret false; }
     val t: FieldTarget = unwrap[FieldTarget](to);
-    if (!field_record_renameable(ws, an.root, uri, t)) { ret false; }
+    if (!field_record_renameable(ws, an.root, t)) { ret false; }
     # the range reported is the cursor's own field-name token in the buffer; the
     # decl-site name lives in the record's module, which may not be the buffer
     val fo: Option[features.FieldRef] = features.field_ref_at(an.a, offset);
@@ -1051,10 +1042,7 @@ pub fun references(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Al
     if (is_err[*XRef, str](ra)) { reply_empty_array(alloc, id_raw); ret; }
     val refs: *XRef = unwrap_ok[*XRef, str](ra);
 
-    # a failed bridge only degrades references to buffer-local results; rename
-    # is where it must refuse (see build_refs / BRIDGE_FAILED)
-    var status: i64 = BRIDGE_LOCAL;
-    val n: usize = build_refs(ws, an, uri, sym, sr.sym_id, false, refs, cap, ?status);
+    val n: usize = build_refs(ws, an, uri, sym, sr.sym_id, false, refs, cap);
     emit_locations(alloc, id_raw, refs, n, bind, has_bind);
     free_refs(ws, refs, n);
     deallocate[XRef](alloc, refs, cap);
@@ -1067,8 +1055,7 @@ pub fun references(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Al
 # declared in the user's own project: a dependency's declaration is not the
 # editor's to rewrite (whether referenced cross-module or opened as the buffer
 # itself), so those yield an empty edit. an empty edit is also returned when a
-# module-scope pub symbol's cross-file identity cannot be recovered from its
-# stale on-disk twin - a buffer-local edit there would be a partial rename
+# module-scope symbol resolves to a dependency owned by the user
 pub fun rename(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
     val id_raw: str = json.extract_raw(body, "\"id\"", alloc);
     if (id_raw == nil) { ret; }
@@ -1093,7 +1080,7 @@ pub fun rename(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Alloca
     val so: Option[*res.Symbol] = features.symbol(an.rr, sr.sym_id);
     if (!is_some[*res.Symbol](so)) { reply_empty_edit(alloc, id_raw); json.free_str(new_name, alloc); ret; }
     val sym: *res.Symbol = unwrap[*res.Symbol](so);
-    if (!renameable(ws, an.root, uri, sym, sr)) { reply_empty_edit(alloc, id_raw); json.free_str(new_name, alloc); ret; }
+    if (!renameable(ws, an.root, sym)) { reply_empty_edit(alloc, id_raw); json.free_str(new_name, alloc); ret; }
 
     # the declared name guards the cross-file walk: only occurrences spelled with
     # it are rewritten, so an aliased import's references are left untouched
@@ -1111,22 +1098,13 @@ pub fun rename(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Alloca
     var doc: token.Span;
     val has_doc: bool = param_generic_doc_span(an, sym, name, ?doc);
 
-    val cap: usize = (project.module_count(an.root) + 1)::usize;
+    var cap: usize = project.module_count(an.root)::usize;
+    if (cap == 0) { cap = 1; }
     val ra: Result[*XRef, str] = allocate[XRef](alloc, cap);
     if (is_err[*XRef, str](ra)) { reply_empty_edit(alloc, id_raw); json.free_str(new_name, alloc); ret; }
     val refs: *XRef = unwrap_ok[*XRef, str](ra);
 
-    var status: i64 = BRIDGE_LOCAL;
-    val n: usize = build_refs(ws, an, uri, sym, sr.sym_id, true, refs, cap, ?status);
-    if (status == BRIDGE_FAILED) {
-        # the pub declaration's cross-file identity is unrecoverable (stale
-        # twin); a buffer-local edit would be the partial rename #47 forbids.
-        free_refs(ws, refs, n);
-        deallocate[XRef](alloc, refs, cap);
-        json.free_str(new_name, alloc);
-        reply_empty_edit(alloc, id_raw);
-        ret;
-    }
+    val n: usize = build_refs(ws, an, uri, sym, sr.sym_id, true, refs, cap);
     emit_rename(alloc, id_raw, refs, n, new_name, name, bind, has_bind, doc, has_doc);
     free_refs(ws, refs, n);
     deallocate[XRef](alloc, refs, cap);
@@ -1185,7 +1163,7 @@ pub fun prepare_rename(ws: *project.Workspace, es: *editor.EditorSession, alloc:
 
     val so: Option[*res.Symbol] = features.symbol(an.rr, sr.sym_id);
     if (!is_some[*res.Symbol](so)) { reply_null(alloc, id_raw); ret; }
-    if (!renameable(ws, an.root, uri, unwrap[*res.Symbol](so), sr)) { reply_null(alloc, id_raw); ret; }
+    if (!renameable(ws, an.root, unwrap[*res.Symbol](so))) { reply_null(alloc, id_raw); ret; }
 
     reply_range(alloc, id_raw, an.file, sr.name_span);
 }
@@ -1205,13 +1183,19 @@ fun reply_range(alloc: *Allocator, id_raw: str, file: *src.SourceFile, span: tok
 # answer textDocument/documentSymbol with a flat list of the
 # file's top-level declarations as DocumentSymbol nodes (name, kind, range,
 # selectionRange)
-pub fun document_symbol(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
+pub fun document_symbol(es: *editor.EditorSession, alloc: *Allocator, docs: *documents.Store, body: str, uri: str) {
     val id_raw: str = json.extract_raw(body, "\"id\"", alloc);
     if (id_raw == nil) { ret; }
 
+    val d: *documents.Document = documents.find(docs, uri);
+    if (d == nil) { reply_empty_array(alloc, id_raw); ret; }
+    val ar: Result[*ast.Ast, str] = editor.parse(es, d.file_id);
+    if (is_err[*ast.Ast, str](ar)) { reply_empty_array(alloc, id_raw); ret; }
+    val fo: Option[*src.SourceFile] = src.get(?es.s.sources, d.file_id);
+    if (!is_some[*src.SourceFile](fo)) { reply_empty_array(alloc, id_raw); ret; }
     var an: Analyzed;
-    val okd: bool = analyze(ws, es, docs, uri, ?an);
-    if (!okd) { reply_empty_array(alloc, id_raw); ret; }
+    an.a = unwrap_ok[*ast.Ast, str](ar);
+    an.file = unwrap[*src.SourceFile](fo);
 
     emit_document_symbols(an, alloc, id_raw);
 }
@@ -1242,143 +1226,81 @@ fun binding_span(an: Analyzed, sid: res.SymbolId, out: *token.Span) bool {
     ret true;
 }
 
-# whether the symbol at the cursor may be renamed. a cross-module
-# symbol must be declared in a project-owned module, and a buffer-local symbol
-# is only renameable when the buffer itself is the editor's to rewrite: its
-# on-disk twin (when the buffer is a loaded module's file - e.g. a dependency
-# source opened via go-to-definition, whose symbols all resolve buffer-locally)
-# must also be project-owned. a buffer with no twin renames buffer-local - unless
-# its governing root is a vendored dependency project, whose every file is
-# read-only even outside that root's own graph closure (a vendored dep source the
-# outer project never imports still routes to its own vendored root)
-fun renameable(ws: *project.Workspace, root: *project.Root, uri: str, sym: *res.Symbol, sr: features.SymbolRef) bool {
-    if (!sr.local) { ret project.is_project_module(ws, root, sym.origin); }
-    val twin_o: Option[sess.ModuleId] = project.module_for_uri(ws, root, uri);
-    if (!is_some[sess.ModuleId](twin_o)) { ret !project.root_vendored(root); }
-    ret project.is_project_module(ws, root, unwrap[sess.ModuleId](twin_o));
+# whether the symbol's canonical declaring module is owned by the user. A
+# standalone buffer has no project boundary and remains directly editable.
+fun renameable(ws: *project.Workspace, root: *project.Root, sym: *res.Symbol) bool {
+    if (root == nil) { ret true; }
+    ret project.is_project_module(ws, root, sym.origin);
 }
 
 # one file contributing references to a target symbol - its Ast, resolve
 # tables, source file, document URI, and the local SymbolId every reference in
-# it resolves to. the active buffer is always the first XRef (live resolve,
-# borrowed URI); each other loaded module that references the symbol is another
-# (graph snapshot, an owned `file://` URI freed by free_refs). see build_refs
+# it resolves to. Project modules are visited exactly once; the active module
+# borrows the request URI and other modules own their generated file URI.
 rec XRef {
     a:      *ast.Ast;
     rr:     *res.ResolveResult;
     file:   *src.SourceFile;
     uri:    str;
     target: res.SymbolId;
+    owned:  bool;
 }
 
-# bridge status of build_refs' buffer -> on-disk-twin identity translation
-# ---
-# BRIDGE_LOCAL:  the symbol has no cross-file identity (block-local, non-pub,
-#                or the buffer has no loaded twin); buffer-local results are
-#                complete on their own terms.
-# BRIDGE_OK:     a canonical (origin, decl) identity resolved; the graph walk
-#                ran and cross-file results are included.
-# BRIDGE_FAILED: the symbol is a module-scope pub declaration but its identity
-#                could not be recovered from the on-disk twin - e.g. unsaved
-#                edits renamed the declaration, so the stale twin does not
-#                export the name. rename must refuse rather than emit the
-#                compile-breaking partial edit a buffer-local fallback would be.
-val BRIDGE_LOCAL:  i64 = 0;
-val BRIDGE_OK:     i64 = 1;
-val BRIDGE_FAILED: i64 = 2;
-
-# populate `out` with the files that reference the symbol at the
-# cursor and return the count. `out[0]` is always the active buffer (resolved
-# live, matched by its own SymbolId). each subsequent entry is a loaded module
-# whose resolve result contains the symbol's canonical (origin, decl) identity,
-# skipping the buffer's on-disk twin so its live edits are not double-counted.
-# `project_only` restricts the walk to project-owned modules (rename); references
-# passes false to include dependency modules. the canonical identity is read
-# directly for a cross-module reference; for a buffer-local symbol it is bridged
-# through the buffer's on-disk twin, but only when the symbol is a module-scope
-# pub declaration - a block-local binding that shadows a pub symbol's name, or a
-# non-pub declaration, has no importers and must not bridge to one. the bridge
-# outcome is reported in `status` (see BRIDGE_*) so rename can refuse on a
-# failed bridge instead of degrading to a partial buffer-local edit
-# ---
-# ws:          the workspace
-# an:          the active buffer's analysis
-# uri:         the active buffer's document URI
-# sym:         the resolved symbol at the cursor
-# self_target: the symbol's SymbolId in the active buffer's resolve result
-# project_only:restrict the graph walk to project-owned modules
-# out:         array of at least `cap` XRef slots
-# cap:         capacity of `out` (module_count + 1)
-# status:      receives the BRIDGE_* outcome
-# ret:         number of populated entries (>= 1)
-fun build_refs(ws: *project.Workspace, an: Analyzed, uri: str, sym: *res.Symbol, self_target: res.SymbolId, project_only: bool, out: *XRef, cap: usize, status: *i64) usize {
-    out[0].a      = an.a;
-    out[0].rr     = an.rr;
-    out[0].file   = an.file;
-    out[0].uri    = uri;
-    out[0].target = self_target;
-    var n: usize = 1;
-    @status = BRIDGE_LOCAL;
-
-    val self_o: Option[sess.ModuleId] = project.module_for_uri(ws, an.root, uri);
-    val have_self: bool = is_some[sess.ModuleId](self_o);
-    var self_mid: sess.ModuleId = 0::sess.ModuleId;
-    if (have_self) { self_mid = unwrap[sess.ModuleId](self_o); }
-
-    var canon_origin: sess.ModuleId = sym.origin;
-    var canon_decl:   id.DeclId     = sym.decl;
-    if (sym.origin == an.own) {
-        if ((sym.flags & res.SYM_FLAG_MODULE) == 0 || (sym.flags & res.SYM_FLAG_PUB) == 0) { ret n; }
-        if (!have_self) { ret n; }
-        val mv_o: Option[project.ModuleView] = project.module_view(ws, an.root, self_mid);
-        if (!is_some[project.ModuleView](mv_o)) { @status = BRIDGE_FAILED; ret n; }
-        canon_decl   = features.export_decl_of(unwrap[project.ModuleView](mv_o).rr, sym.name, sym.kind);
-        canon_origin = self_mid;
-        if (canon_decl == id.DECL_NIL) { @status = BRIDGE_FAILED; ret n; }
+# collect each retained module whose resolver maps the target's canonical
+# (origin, declaration) identity. The active document is already that exact
+# ModuleEntry, so it uses the request URI and is neither bridged nor duplicated.
+fun build_refs(ws: *project.Workspace, an: Analyzed, uri: str, sym: *res.Symbol, self_target: res.SymbolId, project_only: bool, out: *XRef, cap: usize) usize {
+    if (an.root == nil || sym.decl == id.DECL_NIL
+        || (sym.origin == an.own && ((sym.flags & res.SYM_FLAG_MODULE) == 0
+            || (sym.flags & res.SYM_FLAG_PUB) == 0))) {
+        out[0].a = an.a;
+        out[0].rr = an.rr;
+        out[0].file = an.file;
+        out[0].uri = uri;
+        out[0].target = self_target;
+        out[0].owned = false;
+        ret 1;
     }
-    if (canon_decl == id.DECL_NIL) { ret n; }
-    @status = BRIDGE_OK;
-
+    var n: usize = 0;
     val mc: u32 = project.module_count(an.root);
     var mid: u32 = 0;
     for (mid < mc && n < cap) {
         val cur: sess.ModuleId = mid::sess.ModuleId;
-        if ((have_self && cur == self_mid)
-            || (project_only && !project.is_project_module(ws, an.root, cur))) { mid = mid + 1; cnt; }
+        if (project_only && !project.is_project_module(ws, an.root, cur)) { mid = mid + 1; cnt; }
         val mv_o: Option[project.ModuleView] = project.module_view(ws, an.root, cur);
         if (!is_some[project.ModuleView](mv_o)) { mid = mid + 1; cnt; }
         val mv: project.ModuleView = unwrap[project.ModuleView](mv_o);
-        val tgt: res.SymbolId = features.symbol_by_decl(mv.rr, canon_origin, canon_decl);
+        val tgt: res.SymbolId = features.symbol_by_decl(mv.rr, sym.origin, sym.decl);
         if (tgt == res.SYMBOL_NIL) { mid = mid + 1; cnt; }
-        val muri: str = project.module_uri(ws, an.root, cur);
+        var muri: str = nil;
+        if (cur == an.own) { muri = uri; }
+        or { muri = project.module_uri(ws, an.root, cur); }
         if (muri == nil) { mid = mid + 1; cnt; }
-        out[n].a      = mv.a;
-        out[n].rr     = mv.rr;
-        out[n].file   = mv.file;
-        out[n].uri    = muri;
+        out[n].a = mv.a;
+        out[n].rr = mv.rr;
+        out[n].file = mv.file;
+        out[n].uri = muri;
         out[n].target = tgt;
+        out[n].owned = cur != an.own;
         n = n + 1;
         mid = mid + 1;
     }
     ret n;
 }
 
-# release the owned `file://` URIs of the graph-module entries in a
-# built XRef array. refs[0] borrows the request's URI and is skipped
+# release generated graph-module URIs; the active request URI is borrowed
 fun free_refs(ws: *project.Workspace, refs: *XRef, n: usize) {
-    var i: usize = 1;
+    var i: usize = 0;
     for (i < n) {
-        if (refs[i].uri != nil) { json.free_str(refs[i].uri, ws.alloc); }
+        if (refs[i].owned && refs[i].uri != nil) { json.free_str(refs[i].uri, ws.alloc); }
         i = i + 1;
     }
 }
-
-# resolve the document named by `uri` against the dependency graph of
 # the project root that governs it and populate `out` with its interner, file,
 # Ast, ResolveResult, governing root, and module id. false when the document is
-# unknown or resolution fails. the module id is the root's synthetic buffer id,
-# matching the one resolution bound local symbols under, so the local /
-# cross-module distinction holds
+# unknown or resolution fails. Project documents use their compiler-owned
+# ModuleId; standalone files use the editor FileId only within that fallback
+# Session.
 fun analyze(ws: *project.Workspace, es: *editor.EditorSession, docs: *documents.Store, uri: str, out: *Analyzed) bool {
     if (uri == nil) { ret false; }
     val doc: *documents.Document = documents.find(docs, uri);

--- a/src/main.mach
+++ b/src/main.mach
@@ -14,11 +14,14 @@ use std.types.option.is_some;
 
 use std.allocator.Allocator;
 use page: std.allocator.page;
+use os:   std.system.os;
 
 use server: mls.server;
 
 #[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
+    if (os.ignore_sigpipe() != 0) { ret 1; }
+
     var alloc: Allocator;
     val pe: Option[str] = page.make(?alloc);
     if (is_some[str](pe)) { ret 1; }

--- a/src/project.mach
+++ b/src/project.mach
@@ -702,7 +702,7 @@ fun sync_overlays(w: *Workspace, r: *Root) Result[bool, str] {
     var i: usize = 0;
     for (i < n) {
         val d: *documents.Document = documents.at(w.docs, i);
-        if (d != nil && d.in_use && d.path != nil) {
+        if (d != nil && d.in_use && d.path != nil && document_belongs(w, r, d.path)) {
             val sr: Result[bool, str] = sess.set_overlay(r.s, d.path, d.text);
             if (is_err[bool, str](sr)) { ret sr; }
             if (d.revision > latest) { latest = d.revision; }
@@ -744,7 +744,8 @@ fun collect_extra_roots(w: *Workspace, r: *Root, m: *manifest.Manifest, out: **i
     var i: usize = 0;
     for (i < n) {
         val d: *documents.Document = documents.at(w.docs, i);
-        if (d != nil && d.in_use && d.path != nil && is_under(d.path, src_norm)) {
+        if (d != nil && d.in_use && d.path != nil && is_under(d.path, src_norm)
+            && document_own_root(w, r, d.path)) {
             # Also mirror under the driver's exact `<root>/<manifest src>/<rel>`
             # spelling. Manifests may use `./src`; overlays are exact path keys.
             val raw_src_r: Result[pathlib.Path, str] = pathlib.join(w.alloc, r.path, unwrap[str](so));
@@ -833,22 +834,25 @@ fun build_mod_paths(w: *Workspace, r: *Root) {
         deallocate[str](w.alloc, unwrap_ok[*str, str](arr_r), n::usize);
         ret;
     }
-    r.mod_paths      = unwrap_ok[*str, str](arr_r);
-    r.mod_fingerprints = unwrap_ok[*SourceFingerprint, str](mt_r);
-    r.mod_path_count = n;
+    val paths: *str = unwrap_ok[*str, str](arr_r);
+    val fingerprints: *SourceFingerprint = unwrap_ok[*SourceFingerprint, str](mt_r);
 
     var i: u32 = 0;
     for (i < n) {
-        r.mod_paths[i] = nil;
-        r.mod_fingerprints[i].mtime = 0;
-        r.mod_fingerprints[i].size = 0;
+        paths[i] = nil;
+        fingerprints[i].mtime = 0;
+        fingerprints[i].size = 0;
         val fo: Option[*src.SourceFile] = src.get(?r.s.sources, (?r.p.modules[i]).file_id);
         if (is_some[*src.SourceFile](fo)) {
-            r.mod_paths[i] = normalize_path(w.alloc, unwrap[*src.SourceFile](fo).path);
-            if (r.mod_paths[i] != nil) { r.mod_fingerprints[i] = file_fingerprint(r.mod_paths[i]); }
+            paths[i] = normalize_path(w.alloc, unwrap[*src.SourceFile](fo).path);
+            if (paths[i] != nil) { fingerprints[i] = file_fingerprint(paths[i]); }
         }
         i = i + 1;
     }
+    free_mod_paths(w, r);
+    r.mod_paths = paths;
+    r.mod_fingerprints = fingerprints;
+    r.mod_path_count = n;
 }
 
 # release the per-module normalized path snapshot
@@ -909,7 +913,7 @@ pub fun document_changed(w: *Workspace, d: *documents.Document) Result[bool, str
     var i: u32 = 0;
     for (i < w.root_cap) {
         val r: *Root = ?w.roots[i];
-        if (r.path != nil && r.s != nil) {
+        if (r.path != nil && r.s != nil && document_belongs(w, r, d.path)) {
             r.input_revision = d.revision;
         }
         i = i + 1;
@@ -924,7 +928,7 @@ pub fun document_closed(w: *Workspace, d: *documents.Document) {
     var i: u32 = 0;
     for (i < w.root_cap) {
         val r: *Root = ?w.roots[i];
-        if (r.path != nil && r.s != nil) {
+        if (r.path != nil && r.s != nil && document_belongs(w, r, d.path)) {
             sess.clear_overlay(r.s, d.path);
             r.input_revision = d.revision;
         }
@@ -980,10 +984,24 @@ fun is_under(file: str, dir: str) bool {
     ret file[dl] == '/';
 }
 
+fun document_own_root(w: *Workspace, r: *Root, path: str) bool {
+    val own: str = project_root_for(w.alloc, path);
+    if (own == nil) { ret false; }
+    val matches: bool = str_equals(own, r.path);
+    strutil.str_free(w.alloc, own);
+    ret matches;
+}
+
+fun document_belongs(w: *Workspace, r: *Root, path: str) bool {
+    if (document_own_root(w, r, path)) { ret true; }
+    ret is_some[sess.ModuleId](module_for_norm(r, path));
+}
+
 # release a root's graph, dep snapshot, and owned path, resetting
 # the slot for reuse
 fun free_root(w: *Workspace, r: *Root) {
     free_root_graph(w, r);
+    free_mod_paths(w, r);
     if (r.s != nil) {
         sess.dnit(r.s);
         deallocate[sess.Session](w.alloc, r.s, 1);
@@ -999,7 +1017,6 @@ fun free_root(w: *Workspace, r: *Root) {
 # reclaims them rather than leaving them for the whole-cache sweep), and the
 # generation is cleared so a later build claims a fresh, non-matching one
 fun free_root_graph(w: *Workspace, r: *Root) {
-    free_mod_paths(w, r);
     if (r.loaded) {
         driver.dnit_project(?r.p);
         r.loaded = false;

--- a/src/project.mach
+++ b/src/project.mach
@@ -38,6 +38,7 @@ use std.allocator.deallocate;
 use std.allocator.reallocate;
 
 use strutil: std.text.string;
+use fnv1a:   std.crypto.hash.fnv1a;
 use fs:      std.filesystem;
 use chrono:  std.chrono.time;
 use pathlib: std.types.path;
@@ -83,6 +84,14 @@ pub rec Site {
     owned: bool;
 }
 
+# sentinel for a content hash that has not been computed (or could not be)
+val HASH_UNKNOWN: u64 = 0;
+
+# a source file's change-detection state
+# ---
+# mtime: modification time in unix nanoseconds, 0 when absent
+# size:  size in bytes
+# hash:  FNV-1a of the contents, HASH_UNKNOWN until a stat mismatch forces it
 rec SourceFingerprint {
     mtime: i64;
     size:  usize;
@@ -570,6 +579,8 @@ fun alloc_slot(w: *Workspace) *Root {
 # compose the selected primary artifact request and retain the compiler-owned
 # load/resolve/sema snapshot for `r.path`
 fun try_load(w: *Workspace, r: *Root) bool {
+    val started_ns: i64 = trace.now_ns();
+    fin { trace.logf("project: analyzed {} in {}ms", r.path, (trace.now_ns() - started_ns) / 1000000); }
     record_mtimes(w, r);
     r.dirty = false;
     val sor: Result[bool, str] = sync_overlays(w, r);
@@ -875,7 +886,7 @@ fun build_mod_paths(w: *Workspace, r: *Root) Result[bool, str] {
             free_path_snapshot(w.alloc, paths, fingerprints, n, i);
             ret err[bool, str]("project: failed to normalize loaded module path");
         }
-        fingerprints[i] = file_fingerprint(w.alloc, paths[i]);
+        fingerprints[i] = file_fingerprint(paths[i]);
         i = i + 1;
     }
     free_mod_paths(w, r);
@@ -919,11 +930,8 @@ fun maybe_reload(w: *Workspace, r: *Root) {
     var changed: bool = man != r.man_mtime || lock != r.lock_mtime;
     var i: u32 = 0;
     for (!changed && i < r.mod_path_count) {
-        if (r.mod_paths[i] != nil) {
-            val fp: SourceFingerprint = file_fingerprint(w.alloc, r.mod_paths[i]);
-            if (fp.mtime != r.mod_fingerprints[i].mtime || fp.size != r.mod_fingerprints[i].size
-                || fp.hash != r.mod_fingerprints[i].hash) { changed = true; }
-        }
+        if (r.mod_paths[i] != nil
+            && !fingerprint_matches(w.alloc, r.mod_paths[i], ?r.mod_fingerprints[i])) { changed = true; }
         i = i + 1;
     }
     if (!changed) { ret; }
@@ -1103,26 +1111,77 @@ fun join_mtime(alloc: *Allocator, dir: str, name: str) i64 {
     ret m;
 }
 
-fun file_fingerprint(alloc: *Allocator, path: str) SourceFingerprint {
+# stat-only fingerprint: the metadata half is what every scan reads
+#
+# `hash` is left HASH_UNKNOWN. The content hash exists only to suppress a
+# rebuild after a touch that did not change bytes, so it is computed lazily by
+# `fingerprint_matches` for the rare file whose (mtime, size) moved - never for
+# the whole module set on a periodic scan.
+# ---
+# path: absolute source path to stat
+# ret:  the file's (mtime, size) with an unresolved hash; zeroed when absent
+fun file_fingerprint(path: str) SourceFingerprint {
     var fp: SourceFingerprint;
     fp.mtime = 0;
     fp.size = 0;
-    fp.hash = 0;
+    fp.hash = HASH_UNKNOWN;
     val fi_r: Result[fs.Metadata, str] = fs.metadata(path);
     if (is_err[fs.Metadata, str](fi_r)) { ret fp; }
     var fi: fs.Metadata = unwrap_ok[fs.Metadata, str](fi_r);
     fp.mtime = chrono.time_unix_nsec(fi.modified);
     fp.size = fi.size;
-    val text_r: Result[str, str] = fs.read_string(alloc, path);
-    if (!is_err[str, str](text_r)) {
-        val text: str = unwrap_ok[str, str](text_r);
-        var h: u64 = 14695981039346656037;
-        var i: usize = 0;
-        for (i < str_len(text)) { h = (h ^ text[i]::u64) * 1099511628211; i = i + 1; }
-        fp.hash = h;
-        strutil.str_free(alloc, text);
-    }
     ret fp;
+}
+
+# FNV-1a over a file's bytes, or HASH_UNKNOWN when it cannot be read
+# ---
+# alloc: allocator for the transient file read
+# path:  absolute source path to hash
+# ret:   the content hash, or HASH_UNKNOWN on a read failure
+fun file_content_hash(alloc: *Allocator, path: str) u64 {
+    val text_r: Result[str, str] = fs.read_string(alloc, path);
+    if (is_err[str, str](text_r)) { ret HASH_UNKNOWN; }
+    val text: str = unwrap_ok[str, str](text_r);
+    val n: usize = str_len(text);
+    var h: u64 = fnv1a.FNV_INIT;
+    var i: usize = 0;
+    for (i < n) {
+        h = fnv1a.step_u8(h, text[i]);
+        i = i + 1;
+    }
+    strutil.str_free(alloc, text);
+    if (h == HASH_UNKNOWN) { ret HASH_UNKNOWN + 1; }
+    ret h;
+}
+
+# whether `path` still matches the fingerprint recorded in `prev`
+#
+# Equal (mtime, size) accepts without touching the file's bytes, which is the
+# whole-module-set case on every periodic scan. Only a moved stat pair falls
+# through to a content hash, and only then is `prev.hash` resolved so a pure
+# touch does not force a rebuild. `prev` is updated in place so the resolved
+# hash is reused by later scans.
+# ---
+# alloc: allocator for the transient read a hash comparison needs
+# path:  absolute source path to check
+# prev:  recorded fingerprint, updated in place
+# ret:   true when the file's content is unchanged
+fun fingerprint_matches(alloc: *Allocator, path: str, prev: *SourceFingerprint) bool {
+    val now: SourceFingerprint = file_fingerprint(path);
+    if (now.mtime == prev.mtime && now.size == prev.size) { ret true; }
+    if (now.size != prev.size) {
+        @prev = now;
+        ret false;
+    }
+    # same size, different mtime: only a content hash separates a touch from an
+    # edit, so resolve both sides once and cache them.
+    if (prev.hash == HASH_UNKNOWN) { prev.hash = file_content_hash(alloc, path); }
+    val h: u64 = file_content_hash(alloc, path);
+    prev.mtime = now.mtime;
+    prev.size = now.size;
+    if (h == prev.hash && h != HASH_UNKNOWN) { ret true; }
+    prev.hash = h;
+    ret false;
 }
 
 # where symbol `sym` is declared, as an Ast / SourceFile / URI triple.

--- a/src/project.mach
+++ b/src/project.mach
@@ -105,6 +105,7 @@ rec SourceFingerprint {
 # snapshot_revision: input revision captured by p
 # attempted_revision:last input revision analyzed, including a failed attempt
 # dirty:             explicit watcher/save invalidation requiring one attempt
+# last_disk_scan_ns: last fallback fingerprint scan time
 pub rec Root {
     path:           str;
     loaded:         bool;
@@ -120,6 +121,7 @@ pub rec Root {
     snapshot_revision: u64;
     attempted_revision: u64;
     dirty:           bool;
+    last_disk_scan_ns: i64;
 }
 
 # project roots and the standalone-editor fallback
@@ -128,7 +130,6 @@ pub rec Root {
 # alloc:        workspace allocator
 # roots:        movable Root slots; each Root.s itself has a stable allocation
 # root_cap:     roots allocation length
-# watch_active: confirmed client watcher state
 # load_epoch:   successful snapshot build counter
 # sema_epoch:   semantic snapshot build counter
 # docs:         borrowed live document store
@@ -137,7 +138,6 @@ pub rec Workspace {
     alloc:        *Allocator;
     roots:        *Root;
     root_cap:     u32;
-    watch_active: bool;
     load_epoch:   u32;
     sema_epoch:   u32;
     docs:         *documents.Store;
@@ -154,7 +154,6 @@ pub fun init(s: *sess.Session, alloc: *Allocator) Workspace {
     w.alloc         = alloc;
     w.roots         = nil;
     w.root_cap      = 0;
-    w.watch_active  = false;
     w.load_epoch    = 0;
     w.sema_epoch    = 0;
     w.docs          = nil;
@@ -180,17 +179,6 @@ pub fun type_interner(w: *Workspace, root: *Root) *type.TypeInterner {
     ret ?w.s.types;
 }
 
-# record that the client delivers
-# workspace/didChangeWatchedFiles for the registered manifest / lockfile /
-# source globs, so invalidation is event-driven and the per-request
-# manifest-mtime fallback check is skipped
-# ---
-# w:  the workspace
-# on: whether file watching is active
-pub fun set_watch_active(w: *Workspace, on: bool) {
-    w.watch_active = on;
-}
-
 # the workspace's current load epoch - a counter bumped on every
 # successful root build. the server snapshots it around a feature request; a
 # change means a lazy project load completed, so the open buffers it now governs
@@ -203,12 +191,8 @@ pub fun load_epoch(w: *Workspace) u32 {
     ret w.load_epoch;
 }
 
-# the workspace's current sema epoch - a counter bumped whenever a
-# root's dep closure finishes typing (ensure_sema). the server snapshots it around
-# a feature request alongside the load epoch; a change means a type-aware feature
-# lazily sema'd a closure, so the open buffers it governs can be re-published with
-# their semantic diagnostics - which the load-free publish path could not produce
-# while the closure was still un-sema'd - without waiting for an edit (#113)
+# the workspace's semantic snapshot epoch, bumped with each successful retained
+# frontend analysis
 # ---
 # w:   the workspace
 # ret: the current sema epoch
@@ -319,7 +303,18 @@ fun ancestor_root(w: *Workspace, uri: str, doc_root: str, dir: str) *Root {
     val above: *Root = ancestor_root(w, uri, doc_root, anc);
     if (above != nil) { strutil.str_free(w.alloc, anc); ret above; }
 
-    if (find_root(w, anc) != nil || !vendors_enclosing(w, anc, doc_root)) {
+    val tracked: *Root = find_root(w, anc);
+    if (tracked != nil) {
+        maybe_reload(w, tracked);
+        refresh_inputs(w, tracked);
+        if (tracked.loaded && is_some[sess.ModuleId](module_for_uri(w, tracked, uri))) {
+            strutil.str_free(w.alloc, anc);
+            ret tracked;
+        }
+        strutil.str_free(w.alloc, anc);
+        ret nil;
+    }
+    if (!vendors_enclosing(w, anc, doc_root)) {
         strutil.str_free(w.alloc, anc);
         ret nil;
     }
@@ -332,7 +327,7 @@ fun ancestor_root(w: *Workspace, uri: str, doc_root: str, dir: str) *Root {
 
 # whether the project at `root_path` declares a dependency
 # whose vendor dir encloses `dir` - i.e. `dir` equals or lies under
-# `<root>/<[project].dep>/<alias>` for some `[deps.<alias>]`, the same layout the
+# `<root>/<[project].dep>/<alias>` for some `[dep.<alias>]`, the same layout the
 # driver's dep resolution reads. one small manifest parse answers "could this
 # project's dependency tree contain that nested root?" without paying a full
 # graph build; the loaded graph remains the authority on actual containment.
@@ -538,6 +533,7 @@ fun reset_slot(r: *Root) {
     r.snapshot_revision = 0;
     r.attempted_revision = 0;
     r.dirty = false;
+    r.last_disk_scan_ns = 0;
 }
 
 # a reusable dead slot, growing the array when every slot is
@@ -571,16 +567,8 @@ fun alloc_slot(w: *Workspace) *Root {
     ret ?w.roots[old_cap];
 }
 
-# run build_project_union for `r.path` and snapshot the dep set into
-# `r` (the union of every declared target's closure, so cross-file features cover
-# modules reachable only via a non-default target).
-# the manifest / lockfile mtimes are recorded at the start of the attempt
-# whether it succeeds or fails, so maybe_reload retries a failed root once those
-# files change instead of pinning the failure for the session. a failure is
-# surfaced (trace log + window/showMessage); on success the root claims a fresh
-# generation stamp, so any result resolved before the load (against the empty dep
-# set and the pre-load own_base, stamped a different generation) misses the cache
-# rather than being served stale
+# compose the selected primary artifact request and retain the compiler-owned
+# load/resolve/sema snapshot for `r.path`
 fun try_load(w: *Workspace, r: *Root) bool {
     record_mtimes(w, r);
     r.dirty = false;
@@ -658,10 +646,16 @@ fun try_load(w: *Workspace, r: *Root) bool {
 
     r.p        = unwrap_ok[driver.Project, outcome.Fail](pr);
     r.loaded   = true;
+    val bpr: Result[bool, str] = build_mod_paths(w, r);
+    if (is_err[bool, str](bpr)) {
+        driver.dnit_project(?r.p);
+        r.loaded = false;
+        report_load_failure(w, r.path, unwrap_err[bool, str](bpr));
+        ret false;
+    }
     r.snapshot_revision = r.input_revision;
     w.load_epoch = w.load_epoch + 1;
     w.sema_epoch = w.sema_epoch + 1;
-    build_mod_paths(w, r);
     ret true;
 }
 
@@ -704,7 +698,7 @@ fun sync_overlays(w: *Workspace, r: *Root) Result[bool, str] {
     for (i < n) {
         val d: *documents.Document = documents.at(w.docs, i);
         if (d != nil && d.in_use && d.path != nil && document_belongs(w, r, d.path)) {
-            val sr: Result[bool, str] = sess.set_overlay(r.s, d.path, d.text);
+            val sr: Result[bool, str] = set_document_overlay(w, r, d);
             if (is_err[bool, str](sr)) { ret sr; }
             if (d.revision > latest) { latest = d.revision; }
         }
@@ -712,6 +706,62 @@ fun sync_overlays(w: *Workspace, r: *Root) Result[bool, str] {
     }
     r.input_revision = latest;
     ret ok[bool, str](true);
+}
+
+# install an open document under both its canonical path and the exact raw
+# `<project root>/<manifest src>/<relative module>` spelling the compiler driver
+# currently constructs. The second key covers `src = "./src"` in project and
+# dependency manifests until Mach #2998 centralizes normalization upstream.
+fun set_document_overlay(w: *Workspace, r: *Root, d: *documents.Document) Result[bool, str] {
+    val nr: Result[bool, str] = sess.set_overlay(r.s, d.path, d.text);
+    if (is_err[bool, str](nr)) { ret nr; }
+    val own: str = project_root_for(w.alloc, d.path);
+    if (own == nil) { ret ok[bool, str](true); }
+    val mp_r: Result[pathlib.Path, str] = pathlib.join(w.alloc, own, "mach.toml");
+    if (is_err[pathlib.Path, str](mp_r)) {
+        strutil.str_free(w.alloc, own);
+        ret err[bool, str](unwrap_err[pathlib.Path, str](mp_r));
+    }
+    val mp: str = unwrap_ok[pathlib.Path, str](mp_r);
+    val text_r: Result[str, str] = fs.read_string(w.alloc, mp);
+    strutil.str_free(w.alloc, mp);
+    if (is_err[str, str](text_r)) {
+        strutil.str_free(w.alloc, own);
+        ret err[bool, str](unwrap_err[str, str](text_r));
+    }
+    val text: str = unwrap_ok[str, str](text_r);
+    val table_r: Result[toml.Table, str] = toml.parse(w.alloc, text);
+    strutil.str_free(w.alloc, text);
+    if (is_err[toml.Table, str](table_r)) {
+        strutil.str_free(w.alloc, own);
+        ret err[bool, str](unwrap_err[toml.Table, str](table_r));
+    }
+    var table: toml.Table = unwrap_ok[toml.Table, str](table_r);
+    val src_dir: str = toml.get_str(?table, "project.src");
+    if (src_dir == nil) { strutil.str_free(w.alloc, own); ret ok[bool, str](true); }
+    val raw_src_r: Result[pathlib.Path, str] = pathlib.join(w.alloc, own, src_dir);
+    strutil.str_free(w.alloc, own);
+    if (is_err[pathlib.Path, str](raw_src_r)) { ret err[bool, str](unwrap_err[pathlib.Path, str](raw_src_r)); }
+    val raw_src: str = unwrap_ok[pathlib.Path, str](raw_src_r);
+    val src_norm: str = normalize_path(w.alloc, raw_src);
+    if (src_norm == nil) {
+        strutil.str_free(w.alloc, raw_src);
+        ret err[bool, str]("project: failed to normalize document source directory");
+    }
+    if (!is_under(d.path, src_norm) || str_len(d.path) <= str_len(src_norm)) {
+        strutil.str_free(w.alloc, src_norm);
+        strutil.str_free(w.alloc, raw_src);
+        ret ok[bool, str](true);
+    }
+    val raw_path_r: Result[pathlib.Path, str] = pathlib.join(w.alloc, raw_src,
+        (d.path::usize + str_len(src_norm) + 1)::str);
+    strutil.str_free(w.alloc, src_norm);
+    strutil.str_free(w.alloc, raw_src);
+    if (is_err[pathlib.Path, str](raw_path_r)) { ret err[bool, str](unwrap_err[pathlib.Path, str](raw_path_r)); }
+    val raw_path: str = unwrap_ok[pathlib.Path, str](raw_path_r);
+    val rr: Result[bool, str] = sess.set_overlay(r.s, raw_path, d.text);
+    strutil.str_free(w.alloc, raw_path);
+    ret rr;
 }
 
 # build compiler-owned extra roots for open files under this project's source
@@ -747,31 +797,6 @@ fun collect_extra_roots(w: *Workspace, r: *Root, m: *manifest.Manifest, out: **i
         val d: *documents.Document = documents.at(w.docs, i);
         if (d != nil && d.in_use && d.path != nil && is_under(d.path, src_norm)
             && document_own_root(w, r, d.path)) {
-            # Also mirror under the driver's exact `<root>/<manifest src>/<rel>`
-            # spelling. Manifests may use `./src`; overlays are exact path keys.
-            val raw_src_r: Result[pathlib.Path, str] = pathlib.join(w.alloc, r.path, unwrap[str](so));
-            if (is_err[pathlib.Path, str](raw_src_r)) {
-                strutil.str_free(w.alloc, src_norm);
-                deallocate[intern.StrId](w.alloc, roots, n);
-                ret err[u32, str](unwrap_err[pathlib.Path, str](raw_src_r));
-            }
-            val raw_src: str = unwrap_ok[pathlib.Path, str](raw_src_r);
-            val raw_path_r: Result[pathlib.Path, str] = pathlib.join(w.alloc, raw_src,
-                (d.path::usize + str_len(src_norm) + 1)::str);
-            strutil.str_free(w.alloc, raw_src);
-            if (is_err[pathlib.Path, str](raw_path_r)) {
-                strutil.str_free(w.alloc, src_norm);
-                deallocate[intern.StrId](w.alloc, roots, n);
-                ret err[u32, str](unwrap_err[pathlib.Path, str](raw_path_r));
-            }
-            val raw_path: str = unwrap_ok[pathlib.Path, str](raw_path_r);
-            val orr: Result[bool, str] = sess.set_overlay(r.s, raw_path, d.text);
-            strutil.str_free(w.alloc, raw_path);
-            if (is_err[bool, str](orr)) {
-                strutil.str_free(w.alloc, src_norm);
-                deallocate[intern.StrId](w.alloc, roots, n);
-                ret err[u32, str](unwrap_err[bool, str](orr));
-            }
             val fr: Result[intern.StrId, str] = document_fqn(r, unwrap[str](io), src_norm, d.path);
             if (is_err[intern.StrId, str](fr)) {
                 strutil.str_free(w.alloc, src_norm);
@@ -816,24 +841,20 @@ fun document_fqn(r: *Root, id_text: str, src_dir: str, path: str) Result[intern.
     ret ir;
 }
 
-# hand out a fresh generation stamp. each successful build claims one,
-# so a cache entry's generation identifies its exact build and a reloaded or
-# freed root's stale entries can never match a later build. 0 is the reserved
-# unloaded / single-file sentinel and is skipped if the sequence ever wraps
 # snapshot every loaded module's normalized source path into
 # `r.mod_paths`, indexed by module id, so the per-request uri -> module lookups
-# are allocation-free string compares. a source that cannot be read or
-# normalized leaves a nil entry, making that module unmatchable by uri (the
-# same outcome the per-request normalization had)
-fun build_mod_paths(w: *Workspace, r: *Root) {
+# are allocation-free string compares. replacement is transactional: a failed
+# allocation or normalization rejects the new Project and preserves the last
+# successful path/fingerprint set for disk-change retry detection.
+fun build_mod_paths(w: *Workspace, r: *Root) Result[bool, str] {
     val n: u32 = r.p.module_len;
-    if (n == 0) { ret; }
+    if (n == 0) { free_mod_paths(w, r); ret ok[bool, str](true); }
     val arr_r: Result[*str, str] = allocate[str](w.alloc, n::usize);
-    if (is_err[*str, str](arr_r)) { ret; }
+    if (is_err[*str, str](arr_r)) { ret err[bool, str](unwrap_err[*str, str](arr_r)); }
     val mt_r: Result[*SourceFingerprint, str] = allocate[SourceFingerprint](w.alloc, n::usize);
     if (is_err[*SourceFingerprint, str](mt_r)) {
         deallocate[str](w.alloc, unwrap_ok[*str, str](arr_r), n::usize);
-        ret;
+        ret err[bool, str](unwrap_err[*SourceFingerprint, str](mt_r));
     }
     val paths: *str = unwrap_ok[*str, str](arr_r);
     val fingerprints: *SourceFingerprint = unwrap_ok[*SourceFingerprint, str](mt_r);
@@ -845,28 +866,39 @@ fun build_mod_paths(w: *Workspace, r: *Root) {
         fingerprints[i].size = 0;
         fingerprints[i].hash = 0;
         val fo: Option[*src.SourceFile] = src.get(?r.s.sources, (?r.p.modules[i]).file_id);
-        if (is_some[*src.SourceFile](fo)) {
-            paths[i] = normalize_path(w.alloc, unwrap[*src.SourceFile](fo).path);
-            if (paths[i] != nil) { fingerprints[i] = file_fingerprint(w.alloc, paths[i]); }
+        if (!is_some[*src.SourceFile](fo)) {
+            free_path_snapshot(w.alloc, paths, fingerprints, n, i);
+            ret err[bool, str]("project: loaded module source is unavailable");
         }
+        paths[i] = normalize_path(w.alloc, unwrap[*src.SourceFile](fo).path);
+        if (paths[i] == nil) {
+            free_path_snapshot(w.alloc, paths, fingerprints, n, i);
+            ret err[bool, str]("project: failed to normalize loaded module path");
+        }
+        fingerprints[i] = file_fingerprint(w.alloc, paths[i]);
         i = i + 1;
     }
     free_mod_paths(w, r);
     r.mod_paths = paths;
     r.mod_fingerprints = fingerprints;
     r.mod_path_count = n;
+    ret ok[bool, str](true);
+}
+
+fun free_path_snapshot(alloc: *Allocator, paths: *str, fingerprints: *SourceFingerprint, cap: u32, initialized: u32) {
+    var i: u32 = 0;
+    for (i < initialized) {
+        if (paths[i] != nil) { strutil.str_free(alloc, paths[i]); }
+        i = i + 1;
+    }
+    deallocate[str](alloc, paths, cap::usize);
+    deallocate[SourceFingerprint](alloc, fingerprints, cap::usize);
 }
 
 # release the per-module normalized path snapshot
 fun free_mod_paths(w: *Workspace, r: *Root) {
     if (r.mod_paths == nil) { ret; }
-    var i: u32 = 0;
-    for (i < r.mod_path_count) {
-        if (r.mod_paths[i] != nil) { strutil.str_free(w.alloc, r.mod_paths[i]); }
-        i = i + 1;
-    }
-    deallocate[str](w.alloc, r.mod_paths, r.mod_path_count::usize);
-    if (r.mod_fingerprints != nil) { deallocate[SourceFingerprint](w.alloc, r.mod_fingerprints, r.mod_path_count::usize); }
+    free_path_snapshot(w.alloc, r.mod_paths, r.mod_fingerprints, r.mod_path_count, r.mod_path_count);
     r.mod_paths      = nil;
     r.mod_fingerprints = nil;
     r.mod_path_count = 0;
@@ -878,12 +910,15 @@ fun free_mod_paths(w: *Workspace, r: *Root) {
 # root whose previous load failed. watcher delivery improves latency but does
 # not disable this correctness fallback. a no-op when nothing changed
 fun maybe_reload(w: *Workspace, r: *Root) {
+    val now: i64 = chrono.time_unix_nsec(chrono.monotonic());
+    if (!r.dirty && r.last_disk_scan_ns != 0 && now - r.last_disk_scan_ns < 250000000) { ret; }
+    r.last_disk_scan_ns = now;
     var man:  i64 = 0;
     var lock: i64 = 0;
     stat_mtimes(w, r.path, ?man, ?lock);
     var changed: bool = man != r.man_mtime || lock != r.lock_mtime;
     var i: u32 = 0;
-    for (!changed && r.loaded && i < r.mod_path_count) {
+    for (!changed && i < r.mod_path_count) {
         if (r.mod_paths[i] != nil) {
             val fp: SourceFingerprint = file_fingerprint(w.alloc, r.mod_paths[i]);
             if (fp.mtime != r.mod_fingerprints[i].mtime || fp.size != r.mod_fingerprints[i].size
@@ -996,12 +1031,26 @@ fun document_own_root(w: *Workspace, r: *Root, path: str) bool {
 }
 
 fun document_belongs(w: *Workspace, r: *Root, path: str) bool {
-    if (document_own_root(w, r, path)) { ret true; }
-    ret is_some[sess.ModuleId](module_for_norm(r, path));
+    val own: str = project_root_for(w.alloc, path);
+    if (own != nil && str_equals(own, r.path)) {
+        strutil.str_free(w.alloc, own);
+        ret true;
+    }
+    if (is_some[sess.ModuleId](module_for_norm(r, path))) {
+        if (own != nil) { strutil.str_free(w.alloc, own); }
+        ret true;
+    }
+    # Before the first successful graph there are no retained module paths to
+    # identify an open vendored dependency. Its declaring ancestor is the only
+    # additional root allowed to mirror it; unrelated nested projects remain
+    # isolated.
+    var vendored: bool = false;
+    if (own != nil && r.mod_path_count == 0) { vendored = vendors_enclosing(w, r.path, own); }
+    if (own != nil) { strutil.str_free(w.alloc, own); }
+    ret vendored;
 }
 
-# release a root's graph, dep snapshot, and owned path, resetting
-# the slot for reuse
+# release a root's retained Project, source index, Session, and owned path
 fun free_root(w: *Workspace, r: *Root) {
     free_root_graph(w, r);
     free_mod_paths(w, r);
@@ -1014,11 +1063,8 @@ fun free_root(w: *Workspace, r: *Root) {
     reset_slot(r);
 }
 
-# release a root's dep snapshot, module-path snapshot, and
-# loaded project, leaving the slot tracked with its path so it can reload in
-# place. the build's cached resolve results are evicted first (so a teardown
-# reclaims them rather than leaving them for the whole-cache sweep), and the
-# generation is cleared so a later build claims a fresh, non-matching one
+# release the retained Project while preserving the root, Session, and last
+# successful source index so a failed rebuild can detect a later disk repair
 fun free_root_graph(w: *Workspace, r: *Root) {
     if (r.loaded) {
         driver.dnit_project(?r.p);
@@ -1243,13 +1289,7 @@ pub fun module_view(w: *Workspace, root: *Root, mid: sess.ModuleId) Option[Modul
     ret some[ModuleView](v);
 }
 
-# loaded module `mid`'s SemaResult in `root`, lazily running the
-# type checker over the whole graph on first demand (ensure_sema) and retaining
-# every module's result on the root. none when there is no project, the id is out
-# of range, or the module did not resolve / could not be typed (its retained slot
-# stays zeroed). this is the type-aware twin of `module_view`: a workspace-wide
-# type query (e.g. a field rename's cross-module walk) reads each module's typing
-# through it. the returned pointer is owned by the root
+# loaded module `mid`'s compiler-owned SemaResult
 # ---
 # w:    the workspace
 # root: the root governing the request, or nil
@@ -1263,8 +1303,8 @@ pub fun module_sema(w: *Workspace, root: *Root, mid: sess.ModuleId) Option[*sema
 
 # the semantic type of expression `eid` in SemaResult `sr`, or TYPE_NIL
 # when `sr` is nil or `eid` is out of range. the narrow read the feature layer
-# makes to learn an expression's type - handed a SemaResult (from `sema_doc` or
-# `module_sema`), never the session. delegates to the pure helper so the rule lives
+# makes to learn an expression's type - handed a retained SemaResult, never the
+# session. delegates to the pure helper so the rule lives
 # in one unit-testable place
 # ---
 # sr:  a buffer's / module's SemaResult, or nil
@@ -1423,9 +1463,8 @@ pub fun module_uri(w: *Workspace, root: *Root, mid: sess.ModuleId) str {
 }
 
 # the loaded module in `root` whose source file is the document
-# at `uri` (matched on the normalized filesystem path), or none. lets the
-# workspace walk skip the active buffer's on-disk twin, whose live edits the
-# buffer's own resolve already covers, so its references are not counted twice.
+# at `uri` (matched on the normalized filesystem path), or none. This is the
+# canonical document-to-ModuleEntry identity used for routing and views.
 # matching is lexical (`.` / `..` collapse only): the std fs surface exposes
 # neither realpath nor inode identity, so a buffer opened through a symlinked or
 # differently-cased path does not match its twin and that file is walked as a
@@ -1449,7 +1488,7 @@ pub fun module_for_uri(w: *Workspace, root: *Root, uri: str) Option[sess.ModuleI
 # equals `norm`, or none. the allocation-free core of module_for_uri, also used
 # where one normalized document path is matched against several roots
 fun module_for_norm(root: *Root, norm: str) Option[sess.ModuleId] {
-    if (root == nil || !root.loaded || norm == nil) { ret none[sess.ModuleId](); }
+    if (root == nil || norm == nil) { ret none[sess.ModuleId](); }
     var i: u32 = 0;
     for (i < root.mod_path_count) {
         if (root.mod_paths[i] != nil && str_equals(root.mod_paths[i], norm)) {
@@ -1460,25 +1499,9 @@ fun module_for_norm(root: *Root, norm: str) Option[sess.ModuleId] {
     ret none[sess.ModuleId]();
 }
 
-# whether `root`'s whole tree is a vendored dependency project
-# (its directory lies under an outer project's declared vendor dir), so none of
-# its files are the editor's to rewrite. nil root is not vendored. the per-root
-# read-only signal the rename gate consults for a buffer with no loaded twin,
-# where the per-module is_project_module check has nothing to key on
-# ---
-# root: the root governing the request, or nil
-# ret:  true when the root is a vendored dependency project
-pub fun root_vendored(root: *Root) bool {
-    if (root == nil) { ret false; }
-    ret root.vendored;
-}
-
 # whether loaded module `mid` in `root` belongs to the user's
-# own editable project rather than a vendored dependency - false outright when
-# the whole root is a vendored dependency project (root_vendored), otherwise true
-# iff the module's fully-qualified path's head segment is the project id. rename
-# gates cross-file edits on it so a dependency's declaration (e.g. a std symbol,
-# or any file of a vendored project) is never rewritten
+# own editable project rather than a vendored dependency. False when the whole
+# root is vendored; otherwise true iff the module FQN begins with the project id.
 # ---
 # w:    the workspace
 # root: the root governing the request, or nil
@@ -1714,18 +1737,8 @@ fun normalize_path(alloc: *Allocator, path: str) str {
     ret buf::str;
 }
 
-# a `file://` URI for an already-normalized absolute path, owned by
-# the caller, or nil on allocation failure
 # a `file://` URI for a SourceFile's `path`, owned by the caller, or
 # nil on allocation failure.
-#
-# the two path spaces a SourceFile can come from are distinguished by the scheme,
-# not by a flag: an editor buffer is registered under its URI (`editor.open` takes
-# the uri as the path), so it already carries `file://` and is copied through,
-# while an on-disk project module carries a filesystem path and gains the scheme.
-# this is what a diagnostic's secondary location needs, since `related` may point
-# into either space - a "previous definition here" in the buffer, or in the
-# dependency module the buffer imports
 # ---
 # alloc: allocator backing the returned URI
 # path:  a SourceFile path

--- a/src/project.mach
+++ b/src/project.mach
@@ -38,7 +38,6 @@ use std.allocator.deallocate;
 use std.allocator.reallocate;
 
 use strutil: std.text.string;
-use fnv1a:   std.crypto.hash.fnv1a;
 use fs:      std.filesystem;
 use chrono:  std.chrono.time;
 use pathlib: std.types.path;
@@ -84,18 +83,20 @@ pub rec Site {
     owned: bool;
 }
 
-# sentinel for a content hash that has not been computed (or could not be)
-val HASH_UNKNOWN: u64 = 0;
-
 # a source file's change-detection state
+#
+# Stat metadata only. A content hash would suppress a rebuild after a touch
+# that did not change bytes, but reading and hashing every module to save that
+# case costs more than the case does: a spurious rebuild reuses the retained
+# session, where `Q_FILE_TEXT`'s byte-equality cutoff keeps every unchanged
+# module's parse, resolve, and sema entry valid. The compiler already owns
+# content-change detection, so the LSP does not duplicate it.
 # ---
 # mtime: modification time in unix nanoseconds, 0 when absent
 # size:  size in bytes
-# hash:  FNV-1a of the contents, HASH_UNKNOWN until a stat mismatch forces it
 rec SourceFingerprint {
     mtime: i64;
     size:  usize;
-    hash:  u64;
 }
 
 # one project root and its compiler-owned semantic snapshot
@@ -875,7 +876,6 @@ fun build_mod_paths(w: *Workspace, r: *Root) Result[bool, str] {
         paths[i] = nil;
         fingerprints[i].mtime = 0;
         fingerprints[i].size = 0;
-        fingerprints[i].hash = 0;
         val fo: Option[*src.SourceFile] = src.get(?r.s.sources, (?r.p.modules[i]).file_id);
         if (!is_some[*src.SourceFile](fo)) {
             free_path_snapshot(w.alloc, paths, fingerprints, n, i);
@@ -931,7 +931,7 @@ fun maybe_reload(w: *Workspace, r: *Root) {
     var i: u32 = 0;
     for (!changed && i < r.mod_path_count) {
         if (r.mod_paths[i] != nil
-            && !fingerprint_matches(w.alloc, r.mod_paths[i], ?r.mod_fingerprints[i])) { changed = true; }
+            && !fingerprint_matches(r.mod_paths[i], ?r.mod_fingerprints[i])) { changed = true; }
         i = i + 1;
     }
     if (!changed) { ret; }
@@ -1111,20 +1111,14 @@ fun join_mtime(alloc: *Allocator, dir: str, name: str) i64 {
     ret m;
 }
 
-# stat-only fingerprint: the metadata half is what every scan reads
-#
-# `hash` is left HASH_UNKNOWN. The content hash exists only to suppress a
-# rebuild after a touch that did not change bytes, so it is computed lazily by
-# `fingerprint_matches` for the rare file whose (mtime, size) moved - never for
-# the whole module set on a periodic scan.
+# the `(mtime, size)` of `path`, zeroed when it is absent or unreadable
 # ---
 # path: absolute source path to stat
-# ret:  the file's (mtime, size) with an unresolved hash; zeroed when absent
+# ret:  the file's stat fingerprint
 fun file_fingerprint(path: str) SourceFingerprint {
     var fp: SourceFingerprint;
     fp.mtime = 0;
     fp.size = 0;
-    fp.hash = HASH_UNKNOWN;
     val fi_r: Result[fs.Metadata, str] = fs.metadata(path);
     if (is_err[fs.Metadata, str](fi_r)) { ret fp; }
     var fi: fs.Metadata = unwrap_ok[fs.Metadata, str](fi_r);
@@ -1133,54 +1127,18 @@ fun file_fingerprint(path: str) SourceFingerprint {
     ret fp;
 }
 
-# FNV-1a over a file's bytes, or HASH_UNKNOWN when it cannot be read
-# ---
-# alloc: allocator for the transient file read
-# path:  absolute source path to hash
-# ret:   the content hash, or HASH_UNKNOWN on a read failure
-fun file_content_hash(alloc: *Allocator, path: str) u64 {
-    val text_r: Result[str, str] = fs.read_string(alloc, path);
-    if (is_err[str, str](text_r)) { ret HASH_UNKNOWN; }
-    val text: str = unwrap_ok[str, str](text_r);
-    val n: usize = str_len(text);
-    var h: u64 = fnv1a.FNV_INIT;
-    var i: usize = 0;
-    for (i < n) {
-        h = fnv1a.step_u8(h, text[i]);
-        i = i + 1;
-    }
-    strutil.str_free(alloc, text);
-    if (h == HASH_UNKNOWN) { ret HASH_UNKNOWN + 1; }
-    ret h;
-}
-
 # whether `path` still matches the fingerprint recorded in `prev`
 #
-# Equal (mtime, size) accepts without touching the file's bytes, which is the
-# whole-module-set case on every periodic scan. Only a moved stat pair falls
-# through to a content hash, and only then is `prev.hash` resolved so a pure
-# touch does not force a rebuild. `prev` is updated in place so the resolved
-# hash is reused by later scans.
+# `prev` is refreshed on a mismatch so one disk change triggers one rebuild
+# rather than one per scan until the snapshot is replaced.
 # ---
-# alloc: allocator for the transient read a hash comparison needs
-# path:  absolute source path to check
-# prev:  recorded fingerprint, updated in place
-# ret:   true when the file's content is unchanged
-fun fingerprint_matches(alloc: *Allocator, path: str, prev: *SourceFingerprint) bool {
+# path: absolute source path to check
+# prev: recorded fingerprint, updated in place on a mismatch
+# ret:  true when the file looks unchanged
+fun fingerprint_matches(path: str, prev: *SourceFingerprint) bool {
     val now: SourceFingerprint = file_fingerprint(path);
     if (now.mtime == prev.mtime && now.size == prev.size) { ret true; }
-    if (now.size != prev.size) {
-        @prev = now;
-        ret false;
-    }
-    # same size, different mtime: only a content hash separates a touch from an
-    # edit, so resolve both sides once and cache them.
-    if (prev.hash == HASH_UNKNOWN) { prev.hash = file_content_hash(alloc, path); }
-    val h: u64 = file_content_hash(alloc, path);
-    prev.mtime = now.mtime;
-    prev.size = now.size;
-    if (h == prev.hash && h != HASH_UNKNOWN) { ret true; }
-    prev.hash = h;
+    @prev = now;
     ret false;
 }
 

--- a/src/project.mach
+++ b/src/project.mach
@@ -86,6 +86,7 @@ pub rec Site {
 rec SourceFingerprint {
     mtime: i64;
     size:  usize;
+    hash:  u64;
 }
 
 # one project root and its compiler-owned semantic snapshot
@@ -842,10 +843,11 @@ fun build_mod_paths(w: *Workspace, r: *Root) {
         paths[i] = nil;
         fingerprints[i].mtime = 0;
         fingerprints[i].size = 0;
+        fingerprints[i].hash = 0;
         val fo: Option[*src.SourceFile] = src.get(?r.s.sources, (?r.p.modules[i]).file_id);
         if (is_some[*src.SourceFile](fo)) {
             paths[i] = normalize_path(w.alloc, unwrap[*src.SourceFile](fo).path);
-            if (paths[i] != nil) { fingerprints[i] = file_fingerprint(paths[i]); }
+            if (paths[i] != nil) { fingerprints[i] = file_fingerprint(w.alloc, paths[i]); }
         }
         i = i + 1;
     }
@@ -883,8 +885,9 @@ fun maybe_reload(w: *Workspace, r: *Root) {
     var i: u32 = 0;
     for (!changed && r.loaded && i < r.mod_path_count) {
         if (r.mod_paths[i] != nil) {
-            val fp: SourceFingerprint = file_fingerprint(r.mod_paths[i]);
-            if (fp.mtime != r.mod_fingerprints[i].mtime || fp.size != r.mod_fingerprints[i].size) { changed = true; }
+            val fp: SourceFingerprint = file_fingerprint(w.alloc, r.mod_paths[i]);
+            if (fp.mtime != r.mod_fingerprints[i].mtime || fp.size != r.mod_fingerprints[i].size
+                || fp.hash != r.mod_fingerprints[i].hash) { changed = true; }
         }
         i = i + 1;
     }
@@ -1054,15 +1057,25 @@ fun join_mtime(alloc: *Allocator, dir: str, name: str) i64 {
     ret m;
 }
 
-fun file_fingerprint(path: str) SourceFingerprint {
+fun file_fingerprint(alloc: *Allocator, path: str) SourceFingerprint {
     var fp: SourceFingerprint;
     fp.mtime = 0;
     fp.size = 0;
+    fp.hash = 0;
     val fi_r: Result[fs.Metadata, str] = fs.metadata(path);
     if (is_err[fs.Metadata, str](fi_r)) { ret fp; }
     var fi: fs.Metadata = unwrap_ok[fs.Metadata, str](fi_r);
     fp.mtime = chrono.time_unix_nsec(fi.modified);
     fp.size = fi.size;
+    val text_r: Result[str, str] = fs.read_string(alloc, path);
+    if (!is_err[str, str](text_r)) {
+        val text: str = unwrap_ok[str, str](text_r);
+        var h: u64 = 14695981039346656037;
+        var i: usize = 0;
+        for (i < str_len(text)) { h = (h ^ text[i]::u64) * 1099511628211; i = i + 1; }
+        fp.hash = h;
+        strutil.str_free(alloc, text);
+    }
     ret fp;
 }
 

--- a/src/project.mach
+++ b/src/project.mach
@@ -702,7 +702,7 @@ fun sync_overlays(w: *Workspace, r: *Root) Result[bool, str] {
     var i: usize = 0;
     for (i < n) {
         val d: *documents.Document = documents.at(w.docs, i);
-        if (d != nil && d.in_use && d.path != nil && root_covers(w, d.path, r.path)) {
+        if (d != nil && d.in_use && d.path != nil) {
             val sr: Result[bool, str] = sess.set_overlay(r.s, d.path, d.text);
             if (is_err[bool, str](sr)) { ret sr; }
             if (d.revision > latest) { latest = d.revision; }
@@ -909,7 +909,7 @@ pub fun document_changed(w: *Workspace, d: *documents.Document) Result[bool, str
     var i: u32 = 0;
     for (i < w.root_cap) {
         val r: *Root = ?w.roots[i];
-        if (r.path != nil && r.s != nil && root_covers(w, d.path, r.path)) {
+        if (r.path != nil && r.s != nil) {
             r.input_revision = d.revision;
         }
         i = i + 1;
@@ -924,7 +924,7 @@ pub fun document_closed(w: *Workspace, d: *documents.Document) {
     var i: u32 = 0;
     for (i < w.root_cap) {
         val r: *Root = ?w.roots[i];
-        if (r.path != nil && r.s != nil && root_covers(w, d.path, r.path)) {
+        if (r.path != nil && r.s != nil) {
             sess.clear_overlay(r.s, d.path);
             r.input_revision = d.revision;
         }
@@ -948,7 +948,8 @@ pub fun invalidate_uri(w: *Workspace, uri: str) {
     var i: u32 = 0;
     for (i < w.root_cap) {
         val r: *Root = ?w.roots[i];
-        if (r.path != nil && root_covers(w, norm, r.path)) {
+        if (r.path != nil && (root_covers(w, norm, r.path)
+            || is_some[sess.ModuleId](module_for_norm(r, norm)))) {
             free_root_graph(w, r);
             r.man_mtime = 0 - 1;
             r.lock_mtime = 0 - 1;

--- a/src/project.mach
+++ b/src/project.mach
@@ -1058,6 +1058,21 @@ fun document_belongs(w: *Workspace, r: *Root, path: str) bool {
     ret vendored;
 }
 
+# whether `d` is mirrored into `r`'s session, and so shares its snapshot
+#
+# Diagnostics for a document can only move when the root that analyzes it is
+# rebuilt, so this is the republish set after a change: the documents a root
+# actually governs, not every open buffer in the session.
+# ---
+# w:   the workspace
+# r:   the root to test against, or nil
+# d:   the open document
+# ret: true when `r` governs `d`
+pub fun root_covers_document(w: *Workspace, r: *Root, d: *documents.Document) bool {
+    if (r == nil || d == nil || d.path == nil || r.path == nil || r.s == nil) { ret false; }
+    ret document_belongs(w, r, d.path);
+}
+
 # release a root's retained Project, source index, Session, and owned path
 fun free_root(w: *Workspace, r: *Root) {
     free_root_graph(w, r);

--- a/src/project.mach
+++ b/src/project.mach
@@ -346,9 +346,8 @@ fun ancestor_root(w: *Workspace, uri: str, doc_root: str, dir: str) *Root {
 # merely its immediate parent, while still never building unrelated outer
 # projects - a monorepo root, this repo above its test fixtures - whose declared
 # vendor dirs enclose nothing the document sits in. a manifest that fails to read
-# or parse vendors nothing. the parsed table is leaked into the server's page
-# allocator - std.data.toml exposes no teardown, the same convention the driver's
-# own manifest reads use
+# or parse vendors nothing. `get_str` and `table_key` borrow out of the table, so
+# it is torn down at scope exit rather than at the last read
 fun vendors_enclosing(w: *Workspace, root_path: str, dir: str) bool {
     val mp_r: Result[pathlib.Path, str] = pathlib.join(w.alloc, root_path, "mach.toml");
     if (is_err[pathlib.Path, str](mp_r)) { ret false; }
@@ -361,6 +360,7 @@ fun vendors_enclosing(w: *Workspace, root_path: str, dir: str) bool {
     strutil.str_free(w.alloc, text);
     if (is_err[toml.Table, str](t_r)) { ret false; }
     var t: toml.Table = unwrap_ok[toml.Table, str](t_r);
+    fin { toml.dnit(w.alloc, ?t); }
 
     val deps: *toml.Table = toml.get_table(?t, "dep");
     if (deps == nil) { ret false; }
@@ -749,6 +749,7 @@ fun set_document_overlay(w: *Workspace, r: *Root, d: *documents.Document) Result
         ret err[bool, str](unwrap_err[toml.Table, str](table_r));
     }
     var table: toml.Table = unwrap_ok[toml.Table, str](table_r);
+    fin { toml.dnit(w.alloc, ?table); }
     val src_dir: str = toml.get_str(?table, "project.src");
     if (src_dir == nil) { strutil.str_free(w.alloc, own); ret ok[bool, str](true); }
     val raw_src_r: Result[pathlib.Path, str] = pathlib.join(w.alloc, own, src_dir);

--- a/src/project.mach
+++ b/src/project.mach
@@ -1,73 +1,15 @@
-# the per-root workspace graphs that power cross-module analysis
+# retained per-root compiler snapshots for cross-module language features
 #
-# the editor surface (`mach.lang.editor`) resolves one buffer in isolation with
-# an empty dependency set, so any symbol imported through a `use` binds to
-# SYMBOL_NIL and go-to-definition / references / hover cannot reach it. this
-# module closes that gap: for each project root open in the session it loads a
-# module graph from disk through the compiler's own `driver.build_project_union`
-# (manifest + lockfile + the `dep/` tree - the union of every declared target's
-# import closure, so modules reachable only via a non-default target are present),
-# snapshots every loaded module's
-# public surface into a `res.ResolveDeps`, and re-resolves an open buffer
-# against that dep set with `res.resolve` directly - the lower-level API the
-# editor's `resolve` wraps.
+# Each project root owns a separately allocated stable Session and at most one
+# live compiler Project. Open documents retain their own canonical path, text,
+# and revision; their text is mirrored into every governing Session as a
+# filesystem-path overlay. A snapshot is rebuilt through analyze_project with
+# all open source files as compiler-owned extra roots, so imports, comptime
+# context, resolve, sema, and diagnostics share the build's exact semantics.
 #
-# multi-root by design: a `Workspace` holds one `Root` per distinct project
-# root open in the session, each with its own `driver.Project`, dep snapshot,
-# and synthetic buffer-id base. a document is routed to the root that governs
-# its path (the nearest ancestor `mach.toml`); a document that is a dependency
-# module of a root rooted elsewhere - already loaded, or an ancestor project
-# loaded on demand when the document's own root is nested under it - is routed
-# to that root read-only, rather than spun up as its own project; a document
-# under no `mach.toml` resolves single-file (empty dep set). the legacy "one
-# project per session" behaviour is just the one-Root case.
-#
-# module-id namespacing: `driver.build_project_union` allocates project-local
-# module ids from 0 and writes them into the session's global module registries,
-# so a second build over the same session clobbers the first there. those clobbered
-# registries are never read for a lookup - every cross-module lookup (site_of,
-# module_view, ...) reads the per-`Root` `driver.Project.modules` array, whose
-# ids are private to that project. the seam guarding that invariant is a
-# narrowed surface, not a language seal: no feature signature carries a
-# `*sess.Session` - feature code is handed only the per-root accessors plus the
-# two never-clobbered session services (`interner` / `sources`) - so reading a
-# session module registry takes deliberately reaching through `Workspace.s` or
-# the vendored `EditorSession.s`, both of which stay readable because mach's
-# `pub` publishes whole recs (no field-level visibility). each `Root` is
-# therefore its own id space and several projects coexist in one shared session
-# without collision; per-root sessions are unnecessary. a buffer resolves under
-# a synthetic id past its root's `module_len`, so a buffer-local symbol's
-# `origin` never equals a loaded dependency's.
-#
-# invalidation: a root's graph is a load-time snapshot. `invalidate_uri` (driven
-# by `workspace/didChangeWatchedFiles`) drops every root whose tree contains the
-# changed file, so the next request rebuilds it from disk. when the client does
-# not deliver watch notifications, a conservative manifest/lockfile mtime check
-# on each access reloads a stale root and retries a previously failed one (a
-# since-fixed manifest); with watching active the check is skipped. the resolve
-# cache stamps each entry with the generation of the root build it resolved
-# against (`Root.gen`, a fresh value per successful build; 0 reserved for a
-# single-file resolve), so a build's teardown makes every entry from it
-# structurally unhittable - no entry survives its root's reload as a stale hit -
-# while a freed root's entries are evicted per-root rather than by clearing the
-# whole cache.
-#
-# incremental rebuild (lsp #117): the free-and-reload is not a from-scratch
-# rebuild. mach 2.5.7's driver is query-engine-driven, and the session query DB
-# (Q_PARSE / Q_RESOLVE / Q_EXPORTS) lives on `Workspace.s` and SURVIVES
-# `driver.dnit_project` - only the per-build `driver.Project` arrays are freed.
-# so the next `build_project_union` reuses every unchanged module's cached parse
-# and resolve and recomputes only the edited module plus the importers whose
-# public surface moved past the Q_EXPORTS firewall; an on-disk edit's cost is the
-# changed closure, not the whole graph. what is NOT yet possible is driving the
-# graph from a still-unsaved buffer's LIVE text (overriding the driver's per-module
-# disk read): the driver's `parse_module` unconditionally re-reads disk and
-# mirrors it into Q_FILE_TEXT, and the editor's buffers live in their own
-# (URI-keyed) FileId space disjoint from the project's (path-keyed) modules - so an
-# unsaved edit reaches an open buffer's own analysis but not its importers'. closing
-# that gap needs a driver-side source-overlay API the vendored driver does not yet
-# expose (tracked as a mach follow-up); until then a cross-module feature reflects an
-# edited dependency only once it is saved.
+# ModuleId, FileId, interner, type, and query identities never cross Root
+# boundaries. Documents inside an already-loaded ancestor dependency graph route
+# to that graph; otherwise the nearest manifest owns them.
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -106,25 +48,24 @@ use page: std.allocator.page;
 
 use sess:     mach.lang.session;
 use src:      mach.lang.source;
-use editor:   mach.lang.editor;
 use intern:   mach.lang.intern;
 use ast:      mach.lang.fe.ast;
 use id:       mach.lang.fe.ast.id;
 use adecl:    mach.lang.fe.ast.decl;
-use diag:     mach.lang.diagnostic;
 use res:      mach.lang.fe.resolve;
 use sema:     mach.lang.fe.sema;
 use type:     mach.lang.type;
-use comptime: mach.lang.fe.comptime;
 use driver:   mach.lang.driver;
 use outcome:  mach.lang.build.outcome;
-use tgt:      mach.lang.target;
-use isa:      mach.lang.target.isa;
+use manifest: mach.lang.manifest;
+use request:  mach.lang.build.request;
+use vector:   std.collections.vector;
 
 use transport: mls.transport;
 use json:      mls.json;
 use trace:     mls.trace;
 use mtypes:    mls.types;
+use documents: mls.documents;
 
 # where a resolved symbol's declaration lives - the Ast and SourceFile to
 # read its spans from, and the document URI to report. for a buffer-local symbol
@@ -142,180 +83,99 @@ pub rec Site {
     owned: bool;
 }
 
-# one buffer's dep-aware resolve result - and, lazily, its sema result -
-# stamped with the Ast it was resolved from and the generation of the root build
-# it resolved against. the editor replaces a buffer's `*ast.Ast` on every text
-# update (`drop_analysis`), so Ast pointer identity catches a text edit - the same
-# contract `editor.resolve` uses for its own cached result; `gen` catches a
-# cross-root or post-reload staleness, since a result resolved against one build
-# never matches a different build's stamp. the resolve result is populated on every
-# resolve; the sema result is populated only when a type-aware feature first asks
-# for it (`sema_doc`), so the diagnostics publish path never pays for sema
-# ---
-# rr:   the cached dep-aware ResolveResult, owned by the cache
-# sr:   the cached SemaResult for the same Ast / gen, or nil until first demanded
-# a:    the Ast both results were derived from (text-edit staleness check)
-# gen:  generation of the root build they were derived against, or 0 for single-file
-rec Cached {
-    rr:  *res.ResolveResult;
-    sr:  *sema.SemaResult;
-    a:   *ast.Ast;
-    gen: u32;
+rec SourceFingerprint {
+    mtime: i64;
+    size:  usize;
 }
 
-# one project root open in the session and the dependency graph built from
-# its manifest's default-target import closure. a slot with a nil path is dead
-# and reusable
+# one project root and its compiler-owned semantic snapshot
 # ---
-# path:           owned absolute project-root path (the dir holding `mach.toml`)
-# loaded:         whether the graph built; a tracked !loaded slot is a remembered
-#                 failed load, retried only when the root is invalidated or its
-#                 manifest / lockfile mtime changes
-# p:              the loaded project graph; valid only when loaded
-# deps:           snapshot of every loaded module's exports, fed to `res.resolve`
-# mod_paths:      owned normalized source path per loaded module (nil entries for
-#                 unreadable / unnormalizable sources), so the per-request
-#                 uri -> module lookups are allocation-free string compares
-# mod_path_count: number of entries in `mod_paths`
-# own_base:       base module id for this root's open buffers, past every loaded
-#                 module id, so a buffer's synthetic module id never collides
-#                 with a dependency's
-# man_mtime:      `mach.toml` mtime at the last load attempt, for the
-#                 conservative reload / retry check
-# lock_mtime:     `mach.lock` mtime at the last load attempt (0 when absent)
-# gen:            generation stamp of the current loaded build - a fresh value
-#                 claimed on each successful load, 0 (reserved) while unloaded;
-#                 resolve cache entries carry it, so a reload or free makes the
-#                 prior build's entries unhittable and per-root evictable
-# vendored:       whether this root's own directory lies under some outer
-#                 project's declared vendor dir - i.e. the whole root is a
-#                 vendored dependency project, so none of its files are the
-#                 editor's to rewrite, regardless of any loaded graph's closure.
-#                 intrinsic to the path (computed at load_root from the ancestor
-#                 manifests), not to the routing that materialized the root
-# sema:           per-loaded-module SemaResult, indexed by ModuleId, parallel to
-#                 the project's module array; populated lazily by ensure_sema on
-#                 the first type-aware feature request, NEVER at load time
-# sema_count:     number of entries in `sema` (= module_len once sema'd, else 0)
-# sema_loaded:    whether sema has run over this build's module graph; reset on
-#                 every (re)load so a fresh build re-runs sema on next demand
+# path:              owned absolute directory containing mach.toml
+# loaded:            whether p is live
+# p:                 retained frontend Project, valid only while loaded
+# mod_paths:         canonical source path per ModuleId
+# mod_path_count:    number of mod_paths entries
+# mod_fingerprints:   on-disk fingerprint per mod_paths entry
+# man_mtime:         last observed manifest mtime
+# lock_mtime:        last observed lockfile mtime
+# vendored:          whether the root belongs to an ancestor dependency tree
+# s:                 separately allocated stable Session owning all identities
+# input_revision:    newest covered document revision mirrored into s
+# snapshot_revision: input revision captured by p
+# attempted_revision:last input revision analyzed, including a failed attempt
+# dirty:             explicit watcher/save invalidation requiring one attempt
 pub rec Root {
     path:           str;
     loaded:         bool;
     p:              driver.Project;
-    deps:           res.ResolveDeps;
     mod_paths:      *str;
     mod_path_count: u32;
-    own_base:       u32;
+    mod_fingerprints: *SourceFingerprint;
     man_mtime:      i64;
     lock_mtime:     i64;
-    gen:            u32;
     vendored:       bool;
-    sema:           *sema.SemaResult;
-    sema_count:     u32;
-    sema_loaded:    bool;
+    s:              *sess.Session;
+    input_revision: u64;
+    snapshot_revision: u64;
+    attempted_revision: u64;
+    dirty:           bool;
 }
 
-# the session's project roots plus the per-buffer resolve cache
+# project roots and the standalone-editor fallback
 # ---
-# s:            the compiler session. feature code must reach its safe services
-#               through `interner` / `sources` and never read this field: its
-#               per-build module registries are clobbered on every project load,
-#               and mach's whole-rec `pub` means the field cannot be sealed -
-#               keeping it out of feature paths is the contract
-# es:           borrowed editor session (buffer parsing)
-# alloc:        allocator for owned storage
-# roots:        array of Root slots (slots with a path are tracked roots)
-# root_cap:     number of slots in `roots`
-# watch_active: whether the client delivers workspace/didChangeWatchedFiles for
-#               the registered globs; when true the per-request manifest-mtime
-#               fallback check is skipped (the watcher covers it)
-# empty:        the empty dep set used for documents outside any project
-# cache:        per-FileId cache of each buffer's dep-aware ResolveResult
-# cache_len:    number of slots in `cache`
-# gen_seq:      next generation stamp to hand out; each successful root build
-#               claims one, pinning a cache entry's gen to an exact build
-# load_epoch:   monotonic counter bumped on every successful root build, so the
-#               server can tell a feature request triggered a lazy load and
-#               re-publish diagnostics for the now-loaded buffers (#96)
-# sema_epoch:   monotonic counter bumped whenever a root's dep closure finishes
-#               sema (ensure_sema), so the server can tell a feature request
-#               triggered the lazy whole-closure typing and re-publish the open
-#               buffers WITH their semantic diagnostics - the type-diagnostics
-#               twin of load_epoch (#113)
+# s:            fallback Session for documents outside projects
+# alloc:        workspace allocator
+# roots:        movable Root slots; each Root.s itself has a stable allocation
+# root_cap:     roots allocation length
+# watch_active: confirmed client watcher state
+# load_epoch:   successful snapshot build counter
+# sema_epoch:   semantic snapshot build counter
+# docs:         borrowed live document store
 pub rec Workspace {
     s:            *sess.Session;
-    es:           *editor.EditorSession;
     alloc:        *Allocator;
     roots:        *Root;
     root_cap:     u32;
     watch_active: bool;
-    empty:        res.ResolveDeps;
-    cache:        *Cached;
-    cache_len:    u32;
-    gen_seq:      u32;
     load_epoch:   u32;
     sema_epoch:   u32;
+    docs:         *documents.Store;
 }
 
 # construct an empty workspace over the server's sessions
 # ---
 # s:     compiler session the graphs load into
-# es:    editor session whose buffers are re-resolved against the graphs
 # alloc: allocator for all workspace-owned storage
 # ret:   an empty, rootless Workspace
-pub fun init(s: *sess.Session, es: *editor.EditorSession, alloc: *Allocator) Workspace {
+pub fun init(s: *sess.Session, alloc: *Allocator) Workspace {
     var w: Workspace;
     w.s             = s;
-    w.es            = es;
     w.alloc         = alloc;
     w.roots         = nil;
     w.root_cap      = 0;
     w.watch_active  = false;
-    w.empty.entries = nil;
-    w.empty.count   = 0;
-    w.cache         = nil;
-    w.cache_len     = 0;
-    w.gen_seq       = 1;
     w.load_epoch    = 0;
     w.sema_epoch    = 0;
+    w.docs          = nil;
     ret w;
 }
 
-# the session's shared string interner - the append-only symbol-name
-# registry feature code resolves StrIds through. handed out instead of the whole
-# session so no feature signature carries one: the session's per-build module
-# registries are clobbered on every project load, and the interner and source
-# map are the only session services a feature may safely read. (mach's whole-rec
-# `pub` leaves `Workspace.s` technically reachable; the narrowed surface is the
-# guard, not a language seal.)
+# attach the live document store after the mutually referring server fields are
+# initialized
 # ---
-# w:   the workspace
-# ret: the session's interner
-pub fun interner(w: *Workspace) *intern.Interner {
-    ret ?w.s.interner;
+# w:    workspace to configure
+# docs: borrowed live document store
+pub fun attach_documents(w: *Workspace, docs: *documents.Store) {
+    w.docs = docs;
 }
 
-# the session's source-file registry, for resolving a FileId to its
-# SourceFile (text + line index). the other safe-to-read session service feature
-# and diagnostics code needs; see `interner` for why the whole session is kept
-# out of feature signatures
+# the governing root's type interner, or the standalone fallback when root is nil
 # ---
-# w:   the workspace
-# ret: the session's source map
-pub fun sources(w: *Workspace) *src.SourceMap {
-    ret ?w.s.sources;
-}
-
-# the session's type interner, for peeling a record / union TypeId
-# to its nominal declaration site (the cross-module field-reference walk reads
-# each module's typing and matches the field's host type against its key through
-# it). the narrow read the feature layer makes; see `interner` for why the whole
-# session is kept out of feature signatures
-# ---
-# w:   the workspace
+# w:    workspace containing the fallback
+# root: governing compiler root
 # ret: the session's type interner
-pub fun type_interner(w: *Workspace) *type.TypeInterner {
+pub fun type_interner(w: *Workspace, root: *Root) *type.TypeInterner {
+    if (root != nil && root.s != nil) { ret ?root.s.types; }
     ret ?w.s.types;
 }
 
@@ -355,30 +215,10 @@ pub fun sema_epoch(w: *Workspace) u32 {
     ret w.sema_epoch;
 }
 
-# whether `root`'s loaded dep closure has already been sema'd, so its
-# retained per-module typing exists. a load-free check: it never triggers a build
-# or ensure_sema. the diagnostics publish path gates buffer sema on this - only on
-# a ready root is sema_doc cheap and correct (one module against retained dep
-# typing); a loaded-but-un-sema'd root publishes parse + resolve only, keeping
-# open/edit instant (#96). false for a nil, unloaded, or un-sema'd root
-# ---
-# root: the candidate governing root, or nil
-# ret:  true when sema has run over root's current build
-pub fun sema_ready(root: *Root) bool {
-    if (root == nil) { ret false; }
-    ret root.loaded && root.sema_loaded;
-}
-
-# release the resolve cache and every loaded root
+# release every retained project and its stable per-root Session
 # ---
 # w: workspace to tear down; all owned fields are zeroed
 pub fun dnit(w: *Workspace) {
-    free_all_cached(w);
-    if (w.cache != nil && w.cache_len > 0) {
-        deallocate[Cached](w.alloc, w.cache, w.cache_len::usize);
-    }
-    w.cache     = nil;
-    w.cache_len = 0;
     if (w.roots != nil) {
         var i: u32 = 0;
         for (i < w.root_cap) {
@@ -391,231 +231,6 @@ pub fun dnit(w: *Workspace) {
     w.root_cap = 0;
 }
 
-# the buffer's dep-aware ResolveResult under `root` (nil for a
-# single-file document). returns the cached result when the buffer's Ast is
-# unchanged since the last resolve; otherwise parses if needed and re-resolves
-# with `res.resolve` against the root's dep set (empty when root is nil)
-# ---
-# w:    the workspace
-# root: the root governing the document (from `root_for`), or nil
-# fid:  FileId of an open editor buffer
-# ret:  a borrowed pointer to the cached ResolveResult, or an error
-pub fun resolve_doc(w: *Workspace, root: *Root, fid: src.FileId) Result[*res.ResolveResult, str] {
-    var a: *ast.Ast = editor.ast_of(w.es, fid);
-    if (a != nil) {
-        val hit: *res.ResolveResult = cache_hit(w, fid, a, root);
-        if (hit != nil) { ret ok[*res.ResolveResult, str](hit); }
-    }
-    if (a == nil) {
-        val pr: Result[*ast.Ast, str] = editor.parse(w.es, fid);
-        if (is_err[*ast.Ast, str](pr)) { ret err[*res.ResolveResult, str](unwrap_err[*ast.Ast, str](pr)); }
-        a = unwrap_ok[*ast.Ast, str](pr);
-    }
-    ret resolve_fresh(w, root, fid, a);
-}
-
-# re-resolve buffer `a` (FileId `fid`) against `root`'s dep set
-# unconditionally - the cache-miss core shared by `resolve_doc` (after its cache
-# check) and `diagnose_doc` (which forces a fresh parse to repopulate the session
-# DiagList). drops any prior cached result for `fid`, resolves with `res.resolve`,
-# and caches the new result. the resolve's diagnostics land on the session
-# DiagList, which `diagnose_doc` then publishes
-# ---
-# w:    the workspace
-# root: the root governing the document, or nil for a single-file document
-# fid:  FileId of the open buffer
-# a:    the buffer's current parsed Ast
-# ret:  a borrowed pointer to the cached ResolveResult, or an error
-fun resolve_fresh(w: *Workspace, root: *Root, fid: src.FileId, a: *ast.Ast) Result[*res.ResolveResult, str] {
-    free_cached(w, fid);
-
-    # resolve under the same comptime environment the project's own modules
-    # were resolved under, so target-gated imports ($if on os / arch) fold the
-    # same way; neutral host defaults outside a project
-    var deps: *res.ResolveDeps = ?w.empty;
-    var ctx: comptime.ComptimeCtx;
-    if (root != nil) {
-        deps = ?root.deps;
-        ctx = comptime.init(w.alloc, root.p.target.os_id, root.p.target.arch_id, root.p.target.abi_id, comptime.MODE_DEBUG, 0, root.p.target.isa.pointer_width, root.p.target.model.vector_bits, root.p.compiler_name, root.p.compiler_ver);
-        comptime.set_target_defs(?ctx, root.p.target.isa.defs);
-    }
-    or {
-        ctx = comptime.init(w.alloc, 0, 0, 0, comptime.MODE_DEBUG, 0, 8, isa.VECTOR_BITS_128, intern.STR_NIL, intern.STR_NIL);
-    }
-
-    val own: sess.ModuleId = own_module(root, fid);
-    val rr_r: Result[res.ResolveResult, str] = res.resolve(w.s, a, deps, ?ctx, own);
-    comptime.dnit(?ctx);
-    if (is_err[res.ResolveResult, str](rr_r)) {
-        ret err[*res.ResolveResult, str](unwrap_err[res.ResolveResult, str](rr_r));
-    }
-
-    val slot_r: Result[*res.ResolveResult, str] = allocate[res.ResolveResult](w.alloc, 1);
-    if (is_err[*res.ResolveResult, str](slot_r)) {
-        var local: res.ResolveResult = unwrap_ok[res.ResolveResult, str](rr_r);
-        res.dnit_result(?local);
-        ret slot_r;
-    }
-    val slot: *res.ResolveResult = unwrap_ok[*res.ResolveResult, str](slot_r);
-    @slot = unwrap_ok[res.ResolveResult, str](rr_r);
-
-    if (!cache_put(w, fid, slot, a, root_gen(root))) {
-        res.dnit_result(slot);
-        deallocate[res.ResolveResult](w.alloc, slot, 1);
-        ret err[*res.ResolveResult, str]("project: resolve cache allocation failed");
-    }
-    ret ok[*res.ResolveResult, str](slot);
-}
-
-# the buffer's SemaResult under `root` - its per-expression typing,
-# computed against the root's dep-closure typing. the type-aware twin of
-# `resolve_doc`: it first resolves the buffer (populating the resolve cache entry),
-# then, on a cache miss for the same Ast / build, lazily sema's the whole root
-# graph (`ensure_sema`) so every dependency's decl types are available, and finally
-# sema's the buffer itself against a SemaDeps spanning every sema'd root module -
-# keyed on the same Ast-pointer / generation stamp the resolve cache uses, so an
-# unedited buffer reuses it. heavy on a cold root (the first call pays for the whole
-# dep closure), so it is reached only from a type-aware feature, never the
-# diagnostics publish path. `root` must be non-nil: a single-file document has no
-# dep typing to check against. the returned pointer is owned by the cache
-# ---
-# w:    the workspace
-# root: the loaded root governing the document (non-nil)
-# fid:  FileId of an open editor buffer
-# ret:  a borrowed pointer to the cached SemaResult, or an error
-pub fun sema_doc(w: *Workspace, root: *Root, fid: src.FileId) Result[*sema.SemaResult, str] {
-    if (root == nil) { ret err[*sema.SemaResult, str]("project: sema requires a loaded project root"); }
-
-    val rr_r: Result[*res.ResolveResult, str] = resolve_doc(w, root, fid);
-    if (is_err[*res.ResolveResult, str](rr_r)) {
-        ret err[*sema.SemaResult, str](unwrap_err[*res.ResolveResult, str](rr_r));
-    }
-    val rr: *res.ResolveResult = unwrap_ok[*res.ResolveResult, str](rr_r);
-
-    val c: *Cached = cache_slot(w, fid);
-    if (c == nil) { ret err[*sema.SemaResult, str]("project: buffer not cached for sema"); }
-    if (c.sr != nil) { ret ok[*sema.SemaResult, str](c.sr); }
-
-    val a: *ast.Ast = editor.ast_of(w.es, fid);
-    if (a == nil) { ret err[*sema.SemaResult, str]("project: buffer ast unavailable for sema"); }
-
-    # the buffer types against the dep closure, so the whole graph must be sema'd
-    # first; ensure_sema is idempotent and cached for the build.
-    ensure_sema(w, root);
-
-    var deps: sema.SemaDeps;
-    build_full_sema_deps(w, root, ?deps);
-
-    val own: sess.ModuleId = own_module(root, fid);
-    var ctx: comptime.ComptimeCtx = comptime.init(w.alloc, root.p.target.os_id, root.p.target.arch_id, root.p.target.abi_id, comptime.MODE_DEBUG, 0, root.p.target.isa.pointer_width, root.p.target.model.vector_bits, root.p.compiler_name, root.p.compiler_ver);
-    comptime.set_target_defs(?ctx, root.p.target.isa.defs);
-    val sr_r: Result[sema.SemaResult, str] = sema.sema(w.s, a, rr, ?deps, ?ctx, own);
-    comptime.dnit(?ctx);
-    free_sema_deps(w, ?deps);
-    if (is_err[sema.SemaResult, str](sr_r)) {
-        ret err[*sema.SemaResult, str](unwrap_err[sema.SemaResult, str](sr_r));
-    }
-
-    val slot_r: Result[*sema.SemaResult, str] = allocate[sema.SemaResult](w.alloc, 1);
-    if (is_err[*sema.SemaResult, str](slot_r)) {
-        var local: sema.SemaResult = unwrap_ok[sema.SemaResult, str](sr_r);
-        sema.dnit_result(?local);
-        ret slot_r;
-    }
-    val slot: *sema.SemaResult = unwrap_ok[*sema.SemaResult, str](slot_r);
-    @slot = unwrap_ok[sema.SemaResult, str](sr_r);
-    c.sr = slot;
-    ret ok[*sema.SemaResult, str](slot);
-}
-
-# assemble a SemaDeps spanning EVERY sema'd module of
-# `root`, for typing the active buffer (which may `use` any loaded module). each
-# entry borrows the module's retained decl_type snapshot; an un-sema'd module
-# contributes a decl-type-less entry (a lookup against it yields TYPE_ERROR, like a
-# miss). writes the deps into `out`, leaving it empty on allocation failure or when
-# the root has no retained sema. the borrowed arrays are owned by the Root's
-# SemaResults, so the result must be released with `free_sema_deps`
-fun build_full_sema_deps(w: *Workspace, root: *Root, out: *sema.SemaDeps) {
-    out.entries = nil;
-    out.count   = 0;
-    val n: u32 = root.sema_count;
-    if (root.sema == nil || n == 0) { ret; }
-
-    val r: Result[*sema.ModuleSema, str] = allocate[sema.ModuleSema](w.alloc, n::usize);
-    if (is_err[*sema.ModuleSema, str](r)) { ret; }
-    out.entries = unwrap_ok[*sema.ModuleSema, str](r);
-    out.count   = n;
-
-    var i: u32 = 0;
-    for (i < n) {
-        var ms: sema.ModuleSema;
-        ms.path       = (?root.p.modules[i]).fqn;
-        ms.module     = i::sess.ModuleId;
-        ms.decl_type  = root.sema[i].decl_type;
-        ms.decl_count = root.sema[i].decl_count;
-        out.entries[i] = ms;
-        i = i + 1;
-    }
-}
-
-# the Cached entry for `fid`, or nil when out of range. the borrowed
-# slot handle sema_doc uses to attach a buffer's SemaResult to its resolve entry
-fun cache_slot(w: *Workspace, fid: src.FileId) *Cached {
-    if (w.cache == nil || fid::u32 >= w.cache_len) { ret nil; }
-    ret ?w.cache[fid::u32];
-}
-
-# parse and dep-aware-resolve the buffer governed by `root`,
-# returning the session DiagList populated with both its syntactic and its
-# name-resolution diagnostics. resolving against `root.deps` - the same dep set
-# go-to-definition uses - is what makes an import of a module outside the
-# project's dep closure surface its `imported module is not in the dep set`
-# diagnostic instead of binding silently to SYMBOL_NIL, so the published
-# diagnostics and what the features can resolve no longer disagree (#78). the
-# dep-aware ResolveResult is cached as a side effect, so a feature request on the
-# same unedited buffer reuses it. the fresh parse resets the session DiagList and
-# emits this buffer's lex / parse diagnostics; the resolve appends its own.
-# `root` must be non-nil: a single-file document keeps the editor's parse-only
-# diagnostics so its cross-module `use`s are not flagged against an empty dep set
-# ---
-# w:    the workspace
-# root: the root governing the document (non-nil)
-# fid:  FileId of the open buffer
-# ret:  a borrowed pointer to the session DiagList, or an error
-pub fun diagnose_doc(w: *Workspace, root: *Root, fid: src.FileId) Result[*diag.DiagList, str] {
-    val pr: Result[*ast.Ast, str] = editor.parse(w.es, fid);
-    if (is_err[*ast.Ast, str](pr)) { ret err[*diag.DiagList, str](unwrap_err[*ast.Ast, str](pr)); }
-    val a: *ast.Ast = unwrap_ok[*ast.Ast, str](pr);
-
-    val rr: Result[*res.ResolveResult, str] = resolve_fresh(w, root, fid, a);
-    if (is_err[*res.ResolveResult, str](rr)) {
-        ret err[*diag.DiagList, str](unwrap_err[*res.ResolveResult, str](rr));
-    }
-    ret ok[*diag.DiagList, str](?w.s.diags);
-}
-
-# the synthetic module id a buffer resolves under for `root`. offset
-# past every loaded module id so a buffer-local symbol's `origin` never equals a
-# loaded dependency's, keeping the local/cross-module distinction exact. base 0
-# for a single-file document (root nil), whose empty dep set has no module ids
-# ---
-# root: the root governing the buffer, or nil
-# fid:  FileId of the buffer
-# ret:  the buffer's module id for resolution
-pub fun own_module(root: *Root, fid: src.FileId) sess.ModuleId {
-    var base: u32 = 0;
-    if (root != nil) { base = root.own_base; }
-    ret (base + fid::u32)::sess.ModuleId;
-}
-
-# the generation stamp a buffer's resolve carries under `root` - the
-# root's current build generation, or the reserved 0 for a single-file document
-# (root nil). the single source of the stamp rule, shared by cache_put's write
-# and cache_hit's check so the two sides cannot drift
-fun root_gen(root: *Root) u32 {
-    if (root == nil) { ret 0; }
-    ret root.gen;
-}
 
 # the root governing the document at `uri`, loading it on first use,
 # or nil when the document resolves single-file (no ancestor `mach.toml`, or a
@@ -630,10 +245,6 @@ fun root_gen(root: *Root) u32 {
 pub fun root_for(w: *Workspace, uri: str) *Root {
     if (uri == nil) { ret nil; }
     val doc_root: str = document_root(w, uri);
-
-    # a loaded root rooted elsewhere that holds the document as one of its
-    # modules governs it read-only: a vendored dependency resolves in the
-    # project that depends on it, never as its own project
     val twin: *Root = containing_root(w, uri, doc_root);
     if (twin != nil) {
         if (doc_root != nil) { strutil.str_free(w.alloc, doc_root); }
@@ -645,17 +256,13 @@ pub fun root_for(w: *Workspace, uri: str) *Root {
     if (existing != nil) {
         strutil.str_free(w.alloc, doc_root);
         maybe_reload(w, existing);
+        val rr: Result[bool, str] = refresh_inputs(w, existing);
+        if (is_err[bool, str](rr)) { ret nil; }
         if (!existing.loaded) { ret nil; }
         ret existing;
     }
-
-    # fresh root: when an ancestor project declares this root as one of its dep
-    # vendor dirs, load that project and prefer it when its graph holds the
-    # document - so a dependency source opened before any project document
-    # still routes read-only instead of becoming its own renameable project
     val outer: *Root = ancestor_root(w, uri, doc_root, doc_root);
     if (outer != nil) { strutil.str_free(w.alloc, doc_root); ret outer; }
-
     ret load_root(w, doc_root);
 }
 
@@ -675,12 +282,8 @@ pub fun root_for(w: *Workspace, uri: str) *Root {
 # ret: a borrowed pointer to the governing loaded Root, or nil
 pub fun root_for_loaded(w: *Workspace, uri: str) *Root {
     if (uri == nil) { ret nil; }
-
-    # a loaded root rooted elsewhere holding the document governs it read-only,
-    # exactly as in root_for - checked without reloading
     val twin: *Root = containing_root_loaded(w, uri);
     if (twin != nil) { ret twin; }
-
     val doc_root: str = document_root(w, uri);
     if (doc_root == nil) { ret nil; }
     val existing: *Root = find_root(w, doc_root);
@@ -753,7 +356,7 @@ fun vendors_enclosing(w: *Workspace, root_path: str, dir: str) bool {
     if (is_err[toml.Table, str](t_r)) { ret false; }
     var t: toml.Table = unwrap_ok[toml.Table, str](t_r);
 
-    val deps: *toml.Table = toml.get_table(?t, "deps");
+    val deps: *toml.Table = toml.get_table(?t, "dep");
     if (deps == nil) { ret false; }
     var dir_dep: str = toml.get_str(?t, "project.dep");
     if (dir_dep == nil) { dir_dep = "dep"; }
@@ -823,6 +426,7 @@ fun containing_root(w: *Workspace, uri: str, doc_root: str) *Root {
             && (doc_root == nil || !str_equals(r.path, doc_root))
             && is_some[sess.ModuleId](module_for_norm(r, norm))) {
             maybe_reload(w, r);
+            refresh_inputs(w, r);
             if (r.loaded && is_some[sess.ModuleId](module_for_norm(r, norm))
                 && (found == nil || str_len(r.path) < str_len(found.path))) {
                 found = r;
@@ -869,6 +473,17 @@ fun containing_root_loaded(w: *Workspace, uri: str) *Root {
 fun load_root(w: *Workspace, root_path: str) *Root {
     val slot: *Root = alloc_slot(w);
     if (slot == nil) { strutil.str_free(w.alloc, root_path); ret nil; }
+    val sp_r: Result[*sess.Session, str] = allocate[sess.Session](w.alloc, 1);
+    if (is_err[*sess.Session, str](sp_r)) { strutil.str_free(w.alloc, root_path); ret nil; }
+    slot.s = unwrap_ok[*sess.Session, str](sp_r);
+    val sr: Result[sess.Session, str] = sess.init(w.alloc);
+    if (is_err[sess.Session, str](sr)) {
+        deallocate[sess.Session](w.alloc, slot.s, 1);
+        slot.s = nil;
+        strutil.str_free(w.alloc, root_path);
+        ret nil;
+    }
+    @slot.s = unwrap_ok[sess.Session, str](sr);
     slot.path     = root_path;
     slot.vendored = vendored_under_ancestor(w, root_path);
     if (try_load(w, slot)) { ret slot; }
@@ -911,18 +526,17 @@ fun vendored_under_ancestor(w: *Workspace, root_path: str) bool {
 fun reset_slot(r: *Root) {
     r.path           = nil;
     r.loaded         = false;
-    r.deps.entries   = nil;
-    r.deps.count     = 0;
     r.mod_paths      = nil;
     r.mod_path_count = 0;
-    r.own_base       = 0;
+    r.mod_fingerprints = nil;
     r.man_mtime      = 0;
     r.lock_mtime     = 0;
-    r.gen            = 0;
     r.vendored       = false;
-    r.sema           = nil;
-    r.sema_count     = 0;
-    r.sema_loaded    = false;
+    r.s              = nil;
+    r.input_revision = 0;
+    r.snapshot_revision = 0;
+    r.attempted_revision = 0;
+    r.dirty = false;
 }
 
 # a reusable dead slot, growing the array when every slot is
@@ -968,14 +582,73 @@ fun alloc_slot(w: *Workspace) *Root {
 # rather than being served stale
 fun try_load(w: *Workspace, r: *Root) bool {
     record_mtimes(w, r);
-
-    val reg_r: Result[bool, str] = tgt.register_all(?w.s.registry);
-    if (is_err[bool, str](reg_r)) {
-        report_load_failure(w, r.path, unwrap_err[bool, str](reg_r));
+    r.dirty = false;
+    val sor: Result[bool, str] = sync_overlays(w, r);
+    if (is_err[bool, str](sor)) {
+        report_load_failure(w, r.path, unwrap_err[bool, str](sor));
         ret false;
     }
+    r.attempted_revision = r.input_revision;
 
-    val pr: Result[driver.Project, outcome.Fail] = driver.build_project_union(w.s, r.path);
+    val mr: Result[manifest.Manifest, str] = driver.load_manifest(r.s, r.path);
+    if (is_err[manifest.Manifest, str](mr)) {
+        report_load_failure(w, r.path, unwrap_err[manifest.Manifest, str](mr));
+        ret false;
+    }
+    var m: manifest.Manifest = unwrap_ok[manifest.Manifest, str](mr);
+
+    var sel: manifest.Selection;
+    sel.target = "";
+    sel.profile = "";
+    sel.artifact = "";
+    sel.want_lib = false;
+    sel.has_artifact = false;
+    val psr: Result[bool, str] = manifest.select_primary_artifact(w.alloc, ?r.s.interner, ?m, ?sel);
+    if (is_err[bool, str](psr)) {
+        val msg: str = unwrap_err[bool, str](psr);
+        manifest.dnit(?m, r.s.build_alloc);
+        report_load_failure(w, r.path, msg);
+        ret false;
+    }
+    if (!sel.has_artifact && m.artifact_count == 1) {
+        val ao: Option[str] = intern.lookup(?r.s.interner, m.artifacts[0].name);
+        if (!is_some[str](ao)) {
+            manifest.dnit(?m, r.s.build_alloc);
+            report_load_failure(w, r.path, "project: artifact name is not interned");
+            ret false;
+        }
+        sel.artifact = unwrap[str](ao);
+        sel.want_lib = m.artifacts[0].is_lib;
+        sel.has_artifact = true;
+    }
+
+    var cli: request.CliArgs = empty_cli();
+    val rr: Result[request.BuildRequest, outcome.Fail] = request.compose(
+        w.alloc, ?r.s.interner, ?m, ?cli, r.path, request.GOAL_OBJECTS, ?sel);
+    if (is_err[request.BuildRequest, outcome.Fail](rr)) {
+        var f: outcome.Fail = unwrap_err[request.BuildRequest, outcome.Fail](rr);
+        manifest.dnit(?m, r.s.build_alloc);
+        report_load_failure(w, r.path, fail_message(?f));
+        ret false;
+    }
+    var req: request.BuildRequest = unwrap_ok[request.BuildRequest, outcome.Fail](rr);
+
+    var extra: *intern.StrId = nil;
+    val ecr: Result[u32, str] = collect_extra_roots(w, r, ?m, ?extra);
+    if (is_err[u32, str](ecr)) {
+        val msg: str = unwrap_err[u32, str](ecr);
+        vector.dnit[request.LinkToken](?req.link_tokens);
+        vector.dnit[str](?req.lib_dirs);
+        manifest.dnit(?m, r.s.build_alloc);
+        report_load_failure(w, r.path, msg);
+        ret false;
+    }
+    val extra_count: u32 = unwrap_ok[u32, str](ecr);
+    val pr: Result[driver.Project, outcome.Fail] = driver.analyze_project(r.s, ?m, ?req, extra, extra_count);
+    if (extra != nil) { deallocate[intern.StrId](w.alloc, extra, documents.slot_count(w.docs)); }
+    vector.dnit[request.LinkToken](?req.link_tokens);
+    vector.dnit[str](?req.lib_dirs);
+    manifest.dnit(?m, r.s.build_alloc);
     if (is_err[driver.Project, outcome.Fail](pr)) {
         var f: outcome.Fail = unwrap_err[driver.Project, outcome.Fail](pr);
         report_load_failure(w, r.path, fail_message(?f));
@@ -984,30 +657,167 @@ fun try_load(w: *Workspace, r: *Root) bool {
 
     r.p        = unwrap_ok[driver.Project, outcome.Fail](pr);
     r.loaded   = true;
-    r.own_base = r.p.module_len;
-    r.gen      = next_gen(w);
-    # sema is lazy: a fresh build starts un-sema'd, run on the first type-aware
-    # feature request (ensure_sema), never here on the load path.
-    r.sema        = nil;
-    r.sema_count  = 0;
-    r.sema_loaded = false;
+    r.snapshot_revision = r.input_revision;
     w.load_epoch = w.load_epoch + 1;
+    w.sema_epoch = w.sema_epoch + 1;
     build_mod_paths(w, r);
-    build_deps(w, r);
     ret true;
+}
+
+fun empty_cli() request.CliArgs {
+    var c: request.CliArgs;
+    c.verbosity = 0;
+    c.quiet = false;
+    c.verify_ir = false;
+    c.target = nil;
+    c.output = nil;
+    c.emit_asm = false;
+    c.emit_ir = false;
+    c.profile = nil;
+    c.bin = nil;
+    c.lib = nil;
+    c.all_targets = false;
+    c.pie = false;
+    c.subsystem = nil;
+    c.g = false;
+    c.opt_set = false;
+    c.opt_release = false;
+    c.jobs = nil;
+    c.include_deps = false;
+    c.link_tokens = vector.init[*u8](nil);
+    c.lib_dirs = vector.init[*u8](nil);
+    ret c;
+}
+
+# mirror every open filesystem buffer covered by a root into its persistent
+# compiler session and capture the latest input revision.
+fun sync_overlays(w: *Workspace, r: *Root) Result[bool, str] {
+    if (w.docs == nil) { ret ok[bool, str](true); }
+    # Reset keys before reconstructing them from the authoritative open set. This
+    # removes normalized and manifest-raw spellings for documents closed since
+    # the previous snapshot.
+    for (r.s.overlay_len > 0) { sess.clear_overlay(r.s, r.s.overlays[0].path); }
+    val n: usize = documents.slot_count(w.docs);
+    var latest: u64 = r.input_revision;
+    var i: usize = 0;
+    for (i < n) {
+        val d: *documents.Document = documents.at(w.docs, i);
+        if (d != nil && d.in_use && d.path != nil && root_covers(w, d.path, r.path)) {
+            val sr: Result[bool, str] = sess.set_overlay(r.s, d.path, d.text);
+            if (is_err[bool, str](sr)) { ret sr; }
+            if (d.revision > latest) { latest = d.revision; }
+        }
+        i = i + 1;
+    }
+    r.input_revision = latest;
+    ret ok[bool, str](true);
+}
+
+# build compiler-owned extra roots for open files under this project's source
+# directory. files already in the artifact closure are harmless duplicates.
+fun collect_extra_roots(w: *Workspace, r: *Root, m: *manifest.Manifest, out: **intern.StrId) Result[u32, str] {
+    @out = nil;
+    if (w.docs == nil) { ret ok[u32, str](0); }
+    val n: usize = documents.slot_count(w.docs);
+    if (n == 0) { ret ok[u32, str](0); }
+    if (n > 4294967295) { ret err[u32, str]("project: too many open documents"); }
+    val ar: Result[*intern.StrId, str] = allocate[intern.StrId](w.alloc, n);
+    if (is_err[*intern.StrId, str](ar)) { ret err[u32, str](unwrap_err[*intern.StrId, str](ar)); }
+    val roots: *intern.StrId = unwrap_ok[*intern.StrId, str](ar);
+
+    val io: Option[str] = intern.lookup(?r.s.interner, m.id);
+    val so: Option[str] = intern.lookup(?r.s.interner, m.src);
+    if (!is_some[str](io) || !is_some[str](so)) {
+        deallocate[intern.StrId](w.alloc, roots, n);
+        ret err[u32, str]("project: manifest source path is not interned");
+    }
+    val src_r: Result[pathlib.Path, str] = pathlib.join(w.alloc, r.path, unwrap[str](so));
+    if (is_err[pathlib.Path, str](src_r)) {
+        deallocate[intern.StrId](w.alloc, roots, n);
+        ret err[u32, str](unwrap_err[pathlib.Path, str](src_r));
+    }
+    val src_norm: str = normalize_path(w.alloc, unwrap_ok[pathlib.Path, str](src_r));
+    strutil.str_free(w.alloc, unwrap_ok[pathlib.Path, str](src_r));
+    if (src_norm == nil) { deallocate[intern.StrId](w.alloc, roots, n); ret err[u32, str]("project: failed to normalize source directory"); }
+
+    var count: u32 = 0;
+    var i: usize = 0;
+    for (i < n) {
+        val d: *documents.Document = documents.at(w.docs, i);
+        if (d != nil && d.in_use && d.path != nil && is_under(d.path, src_norm)) {
+            # Also mirror under the driver's exact `<root>/<manifest src>/<rel>`
+            # spelling. Manifests may use `./src`; overlays are exact path keys.
+            val raw_src_r: Result[pathlib.Path, str] = pathlib.join(w.alloc, r.path, unwrap[str](so));
+            if (is_err[pathlib.Path, str](raw_src_r)) {
+                strutil.str_free(w.alloc, src_norm);
+                deallocate[intern.StrId](w.alloc, roots, n);
+                ret err[u32, str](unwrap_err[pathlib.Path, str](raw_src_r));
+            }
+            val raw_src: str = unwrap_ok[pathlib.Path, str](raw_src_r);
+            val raw_path_r: Result[pathlib.Path, str] = pathlib.join(w.alloc, raw_src,
+                (d.path::usize + str_len(src_norm) + 1)::str);
+            strutil.str_free(w.alloc, raw_src);
+            if (is_err[pathlib.Path, str](raw_path_r)) {
+                strutil.str_free(w.alloc, src_norm);
+                deallocate[intern.StrId](w.alloc, roots, n);
+                ret err[u32, str](unwrap_err[pathlib.Path, str](raw_path_r));
+            }
+            val raw_path: str = unwrap_ok[pathlib.Path, str](raw_path_r);
+            val orr: Result[bool, str] = sess.set_overlay(r.s, raw_path, d.text);
+            strutil.str_free(w.alloc, raw_path);
+            if (is_err[bool, str](orr)) {
+                strutil.str_free(w.alloc, src_norm);
+                deallocate[intern.StrId](w.alloc, roots, n);
+                ret err[u32, str](unwrap_err[bool, str](orr));
+            }
+            val fr: Result[intern.StrId, str] = document_fqn(r, unwrap[str](io), src_norm, d.path);
+            if (is_err[intern.StrId, str](fr)) {
+                strutil.str_free(w.alloc, src_norm);
+                deallocate[intern.StrId](w.alloc, roots, n);
+                ret err[u32, str](unwrap_err[intern.StrId, str](fr));
+            }
+            roots[count] = unwrap_ok[intern.StrId, str](fr);
+            count = count + 1;
+        }
+        i = i + 1;
+    }
+    strutil.str_free(w.alloc, src_norm);
+    if (count == 0) { deallocate[intern.StrId](w.alloc, roots, n); ret ok[u32, str](0); }
+    @out = roots;
+    ret ok[u32, str](count);
+}
+
+fun document_fqn(r: *Root, id_text: str, src_dir: str, path: str) Result[intern.StrId, str] {
+    val prefix: usize = str_len(src_dir);
+    val plen: usize = str_len(path);
+    if (plen <= prefix + 6 || path[prefix] != '/') { ret err[intern.StrId, str]("project: document lies outside the source directory"); }
+    if (path[plen - 5] != '.' || path[plen - 4] != 'm' || path[plen - 3] != 'a'
+        || path[plen - 2] != 'c' || path[plen - 1] != 'h') { ret err[intern.StrId, str]("project: document is not a Mach source file"); }
+    val rel_len: usize = plen - prefix - 1 - 5;
+    val id_len: usize = str_len(id_text);
+    val total: usize = id_len + 1 + rel_len;
+    val br: Result[*u8, str] = allocate[u8](r.s.alloc, total);
+    if (is_err[*u8, str](br)) { ret err[intern.StrId, str](unwrap_err[*u8, str](br)); }
+    val buf: *u8 = unwrap_ok[*u8, str](br);
+    var i: usize = 0;
+    for (i < id_len) { buf[i] = id_text[i]; i = i + 1; }
+    buf[id_len] = '.';
+    var j: usize = 0;
+    for (j < rel_len) {
+        val c: u8 = path[prefix + 1 + j];
+        if (c == '/') { buf[id_len + 1 + j] = '.'; }
+        or { buf[id_len + 1 + j] = c; }
+        j = j + 1;
+    }
+    val ir: Result[intern.StrId, str] = intern.intern_bytes(?r.s.interner, buf::str, total);
+    deallocate[u8](r.s.alloc, buf, total);
+    ret ir;
 }
 
 # hand out a fresh generation stamp. each successful build claims one,
 # so a cache entry's generation identifies its exact build and a reloaded or
 # freed root's stale entries can never match a later build. 0 is the reserved
 # unloaded / single-file sentinel and is skipped if the sequence ever wraps
-fun next_gen(w: *Workspace) u32 {
-    if (w.gen_seq == 0) { w.gen_seq = 1; }
-    val g: u32 = w.gen_seq;
-    w.gen_seq = w.gen_seq + 1;
-    ret g;
-}
-
 # snapshot every loaded module's normalized source path into
 # `r.mod_paths`, indexed by module id, so the per-request uri -> module lookups
 # are allocation-free string compares. a source that cannot be read or
@@ -1018,15 +828,24 @@ fun build_mod_paths(w: *Workspace, r: *Root) {
     if (n == 0) { ret; }
     val arr_r: Result[*str, str] = allocate[str](w.alloc, n::usize);
     if (is_err[*str, str](arr_r)) { ret; }
+    val mt_r: Result[*SourceFingerprint, str] = allocate[SourceFingerprint](w.alloc, n::usize);
+    if (is_err[*SourceFingerprint, str](mt_r)) {
+        deallocate[str](w.alloc, unwrap_ok[*str, str](arr_r), n::usize);
+        ret;
+    }
     r.mod_paths      = unwrap_ok[*str, str](arr_r);
+    r.mod_fingerprints = unwrap_ok[*SourceFingerprint, str](mt_r);
     r.mod_path_count = n;
 
     var i: u32 = 0;
     for (i < n) {
         r.mod_paths[i] = nil;
-        val fo: Option[*src.SourceFile] = src.get(?w.s.sources, (?r.p.modules[i]).file_id);
+        r.mod_fingerprints[i].mtime = 0;
+        r.mod_fingerprints[i].size = 0;
+        val fo: Option[*src.SourceFile] = src.get(?r.s.sources, (?r.p.modules[i]).file_id);
         if (is_some[*src.SourceFile](fo)) {
             r.mod_paths[i] = normalize_path(w.alloc, unwrap[*src.SourceFile](fo).path);
+            if (r.mod_paths[i] != nil) { r.mod_fingerprints[i] = file_fingerprint(r.mod_paths[i]); }
         }
         i = i + 1;
     }
@@ -1041,25 +860,76 @@ fun free_mod_paths(w: *Workspace, r: *Root) {
         i = i + 1;
     }
     deallocate[str](w.alloc, r.mod_paths, r.mod_path_count::usize);
+    if (r.mod_fingerprints != nil) { deallocate[SourceFingerprint](w.alloc, r.mod_fingerprints, r.mod_path_count::usize); }
     r.mod_paths      = nil;
+    r.mod_fingerprints = nil;
     r.mod_path_count = 0;
 }
 
 # rebuild `r`'s graph when its manifest or lockfile changed on
 # disk since the last load attempt - the conservative fallback for clients that
 # do not deliver `workspace/didChangeWatchedFiles`, and the retry path for a
-# root whose previous load failed (a since-fixed manifest). skipped entirely
-# when file watching is active: the watcher already invalidates on those
-# changes, so the per-request stats would be pure overhead. a no-op when
-# nothing changed
+# root whose previous load failed. watcher delivery improves latency but does
+# not disable this correctness fallback. a no-op when nothing changed
 fun maybe_reload(w: *Workspace, r: *Root) {
-    if (w.watch_active) { ret; }
     var man:  i64 = 0;
     var lock: i64 = 0;
     stat_mtimes(w, r.path, ?man, ?lock);
-    if (man == r.man_mtime && lock == r.lock_mtime) { ret; }
+    var changed: bool = man != r.man_mtime || lock != r.lock_mtime;
+    var i: u32 = 0;
+    for (!changed && r.loaded && i < r.mod_path_count) {
+        if (r.mod_paths[i] != nil) {
+            val fp: SourceFingerprint = file_fingerprint(r.mod_paths[i]);
+            if (fp.mtime != r.mod_fingerprints[i].mtime || fp.size != r.mod_fingerprints[i].size) { changed = true; }
+        }
+        i = i + 1;
+    }
+    if (!changed) { ret; }
     free_root_graph(w, r);
     try_load(w, r);
+}
+
+# rebuild a retained snapshot when any covered open document has advanced past
+# the revision captured by the compiler-owned project.
+fun refresh_inputs(w: *Workspace, r: *Root) Result[bool, str] {
+    if (r.dirty || (r.loaded && r.input_revision != r.snapshot_revision)) {
+        free_root_graph(w, r);
+        try_load(w, r);
+    }
+    or (!r.loaded && r.input_revision != r.attempted_revision) {
+        try_load(w, r);
+    }
+    ret ok[bool, str](r.loaded);
+}
+
+# mirror a changed document into every already-tracked root it belongs to and
+# mark those snapshots stale. a not-yet-tracked root picks it up during load.
+pub fun document_changed(w: *Workspace, d: *documents.Document) Result[bool, str] {
+    if (d == nil || d.path == nil || w.roots == nil) { ret ok[bool, str](true); }
+    var i: u32 = 0;
+    for (i < w.root_cap) {
+        val r: *Root = ?w.roots[i];
+        if (r.path != nil && r.s != nil && root_covers(w, d.path, r.path)) {
+            r.input_revision = d.revision;
+        }
+        i = i + 1;
+    }
+    ret ok[bool, str](true);
+}
+
+# remove a closing document's compiler overlays before its owned text is freed.
+# the next request rebuilds affected snapshots from disk.
+pub fun document_closed(w: *Workspace, d: *documents.Document) {
+    if (d == nil || d.path == nil || w.roots == nil) { ret; }
+    var i: u32 = 0;
+    for (i < w.root_cap) {
+        val r: *Root = ?w.roots[i];
+        if (r.path != nil && r.s != nil && root_covers(w, d.path, r.path)) {
+            sess.clear_overlay(r.s, d.path);
+            r.input_revision = d.revision;
+        }
+        i = i + 1;
+    }
 }
 
 # drop every loaded root whose tree contains the changed file, so
@@ -1079,7 +949,10 @@ pub fun invalidate_uri(w: *Workspace, uri: str) {
     for (i < w.root_cap) {
         val r: *Root = ?w.roots[i];
         if (r.path != nil && root_covers(w, norm, r.path)) {
-            free_root(w, r);
+            free_root_graph(w, r);
+            r.man_mtime = 0 - 1;
+            r.lock_mtime = 0 - 1;
+            r.dirty = true;
         }
         i = i + 1;
     }
@@ -1110,6 +983,11 @@ fun is_under(file: str, dir: str) bool {
 # the slot for reuse
 fun free_root(w: *Workspace, r: *Root) {
     free_root_graph(w, r);
+    if (r.s != nil) {
+        sess.dnit(r.s);
+        deallocate[sess.Session](w.alloc, r.s, 1);
+        r.s = nil;
+    }
     if (r.path != nil) { strutil.str_free(w.alloc, r.path); }
     reset_slot(r);
 }
@@ -1120,36 +998,11 @@ fun free_root(w: *Workspace, r: *Root) {
 # reclaims them rather than leaving them for the whole-cache sweep), and the
 # generation is cleared so a later build claims a fresh, non-matching one
 fun free_root_graph(w: *Workspace, r: *Root) {
-    evict_root(w, r);
-    free_sema(w, r);
-    free_deps(w, ?r.deps);
     free_mod_paths(w, r);
     if (r.loaded) {
         driver.dnit_project(?r.p);
         r.loaded = false;
     }
-    r.gen = 0;
-}
-
-# tear down the root's retained per-module SemaResults and the array
-# holding them, resetting the lazy-sema state so a reloaded build re-runs sema on
-# next demand. each SemaResult's parallel TypeId arrays are freed; the interned
-# types they reference live on the session and are not touched here
-fun free_sema(w: *Workspace, r: *Root) {
-    if (r.sema == nil) {
-        r.sema_count  = 0;
-        r.sema_loaded = false;
-        ret;
-    }
-    var i: u32 = 0;
-    for (i < r.sema_count) {
-        sema.dnit_result(?r.sema[i]);
-        i = i + 1;
-    }
-    deallocate[sema.SemaResult](w.alloc, r.sema, r.sema_count::usize);
-    r.sema        = nil;
-    r.sema_count  = 0;
-    r.sema_loaded = false;
 }
 
 # snapshot the root's manifest / lockfile mtimes for the
@@ -1183,6 +1036,18 @@ fun join_mtime(alloc: *Allocator, dir: str, name: str) i64 {
     ret m;
 }
 
+fun file_fingerprint(path: str) SourceFingerprint {
+    var fp: SourceFingerprint;
+    fp.mtime = 0;
+    fp.size = 0;
+    val fi_r: Result[fs.Metadata, str] = fs.metadata(path);
+    if (is_err[fs.Metadata, str](fi_r)) { ret fp; }
+    var fi: fs.Metadata = unwrap_ok[fs.Metadata, str](fi_r);
+    fp.mtime = chrono.time_unix_nsec(fi.modified);
+    fp.size = fi.size;
+    ret fp;
+}
+
 # where symbol `sym` is declared, as an Ast / SourceFile / URI triple.
 # a buffer-local symbol (origin equals the buffer's module) reports against the
 # request buffer; a cross-module symbol reports against the defining dependency
@@ -1211,7 +1076,7 @@ pub fun site_of(w: *Workspace, root: *Root, own: sess.ModuleId, own_a: *ast.Ast,
 
     val m: *driver.ModuleEntry = module_entry(root, sym.origin);
     if (m == nil) { ret none[Site](); }
-    val fo: Option[*src.SourceFile] = src.get(?w.s.sources, m.file_id);
+    val fo: Option[*src.SourceFile] = src.get(?root.s.sources, m.file_id);
     if (!is_some[*src.SourceFile](fo)) { ret none[Site](); }
 
     val furi: str = module_uri(w, root, sym.origin);
@@ -1254,6 +1119,68 @@ pub rec ModuleView {
     file: *src.SourceFile;
 }
 
+# compiler-owned snapshot of one open document.
+pub rec DocumentView {
+    root:     *Root;
+    module:   sess.ModuleId;
+    a:        *ast.Ast;
+    rr:       *res.ResolveResult;
+    sr:       *sema.SemaResult;
+    file:     *src.SourceFile;
+    interner: *intern.Interner;
+    revision: u64;
+    file_id:  src.FileId;
+}
+
+# analyze through the retained project containing `d` and return its exact
+# ModuleEntry. the input/snapshot revision equality is the staleness boundary.
+pub fun document_view(w: *Workspace, d: *documents.Document) Result[DocumentView, str] {
+    val root: *Root = root_for(w, d.uri);
+    if (root == nil || !root.loaded) { ret err[DocumentView, str]("project: document has no compiler project"); }
+    if (!root.loaded || root.input_revision != root.snapshot_revision) {
+        ret err[DocumentView, str]("project: document snapshot is stale");
+    }
+    ret view_from_root(root, d);
+}
+
+# return a document view only when an already-loaded project captured its latest
+# input; this never loads, rebuilds, or runs sema and is safe on notifications
+# ---
+# w:   workspace containing retained roots
+# d:   live document
+# ret: current compiler view, or an error requiring fallback diagnostics
+pub fun document_view_loaded(w: *Workspace, d: *documents.Document) Result[DocumentView, str] {
+    val root: *Root = root_for_loaded(w, d.uri);
+    if (root == nil || !root.loaded || root.input_revision != root.snapshot_revision
+        || d.revision > root.snapshot_revision) {
+        ret err[DocumentView, str]("project: no current loaded snapshot");
+    }
+    ret view_from_root(root, d);
+}
+
+fun view_from_root(root: *Root, d: *documents.Document) Result[DocumentView, str] {
+    val mo: Option[sess.ModuleId] = module_for_norm(root, d.path);
+    if (!is_some[sess.ModuleId](mo)) { ret err[DocumentView, str]("project: document module was not loaded"); }
+    val mid: sess.ModuleId = unwrap[sess.ModuleId](mo);
+    val m: *driver.ModuleEntry = module_entry(root, mid);
+    if (m == nil || !m.resolved || m.sema_result == nil) {
+        ret err[DocumentView, str]("project: document analysis unavailable");
+    }
+    val fo: Option[*src.SourceFile] = src.get(?root.s.sources, m.file_id);
+    if (!is_some[*src.SourceFile](fo)) { ret err[DocumentView, str]("project: document source unavailable"); }
+    var v: DocumentView;
+    v.root = root;
+    v.module = mid;
+    v.a = m.a;
+    v.rr = m.resolve_result;
+    v.sr = m.sema_result;
+    v.file = unwrap[*src.SourceFile](fo);
+    v.interner = ?root.s.interner;
+    v.revision = root.snapshot_revision;
+    v.file_id = m.file_id;
+    ret ok[DocumentView, str](v);
+}
+
 # the number of loaded modules in `root`, or 0 when root is nil /
 # not loaded. the workspace-wide references / rename walk iterates [0, count)
 # ---
@@ -1276,7 +1203,7 @@ pub fun module_count(root: *Root) u32 {
 pub fun module_view(w: *Workspace, root: *Root, mid: sess.ModuleId) Option[ModuleView] {
     val m: *driver.ModuleEntry = module_entry(root, mid);
     if (m == nil || !m.resolved) { ret none[ModuleView](); }
-    val fo: Option[*src.SourceFile] = src.get(?w.s.sources, m.file_id);
+    val fo: Option[*src.SourceFile] = src.get(?root.s.sources, m.file_id);
     if (!is_some[*src.SourceFile](fo)) { ret none[ModuleView](); }
     var v: ModuleView;
     v.a    = m.a;
@@ -1298,12 +1225,9 @@ pub fun module_view(w: *Workspace, root: *Root, mid: sess.ModuleId) Option[Modul
 # mid:  a loaded module id in [0, module_count)
 # ret:  some(*SemaResult), or none
 pub fun module_sema(w: *Workspace, root: *Root, mid: sess.ModuleId) Option[*sema.SemaResult] {
-    if (root == nil || !root.loaded) { ret none[*sema.SemaResult](); }
-    ensure_sema(w, root);
-    if (root.sema == nil || mid::u32 >= root.sema_count) { ret none[*sema.SemaResult](); }
-    val sr: *sema.SemaResult = ?root.sema[mid::u32];
-    if (sr.expr_type == nil) { ret none[*sema.SemaResult](); }
-    ret some[*sema.SemaResult](sr);
+    val m: *driver.ModuleEntry = module_entry(root, mid);
+    if (m == nil || m.sema_result == nil) { ret none[*sema.SemaResult](); }
+    ret some[*sema.SemaResult](m.sema_result);
 }
 
 # the semantic type of expression `eid` in SemaResult `sr`, or TYPE_NIL
@@ -1373,7 +1297,7 @@ pub fun record_decl(w: *Workspace, root: *Root, tid: type.TypeId) Option[RecordS
 
     val m: *driver.ModuleEntry = module_entry(root, n.origin);
     if (m == nil) { ret none[RecordSite](); }
-    val fo: Option[*src.SourceFile] = src.get(?w.s.sources, m.file_id);
+    val fo: Option[*src.SourceFile] = src.get(?root.s.sources, m.file_id);
     if (!is_some[*src.SourceFile](fo)) { ret none[RecordSite](); }
     ret record_site_from(n.origin, n.decl, m.a, unwrap[*src.SourceFile](fo));
 }
@@ -1423,7 +1347,7 @@ pub fun record_site_at(w: *Workspace, root: *Root, own: sess.ModuleId, own_a: *a
 # guarded on a loaded root. none when there is no project or `tid` is not nominal
 fun nominal_of_tid(w: *Workspace, root: *Root, tid: type.TypeId) Option[mtypes.Nominal] {
     if (root == nil || !root.loaded) { ret none[mtypes.Nominal](); }
-    ret mtypes.nominal_of(?w.s.types, tid);
+    ret mtypes.nominal_of(?root.s.types, tid);
 }
 
 # build a RecordSite for the rec / uni decl `decl` in `a` (backed
@@ -1533,8 +1457,8 @@ pub fun is_project_module(w: *Workspace, root: *Root, mid: sess.ModuleId) bool {
     val m: *driver.ModuleEntry = module_entry(root, mid);
     if (m == nil) { ret false; }
     if (root.vendored) { ret false; }
-    val id_opt:  Option[str] = intern.lookup(?w.s.interner, root.p.config.id);
-    val fqn_opt: Option[str] = intern.lookup(?w.s.interner, m.fqn);
+    val id_opt:  Option[str] = intern.lookup(?root.s.interner, root.p.config.id);
+    val fqn_opt: Option[str] = intern.lookup(?root.s.interner, m.fqn);
     if (!is_some[str](id_opt) || !is_some[str](fqn_opt)) { ret false; }
     val pid: str = unwrap[str](id_opt);
     val fqn: str = unwrap[str](fqn_opt);
@@ -1554,6 +1478,18 @@ fun document_root(w: *Workspace, uri: str) str {
     val root: str = project_root_for(w.alloc, path);
     strutil.str_free(w.alloc, path);
     ret root;
+}
+
+# whether a file URI has an ancestor mach.toml, without loading a project
+# ---
+# w:   workspace allocator owner
+# uri: document URI
+# ret: true when project analysis is required
+pub fun has_project(w: *Workspace, uri: str) bool {
+    val root: str = document_root(w, uri);
+    if (root == nil) { ret false; }
+    strutil.str_free(w.alloc, root);
+    ret true;
 }
 
 # log the loader error and warn the user through
@@ -1619,323 +1555,6 @@ fun show_warning(w: *Workspace, text: str) {
     json.free_str(qmsg, w.alloc);
 }
 
-# snapshot every loaded module's public surface into `r.deps`, one
-# ModuleExports per module keyed by FQN. mirrors the driver's per-module
-# dependency assembly but spans the whole graph, so a buffer's `use` of any
-# loaded module binds. modules with no exports contribute an empty entry
-fun build_deps(w: *Workspace, r: *Root) {
-    val n: u32 = r.p.module_len;
-    if (n == 0) { ret; }
-    val res_r: Result[*res.ModuleExports, str] = allocate[res.ModuleExports](w.alloc, n::usize);
-    if (is_err[*res.ModuleExports, str](res_r)) { ret; }
-    r.deps.entries = unwrap_ok[*res.ModuleExports, str](res_r);
-    r.deps.count   = n;
-
-    var i: u32 = 0;
-    for (i < n) {
-        r.deps.entries[i] = module_exports(w, r, i::sess.ModuleId);
-        i = i + 1;
-    }
-}
-
-# the public surface of loaded module `mid` in `root` as a
-# ModuleExports, copying each pub symbol's (kind, name, decl, slot, origin) so
-# resolve can bind a cross-module reference to the declaring module's Ast. this
-# must track the driver's private build_module_exports field-for-field; the
-# driver helper remained private through the #45 dep bump, so the copy stays
-fun module_exports(w: *Workspace, root: *Root, mid: sess.ModuleId) res.ModuleExports {
-    val m: *driver.ModuleEntry = ?root.p.modules[mid::u32];
-    var mx: res.ModuleExports;
-    mx.path    = m.fqn;
-    mx.module  = mid;
-    mx.symbols = nil;
-    mx.count   = 0;
-    if (!m.resolved || m.resolve_result.pub_count == 0) { ret mx; }
-
-    val pcount: u32 = m.resolve_result.pub_count;
-    val r: Result[*res.PublicSymbol, str] = allocate[res.PublicSymbol](w.alloc, pcount::usize);
-    if (is_err[*res.PublicSymbol, str](r)) { ret mx; }
-    val syms: *res.PublicSymbol = unwrap_ok[*res.PublicSymbol, str](r);
-
-    var i: u32 = 0;
-    for (i < pcount) {
-        val sym: *res.Symbol = ?m.resolve_result.symbols[i];
-        var ps: res.PublicSymbol;
-        ps.kind   = sym.kind;
-        ps.name   = sym.name;
-        ps.decl   = sym.decl;
-        ps.slot   = sym.slot;
-        ps.origin = sym.origin;
-        syms[i] = ps;
-        i = i + 1;
-    }
-    mx.symbols = syms;
-    mx.count   = pcount;
-    ret mx;
-}
-
-# release a dep snapshot's per-module symbol arrays and the entry
-# array, zeroing it
-fun free_deps(w: *Workspace, deps: *res.ResolveDeps) {
-    if (deps.entries == nil) { ret; }
-    var i: u32 = 0;
-    for (i < deps.count) {
-        val mx: *res.ModuleExports = ?deps.entries[i];
-        if (mx.symbols != nil && mx.count > 0) {
-            deallocate[res.PublicSymbol](w.alloc, mx.symbols, mx.count::usize);
-        }
-        i = i + 1;
-    }
-    deallocate[res.ModuleExports](w.alloc, deps.entries, deps.count::usize);
-    deps.entries = nil;
-    deps.count   = 0;
-}
-
-# run the type checker over `root`'s loaded module graph, retaining
-# one SemaResult per module on the Root - the lazy core of the type-aware layer.
-# a no-op once it has run for the current build (sema_loaded) or for an unloaded
-# root. modules are sema'd in dependency (topological) order, each against a
-# SemaDeps assembled from the decl_type snapshots of the modules already sema'd in
-# this pass, exactly as the compiler's own build does; a module that did not
-# resolve is skipped, leaving a zeroed SemaResult that types to TYPE_NIL. the pass
-# is heavy (it walks the whole dep closure), so it runs only when a feature first
-# demands typing - never on the diagnostics publish hot path - and is cached until
-# the build reloads. on completion it bumps the workspace sema epoch, the signal
-# the server uses to re-publish the open buffers with semantic diagnostics now
-# that the closure's retained typing exists (#113). allocation failure leaves the
-# root un-sema'd (typing simply stays unavailable, no epoch bump) rather than
-# aborting the request
-# ---
-# w:    the workspace
-# root: the loaded root whose graph to type-check
-pub fun ensure_sema(w: *Workspace, root: *Root) {
-    if (root == nil || !root.loaded || root.sema_loaded) { ret; }
-    val n: u32 = root.p.module_len;
-    if (n == 0) { root.sema_loaded = true; w.sema_epoch = w.sema_epoch + 1; ret; }
-
-    val arr_r: Result[*sema.SemaResult, str] = allocate[sema.SemaResult](w.alloc, n::usize);
-    if (is_err[*sema.SemaResult, str](arr_r)) { ret; }
-    root.sema       = unwrap_ok[*sema.SemaResult, str](arr_r);
-    root.sema_count = n;
-    zero_sema(root.sema, n);
-
-    # ready[mid]: whether module mid has a populated SemaResult this pass, so a
-    # later module's SemaDeps exposes only the snapshots already produced (every
-    # dep is strictly earlier in topo order and thus ready before its dependents)
-    val rdy_r: Result[*bool, str] = allocate[bool](w.alloc, n::usize);
-    if (is_err[*bool, str](rdy_r)) { free_sema(w, root); ret; }
-    val ready: *bool = unwrap_ok[*bool, str](rdy_r);
-    var z: u32 = 0;
-    for (z < n) { ready[z] = false; z = z + 1; }
-
-    var ti: u32 = 0;
-    for (ti < root.p.topo_len) {
-        val mid: sess.ModuleId = root.p.topo[ti];
-        run_module_sema(w, root, mid, ready);
-        ti = ti + 1;
-    }
-
-    deallocate[bool](w.alloc, ready, n::usize);
-    root.sema_loaded = true;
-    w.sema_epoch = w.sema_epoch + 1;
-}
-
-# type-check one loaded module against the modules already sema'd
-# this pass, storing its SemaResult into `root.sema[mid]` and marking it ready. a
-# module that did not resolve (no resolve_result) is left zeroed and unready - its
-# types stay TYPE_NIL and dependents simply do not see it among their deps. the
-# comptime context the driver populated for the module (`m.ctx`) drives array-length
-# and `$if`-gate evaluation, matching how the compiler sema's the same module. on
-# any failure the slot is left zeroed; the pass continues so a single bad module
-# does not deny typing to the rest
-fun run_module_sema(w: *Workspace, root: *Root, mid: sess.ModuleId, ready: *bool) {
-    if (mid::u32 >= root.p.module_len) { ret; }
-    val m: *driver.ModuleEntry = ?root.p.modules[mid::u32];
-    if (!m.resolved) { ret; }
-
-    var deps: sema.SemaDeps;
-    if (!build_sema_deps(w, root, ready, ?deps)) { ret; }
-
-    val sr_r: Result[sema.SemaResult, str] = sema.sema(w.s, m.a, m.resolve_result, ?deps, ?m.ctx, mid);
-    free_sema_deps(w, ?deps);
-    if (is_err[sema.SemaResult, str](sr_r)) { ret; }
-    root.sema[mid::u32] = unwrap_ok[sema.SemaResult, str](sr_r);
-    ready[mid::u32]     = true;
-}
-
-# assemble the SemaDeps for the module about to be analysed - one
-# ModuleSema entry per module already sema'd this pass (ready), each borrowing that
-# module's decl_type snapshot. cross-module symbol types are looked up by the
-# symbol's origin ModuleId, and a `fwd` re-export carries the originating
-# (transitive) module as the origin, so the snapshot must cover every ready module,
-# not only the direct dependencies - all of them are strictly earlier in topo order
-# and thus already produced. mirrors the compiler's own build_sema_deps. writes the
-# assembled deps into `out`; false on allocation failure (the caller skips the
-# module). an empty set (no module ready yet) is a successful result
-fun build_sema_deps(w: *Workspace, root: *Root, ready: *bool, out: *sema.SemaDeps) bool {
-    out.entries = nil;
-    out.count   = 0;
-
-    var count: u32 = 0;
-    var i: u32 = 0;
-    for (i < root.p.module_len) {
-        if (ready[i]) { count = count + 1; }
-        i = i + 1;
-    }
-    if (count == 0) { ret true; }
-
-    val r: Result[*sema.ModuleSema, str] = allocate[sema.ModuleSema](w.alloc, count::usize);
-    if (is_err[*sema.ModuleSema, str](r)) { ret false; }
-    out.entries = unwrap_ok[*sema.ModuleSema, str](r);
-    out.count   = count;
-
-    var k: u32 = 0;
-    var j: u32 = 0;
-    for (j < root.p.module_len) {
-        if (ready[j]) {
-            val dep: *driver.ModuleEntry = ?root.p.modules[j];
-            var ms: sema.ModuleSema;
-            ms.path       = dep.fqn;
-            ms.module     = j::sess.ModuleId;
-            ms.decl_type  = root.sema[j].decl_type;
-            ms.decl_count = root.sema[j].decl_count;
-            out.entries[k] = ms;
-            k = k + 1;
-        }
-        j = j + 1;
-    }
-    ret true;
-}
-
-# release the entries array a build_sema_deps allocated. the
-# borrowed decl_type arrays it points into are owned by the producing SemaResults
-# and are NOT freed here
-fun free_sema_deps(w: *Workspace, deps: *sema.SemaDeps) {
-    if (deps.entries == nil) { ret; }
-    deallocate[sema.ModuleSema](w.alloc, deps.entries, deps.count::usize);
-    deps.entries = nil;
-    deps.count   = 0;
-}
-
-# zero a freshly allocated SemaResult array so an un-run or skipped
-# module's slot has nil arrays - a lookup against it types to TYPE_NIL, never a
-# wild read. mirrors how the resolve cache zero-fills its gaps
-fun zero_sema(arr: *sema.SemaResult, n: u32) {
-    var i: u32 = 0;
-    for (i < n) {
-        arr[i].alloc            = nil;
-        arr[i].expr_type        = nil;
-        arr[i].type_resolved_ty = nil;
-        arr[i].decl_type        = nil;
-        arr[i].expr_count       = 0;
-        arr[i].type_count       = 0;
-        arr[i].decl_count       = 0;
-        i = i + 1;
-    }
-}
-
-# the cached ResolveResult for `fid` when it was resolved from the
-# exact Ast `a` (the editor replaces the Ast pointer on every text update, so
-# pointer identity proves the text is current) and against the same build as
-# `root` (the entry's generation must equal the root's current `gen`, or 0 when
-# resolving single-file), or nil. the generation match is what makes a result
-# from a since-reloaded or different root structurally unhittable
-fun cache_hit(w: *Workspace, fid: src.FileId, a: *ast.Ast, root: *Root) *res.ResolveResult {
-    if (w.cache == nil || fid::u32 >= w.cache_len) { ret nil; }
-    val c: *Cached = ?w.cache[fid::u32];
-    if (c.rr == nil || c.a != a) { ret nil; }
-    if (c.gen != root_gen(root)) { ret nil; }
-    ret c.rr;
-}
-
-# store `rr` (resolved from Ast `a` against the build stamped `gen`,
-# or 0 for single-file) as the cached result for `fid`, growing the cache to
-# cover the FileId and zero-filling any gap. false when the grow allocation fails
-# - the caller owns `rr` and must free it
-fun cache_put(w: *Workspace, fid: src.FileId, rr: *res.ResolveResult, a: *ast.Ast, gen: u32) bool {
-    val needed: u32 = fid::u32 + 1;
-    if (needed > w.cache_len) {
-        var new_len: u32 = w.cache_len;
-        if (new_len == 0) { new_len = 8; }
-        for (new_len < needed) { new_len = new_len * 2; }
-        if (w.cache == nil) {
-            val r: Result[*Cached, str] = allocate[Cached](w.alloc, new_len::usize);
-            if (is_err[*Cached, str](r)) { ret false; }
-            w.cache = unwrap_ok[*Cached, str](r);
-        }
-        or {
-            val r: Result[*Cached, str] = reallocate[Cached](w.alloc, w.cache, w.cache_len::usize, new_len::usize);
-            if (is_err[*Cached, str](r)) { ret false; }
-            w.cache = unwrap_ok[*Cached, str](r);
-        }
-        var z: u32 = w.cache_len;
-        for (z < new_len) { w.cache[z].rr = nil; w.cache[z].sr = nil; w.cache[z].a = nil; w.cache[z].gen = 0; z = z + 1; }
-        w.cache_len = new_len;
-    }
-    w.cache[fid::u32].rr  = rr;
-    w.cache[fid::u32].sr  = nil;
-    w.cache[fid::u32].a   = a;
-    w.cache[fid::u32].gen = gen;
-    ret true;
-}
-
-# free a cache slot's owned ResolveResult and SemaResult and zero
-# the slot - the one teardown for a Cached entry, shared by every reclamation path.
-# the sema result (populated lazily by sema_doc, nil otherwise) is torn down first.
-# callers guard `c.rr != nil`
-fun release_entry(w: *Workspace, c: *Cached) {
-    if (c.sr != nil) {
-        sema.dnit_result(c.sr);
-        deallocate[sema.SemaResult](w.alloc, c.sr, 1);
-        c.sr = nil;
-    }
-    res.dnit_result(c.rr);
-    deallocate[res.ResolveResult](w.alloc, c.rr, 1);
-    c.rr  = nil;
-    c.a   = nil;
-    c.gen = 0;
-}
-
-# release and clear the cached ResolveResult for `fid`, if any.
-# called before a re-resolve replaces the entry, and by the server on didClose
-# so a retired document's result is reclaimed immediately instead of lingering
-# until its FileId is reused or its root reloads
-# ---
-# w:   the workspace
-# fid: the buffer whose cached result to drop
-pub fun free_cached(w: *Workspace, fid: src.FileId) {
-    if (w.cache == nil || fid::u32 >= w.cache_len) { ret; }
-    val c: *Cached = ?w.cache[fid::u32];
-    if (c.rr != nil) { release_entry(w, c); }
-}
-
-# release every cached result resolved against root `r`'s current
-# build (matched by generation), reclaiming the entries a graph teardown
-# invalidates. a no-op for an unloaded slot (gen 0, no build of its own - and
-# never the single-file entries that also carry gen 0, since those belong to no
-# root). called by free_root_graph at every reload / free, replacing the blanket
-# whole-cache clear
-fun evict_root(w: *Workspace, r: *Root) {
-    if (w.cache == nil || r.gen == 0) { ret; }
-    var i: u32 = 0;
-    for (i < w.cache_len) {
-        val c: *Cached = ?w.cache[i];
-        if (c.rr != nil && c.gen == r.gen) { release_entry(w, c); }
-        i = i + 1;
-    }
-}
-
-# release every cached ResolveResult, keeping the slot array.
-# the teardown sweep used by dnit; per-build invalidation goes through evict_root
-fun free_all_cached(w: *Workspace) {
-    if (w.cache == nil) { ret; }
-    var i: u32 = 0;
-    for (i < w.cache_len) {
-        val c: *Cached = ?w.cache[i];
-        if (c.rr != nil) { release_entry(w, c); }
-        i = i + 1;
-    }
-}
 
 # the percent-decoded filesystem path of a `file://` URI, as an
 # owned string, or nil for a non-file URI / malformed escape
@@ -1980,6 +1599,12 @@ fun uri_to_norm(alloc: *Allocator, uri: str) str {
     val norm: str = normalize_path(alloc, path);
     strutil.str_free(alloc, path);
     ret norm;
+}
+
+# decode and lexically normalize a file URI into an owned absolute compiler
+# overlay path.
+pub fun path_of_uri(alloc: *Allocator, uri: str) str {
+    ret uri_to_norm(alloc, uri);
 }
 
 # the value of a hex digit, or -1
@@ -2111,224 +1736,18 @@ fun append(buf: *u8, offset: usize, s: str) usize {
     ret offset + n;
 }
 
-test "project: sema_ready is false for a nil root" {
-    if (sema_ready(nil)) { ret 1; }
+
+test "project: file uri paths are decoded and normalized" {
+    var pa: Allocator;
+    page.make(?pa);
+    val got: str = path_of_uri(?pa, "file:///tmp/a%20b/src/../main.mach");
+    if (got == nil || !str_equals(got, "/tmp/a b/main.mach")) { ret 1; }
     ret 0;
 }
 
-test "project: sema_ready is false for a loaded but un-sema'd root" {
-    var r: Root;
-    r.loaded      = true;
-    r.sema_loaded = false;
-    if (sema_ready(?r)) { ret 1; }
+test "project: non-file uri has no compiler path" {
+    var pa: Allocator;
+    page.make(?pa);
+    if (path_of_uri(?pa, "untitled:buffer") != nil) { ret 1; }
     ret 0;
-}
-
-test "project: sema_ready is false for an unloaded root even if sema_loaded" {
-    var r: Root;
-    r.loaded      = false;
-    r.sema_loaded = true;
-    if (sema_ready(?r)) { ret 1; }
-    ret 0;
-}
-
-test "project: sema_ready is true only when loaded and sema'd" {
-    var r: Root;
-    r.loaded      = true;
-    r.sema_loaded = true;
-    if (!sema_ready(?r)) { ret 1; }
-    ret 0;
-}
-
-# concatenate two strings into a fresh nul-terminated owned buffer. a test
-# helper; the page allocator reclaims the leaked copies on dnit
-fun t_cat(alloc: *Allocator, a: str, b: str) str {
-    val total: usize = str_len(a) + str_len(b);
-    val r: Result[*u8, str] = allocate[u8](alloc, total + 1);
-    if (is_err[*u8, str](r)) { ret nil; }
-    val buf: *u8 = unwrap_ok[*u8, str](r);
-    var off: usize = 0;
-    off = append(buf, off, a);
-    off = append(buf, off, b);
-    buf[off] = 0;
-    ret buf::str;
-}
-
-# the scaffolded project's mach.toml (id "proj", host-resolved native
-# target), mirroring the three-target shape the driver's own union tests use.
-# [project] is trimmed to the V2 id/version/src/out totality and the artifact
-# carries the root-required link/need keys (#1964/#1971)
-fun t_manifest() str {
-    ret "[project]\nid = \"proj\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.windows]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[target.linux-arm64]\nisa = \"aarch64\"\nos = \"linux\"\nabi = \"aapcs64\"\n\n[artifact.proj]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/proj\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
-}
-
-# write `text` to `path` (test helper), true on success
-fun t_write(path: str, text: str) bool {
-    if (path == nil) { ret false; }
-    ret is_none[str](fs.write_bytes(path, text, str_len(text), 420));
-}
-
-# materialize a temp "proj" project (manifest + src/main,leaf,other) on
-# disk and return its owned root path, or nil. the caller removes the tree via
-# fs.remove_all. main imports both leaf and other; only leaf is edited by the test
-fun t_scaffold(alloc: *Allocator, main_text: str, leaf_text: str) str {
-    val tf_r: Result[fs.TempFile, str] = fs.temp_create(alloc, "mls_inc_test");
-    if (is_err[fs.TempFile, str](tf_r)) { ret nil; }
-    var tf: fs.TempFile = unwrap_ok[fs.TempFile, str](tf_r);
-    val dup_r: Result[str, str] = strutil.str_dup(alloc, fs.temp_path(?tf));
-    fs.temp_close_and_remove(?tf);
-    if (is_err[str, str](dup_r)) { ret nil; }
-    val root: str = unwrap_ok[str, str](dup_r);
-
-    if (is_some[str](fs.create_dir_all(alloc, root, 493))) { ret nil; }
-    val src_dir: str = t_cat(alloc, root, "/src");
-    if (src_dir == nil || is_some[str](fs.create_dir_all(alloc, src_dir, 493))) { ret nil; }
-
-    if (!t_write(t_cat(alloc, root, "/mach.toml"), t_manifest())) { ret nil; }
-    if (!t_write(t_cat(alloc, src_dir, "/main.mach"), main_text)) { ret nil; }
-    if (!t_write(t_cat(alloc, src_dir, "/leaf.mach"), leaf_text)) { ret nil; }
-    if (!t_write(t_cat(alloc, src_dir, "/other.mach"), "pub fun fb() i32 { ret 2; }\n")) { ret nil; }
-    ret root;
-}
-
-# the DeclId (as u32) the buffer's resolve binds the imported symbol
-# named `name` to, or 0xFFFFFFFF when absent (test helper). cross-session safe: the
-# name is matched by interned text on `s`
-fun t_imported_decl(s: *sess.Session, rr: *res.ResolveResult, name: str) u32 {
-    if (rr == nil) { ret 0xFFFFFFFF; }
-    var i: u32 = 0;
-    for (i < rr.symbol_count) {
-        if (rr.symbols[i].kind == res.SYM_IMPORTED) {
-            val no: Option[str] = intern.lookup(?s.interner, rr.symbols[i].name);
-            if (is_some[str](no) && str_equals(unwrap[str](no), name)) { ret rr.symbols[i].decl::u32; }
-        }
-        i = i + 1;
-    }
-    ret 0xFFFFFFFF;
-}
-
-# the borrowed (query-DB-owned) ResolveResult handle of the loaded module
-# at `uri` in `root`, or nil (test helper). pointer identity across a reload proves the
-# module's Q_RESOLVE entry was reused
-fun t_module_rr(w: *Workspace, root: *Root, uri: str) *res.ResolveResult {
-    val mo: Option[sess.ModuleId] = module_for_uri(w, root, uri);
-    if (is_none[sess.ModuleId](mo)) { ret nil; }
-    val mv: Option[ModuleView] = module_view(w, root, unwrap[sess.ModuleId](mo));
-    if (is_none[ModuleView](mv)) { ret nil; }
-    ret unwrap[ModuleView](mv).rr;
-}
-
-# open `main_text` at `main_uri` in a fresh workspace over `root`'s
-# on-disk graph and return the DeclId its `use proj.leaf.fa` binds to (test helper).
-# 0xFFFFFFFF on any failure. the from-scratch oracle the incremental result is checked
-# against
-fun t_buffer_fa_decl(alloc: *Allocator, root: str, main_uri: str, main_text: str) u32 {
-    val srB: Result[sess.Session, str] = sess.init(alloc);
-    if (is_err[sess.Session, str](srB)) { ret 0xFFFFFFFF; }
-    var sB: sess.Session = unwrap_ok[sess.Session, str](srB);
-    var esB: editor.EditorSession = editor.init(?sB);
-    var wB: Workspace = init(?sB, ?esB, alloc);
-
-    var decl: u32 = 0xFFFFFFFF;
-    val fB_r: Result[src.FileId, str] = editor.open(?esB, main_uri, main_text);
-    if (!is_err[src.FileId, str](fB_r)) {
-        val fB: src.FileId = unwrap_ok[src.FileId, str](fB_r);
-        val rootB: *Root = root_for(?wB, main_uri);
-        if (rootB != nil) {
-            val rrB_r: Result[*res.ResolveResult, str] = resolve_doc(?wB, rootB, fB);
-            if (!is_err[*res.ResolveResult, str](rrB_r)) {
-                decl = t_imported_decl(?sB, unwrap_ok[*res.ResolveResult, str](rrB_r), "fa");
-            }
-        }
-    }
-
-    dnit(?wB);
-    editor.dnit(?esB);
-    sess.dnit(?sB);
-    ret decl;
-}
-
-test "project incremental: an on-disk dep edit reloads correctly (matches fresh) and reuses an unaffected module" {
-    var alloc: Allocator;
-    if (is_some[str](page.make(?alloc))) { ret 1; }
-
-    val main_text: str = "use proj.leaf.fa;\nuse proj.other.fb;\nfun main() i32 { ret fa() + fb(); }\n";
-    val leaf_v1:   str = "pub fun fa() i32 { ret 1; }\n";
-    # pub-surface change: prepend a new pub function, shifting fa's DeclId - a change
-    # the importer's binding genuinely depends on
-    val leaf_v2:   str = "pub fun fz() i32 { ret 0; }\npub fun fa() i32 { ret 1; }\n";
-
-    val root: str = t_scaffold(?alloc, main_text, leaf_v1);
-    if (root == nil) { ret 1; }
-
-    val src_dir:   str = t_cat(?alloc, root, "/src");
-    val leaf_path: str = t_cat(?alloc, src_dir, "/leaf.mach");
-    val main_uri:  str = t_cat(?alloc, "file://", t_cat(?alloc, src_dir, "/main.mach"));
-    val leaf_uri:  str = t_cat(?alloc, "file://", leaf_path);
-    val other_uri: str = t_cat(?alloc, "file://", t_cat(?alloc, src_dir, "/other.mach"));
-
-    val srA: Result[sess.Session, str] = sess.init(?alloc);
-    if (is_err[sess.Session, str](srA)) { fs.remove_all(?alloc, root); ret 1; }
-    var sA: sess.Session = unwrap_ok[sess.Session, str](srA);
-    var esA: editor.EditorSession = editor.init(?sA);
-    var wA: Workspace = init(?sA, ?esA, ?alloc);
-
-    var bad: i32 = 0;
-
-    # cold build: open main, load the project, resolve the buffer against the v1 graph
-    val fA_r: Result[src.FileId, str] = editor.open(?esA, main_uri, main_text);
-    if (is_err[src.FileId, str](fA_r)) { bad = 1; }
-    or {
-        val fA: src.FileId = unwrap_ok[src.FileId, str](fA_r);
-        val rootA1: *Root = root_for(?wA, main_uri);
-        if (rootA1 == nil) { bad = 1; }
-        or {
-            val rrA1_r: Result[*res.ResolveResult, str] = resolve_doc(?wA, rootA1, fA);
-            if (is_err[*res.ResolveResult, str](rrA1_r)) { bad = 1; }
-            or {
-                val fa_decl_pre: u32 = t_imported_decl(?sA, unwrap_ok[*res.ResolveResult, str](rrA1_r), "fa");
-                # capture the query-DB resolve handles of the unaffected and edited modules
-                val rr_other_1: *res.ResolveResult = t_module_rr(?wA, rootA1, other_uri);
-                val rr_leaf_1:  *res.ResolveResult = t_module_rr(?wA, rootA1, leaf_uri);
-                if (rr_other_1 == nil || rr_leaf_1 == nil) { bad = 1; }
-
-                # edit leaf's public surface on disk and invalidate the root.
-                if (!t_write(leaf_path, leaf_v2)) { bad = 1; }
-                invalidate_uri(?wA, leaf_uri);
-
-                # incremental reload + re-resolve the buffer against the v2 graph
-                val rootA2: *Root = root_for(?wA, main_uri);
-                if (rootA2 == nil) { bad = 1; }
-                or {
-                    val rrA2_r: Result[*res.ResolveResult, str] = resolve_doc(?wA, rootA2, fA);
-                    if (is_err[*res.ResolveResult, str](rrA2_r)) { bad = 1; }
-                    or {
-                        val fa_decl_post: u32 = t_imported_decl(?sA, unwrap_ok[*res.ResolveResult, str](rrA2_r), "fa");
-                        val rr_other_2: *res.ResolveResult = t_module_rr(?wA, rootA2, other_uri);
-                        val rr_leaf_2:  *res.ResolveResult = t_module_rr(?wA, rootA2, leaf_uri);
-
-                        # reuse: the unaffected module kept its Q_RESOLVE handle; the
-                        # edited one was recomputed (a fresh handle).
-                        if (rr_other_2 != rr_other_1) { bad = 1; }
-                        if (rr_leaf_2 == nil || rr_leaf_2 == rr_leaf_1) { bad = 1; }
-
-                        # propagation: the buffer's binding tracked fa's shifted decl.
-                        if (fa_decl_post == fa_decl_pre) { bad = 1; }
-                        if (fa_decl_post == 0xFFFFFFFF) { bad = 1; }
-
-                        # the incrementally-reloaded result equals a
-                        # from-scratch workspace built over the final on-disk graph
-                        val fa_decl_fresh: u32 = t_buffer_fa_decl(?alloc, root, main_uri, main_text);
-                        if (fa_decl_post != fa_decl_fresh) { bad = 1; }
-                    }
-                }
-            }
-        }
-    }
-
-    dnit(?wA);
-    editor.dnit(?esA);
-    sess.dnit(?sA);
-    fs.remove_all(?alloc, root);
-    ret bad;
 }

--- a/src/project.mach
+++ b/src/project.mach
@@ -119,6 +119,7 @@ use comptime: mach.lang.fe.comptime;
 use driver:   mach.lang.driver;
 use outcome:  mach.lang.build.outcome;
 use tgt:      mach.lang.target;
+use isa:      mach.lang.target.isa;
 
 use transport: mls.transport;
 use json:      mls.json;
@@ -435,10 +436,11 @@ fun resolve_fresh(w: *Workspace, root: *Root, fid: src.FileId, a: *ast.Ast) Resu
     var ctx: comptime.ComptimeCtx;
     if (root != nil) {
         deps = ?root.deps;
-        ctx = comptime.init(w.alloc, root.p.target.os_id, root.p.target.arch_id, root.p.target.abi_id, comptime.MODE_DEBUG, 0, root.p.target.isa.pointer_width, root.p.compiler_name, root.p.compiler_ver);
+        ctx = comptime.init(w.alloc, root.p.target.os_id, root.p.target.arch_id, root.p.target.abi_id, comptime.MODE_DEBUG, 0, root.p.target.isa.pointer_width, root.p.target.model.vector_bits, root.p.compiler_name, root.p.compiler_ver);
+        comptime.set_target_defs(?ctx, root.p.target.isa.defs);
     }
     or {
-        ctx = comptime.init(w.alloc, 0, 0, 0, comptime.MODE_DEBUG, 0, 8, intern.STR_NIL, intern.STR_NIL);
+        ctx = comptime.init(w.alloc, 0, 0, 0, comptime.MODE_DEBUG, 0, 8, isa.VECTOR_BITS_128, intern.STR_NIL, intern.STR_NIL);
     }
 
     val own: sess.ModuleId = own_module(root, fid);
@@ -505,7 +507,8 @@ pub fun sema_doc(w: *Workspace, root: *Root, fid: src.FileId) Result[*sema.SemaR
     build_full_sema_deps(w, root, ?deps);
 
     val own: sess.ModuleId = own_module(root, fid);
-    var ctx: comptime.ComptimeCtx = comptime.init(w.alloc, root.p.target.os_id, root.p.target.arch_id, root.p.target.abi_id, comptime.MODE_DEBUG, 0, root.p.target.isa.pointer_width, root.p.compiler_name, root.p.compiler_ver);
+    var ctx: comptime.ComptimeCtx = comptime.init(w.alloc, root.p.target.os_id, root.p.target.arch_id, root.p.target.abi_id, comptime.MODE_DEBUG, 0, root.p.target.isa.pointer_width, root.p.target.model.vector_bits, root.p.compiler_name, root.p.compiler_ver);
+    comptime.set_target_defs(?ctx, root.p.target.isa.defs);
     val sr_r: Result[sema.SemaResult, str] = sema.sema(w.s, a, rr, ?deps, ?ctx, own);
     comptime.dnit(?ctx);
     free_sema_deps(w, ?deps);

--- a/src/server.mach
+++ b/src/server.mach
@@ -33,6 +33,8 @@ use editor: mach.lang.editor;
 use transport:   mls.transport;
 use json:        mls.json;
 use sj:          std.data.json;
+use jobs:        mls.jobs;
+use atomic:      std.sync.atomic;
 use documents:   mls.documents;
 use diagnostics: mls.diagnostics;
 use language:    mls.language;
@@ -66,7 +68,9 @@ val WATCH_ACTIVE:   u8 = 2;
 # es:            editor session over `s` (per-buffer analysis)
 # docs:          URI -> editor buffer registry
 # ws:            per-root project graphs backing cross-module analysis
-# rd:            per-message JSON parse arena
+# rd:            per-message JSON parse arena, owned by the analysis thread
+# q:             message queue feeding the analysis thread
+# stop:          set once the reading thread should stop; read atomically
 # watch_dynamic: whether the client supports dynamic file-watch registration
 #                (`workspace/didChangeWatchedFiles`), advertised at initialize
 pub rec Server {
@@ -78,6 +82,8 @@ pub rec Server {
     docs:          documents.Store;
     ws:            project.Workspace;
     rd:            json.Reader;
+    q:             jobs.Queue;
+    stop:          i64;
     watch_dynamic: bool;
     watch_state:   u8;
 }
@@ -103,6 +109,8 @@ pub fun init(srv: *Server, alloc: *Allocator) bool {
     srv.ws = project.init(?srv.s, alloc);
     project.attach_documents(?srv.ws, ?srv.docs);
     if (!json.reader_init(?srv.rd, alloc)) { ret false; }
+    srv.stop = 0;
+    if (!jobs.init(?srv.q, alloc)) { ret false; }
     ret true;
 }
 
@@ -110,6 +118,7 @@ pub fun init(srv: *Server, alloc: *Allocator) bool {
 # ---
 # srv: server to tear down
 pub fun dnit(srv: *Server) {
+    jobs.dnit(?srv.q);
     json.reader_dnit(?srv.rd);
     documents.dnit(?srv.docs);
     project.dnit(?srv.ws);
@@ -118,49 +127,76 @@ pub fun dnit(srv: *Server) {
     srv.status = STATUS_EXITED;
 }
 
-# read and dispatch framed messages until the server exits
+# read framed messages until input ends, handing each to the analysis thread
+#
+# This thread owns stdin and nothing else. Every message - parsing included -
+# is handled on the worker, so the compiler's state has exactly one owner and
+# needs no locking, and a cold analysis cannot stop the server from reading the
+# cancellation, edit, or shutdown that follows it.
+#
+# The worker decides the exit code, so the read loop drains the queue before
+# reading it: an EOF arriving while `shutdown` is still queued must not be
+# mistaken for input closing before shutdown.
 # ---
 # srv: the server to drive
 # ret: the process exit code
 pub fun run(srv: *Server) i64 {
     trace.log("=== mach-lsp started ===\n");
 
-    for (srv.status != STATUS_EXITED) {
+    if (!jobs.start(?srv.q, handle_job, (srv)::ptr)) {
+        trace.log("server: could not start the analysis thread\n");
+        ret 1;
+    }
+
+    var last_read: transport.ReadStatus = transport.READ_OK;
+    for (true) {
         var msg: transport.Message;
-        val read_status: transport.ReadStatus = transport.read_message(?msg, srv.alloc);
-        if (read_status != transport.READ_OK) {
-            if (read_status == transport.READ_EOF && srv.status == STATUS_SHUTTING_DOWN) {
-                srv.status = STATUS_EXITED;
-                brk;
-            }
-            if (read_status == transport.READ_EOF) { trace.log("transport: input closed before shutdown\n"); }
-            or (read_status == transport.READ_MALFORMED) { trace.log("transport: malformed input frame\n"); }
-            or { trace.log("transport: input error\n"); }
-            srv.exit_code = 1;
-            srv.status = STATUS_EXITED;
+        last_read = transport.read_message(?msg, srv.alloc);
+        if (last_read != transport.READ_OK) {
+            if (last_read == transport.READ_EOF)        { trace.log("transport: input closed\n"); }
+            or (last_read == transport.READ_MALFORMED)  { trace.log("transport: malformed input frame\n"); }
+            or                                          { trace.log("transport: input error\n"); }
             brk;
         }
 
-        trace.log("recv: ");
-        trace.log(msg.body);
-        trace.log("\n");
-
-        val started_ns: i64 = trace.now_ns();
-        var parsed: json.Message = json.read(?srv.rd, msg.body, msg.body_len);
-        if (parsed.valid) { dispatch(srv, ?parsed.root); }
-        or { reply_parse_error(srv); }
-        json.release(?srv.rd);
-        trace.logf("server: handled message in {}ms", (trace.now_ns() - started_ns) / 1000000);
-        transport.message_free(?msg, srv.alloc);
-        if (transport.write_failed()) {
-            trace.log("transport: output failed\n");
-            srv.exit_code = 1;
-            srv.status = STATUS_EXITED;
+        if (!jobs.push(?srv.q, msg.body, msg.body_len)) {
+            trace.logf("server: analysis queue full at {} messages, dropping input",
+                       jobs.depth(?srv.q)::i64);
         }
+        transport.message_free(?msg, srv.alloc);
+        if (atomic.load(?srv.stop) != 0) { brk; }
     }
 
+    # every accepted message is answered before the exit code is decided
+    jobs.join(?srv.q);
     trace.log("=== mach-lsp exiting ===\n");
-    ret srv.exit_code;
+
+    if (transport.write_failed()) { ret 1; }
+    if (srv.status == STATUS_EXITED)       { ret srv.exit_code; }
+    if (last_read == transport.READ_EOF && srv.status == STATUS_SHUTTING_DOWN) { ret 0; }
+    ret 1;
+}
+
+# handle one queued message on the analysis thread
+#
+# The parse arena and every compiler-owned structure belong to this thread.
+fun handle_job(ctx: ptr, body: str, len: usize) {
+    val srv: *Server = ctx::*Server;
+
+    trace.log("recv: ");
+    trace.log(body);
+    trace.log("\n");
+
+    val started_ns: i64 = trace.now_ns();
+    var parsed: json.Message = json.read(?srv.rd, body, len);
+    if (parsed.valid) { dispatch(srv, ?parsed.root); }
+    or { reply_parse_error(srv); }
+    json.release(?srv.rd);
+    trace.logf("server: handled message in {}ms", (trace.now_ns() - started_ns) / 1000000);
+
+    if (srv.status == STATUS_EXITED || transport.write_failed()) {
+        atomic.store(?srv.stop, 1);
+    }
 }
 
 # route one parsed message by its `method` member

--- a/src/server.mach
+++ b/src/server.mach
@@ -131,7 +131,9 @@ pub fun run(srv: *Server) i64 {
         trace.log(msg.body);
         trace.log("\n");
 
+        val started_ns: i64 = trace.now_ns();
         dispatch(srv, ?msg);
+        trace.logf("server: handled message in {}ms", (trace.now_ns() - started_ns) / 1000000);
         transport.message_free(?msg, srv.alloc);
         if (transport.write_failed()) {
             trace.log("transport: output failed\n");

--- a/src/server.mach
+++ b/src/server.mach
@@ -71,6 +71,8 @@ val WATCH_ACTIVE:   u8 = 2;
 # rd:            per-message JSON parse arena, owned by the analysis thread
 # q:             message queue feeding the analysis thread
 # stop:          set once the reading thread should stop; read atomically
+# deferred:      a document changed but its analysis was postponed behind newer
+#                input, and must run once the queue drains
 # watch_dynamic: whether the client supports dynamic file-watch registration
 #                (`workspace/didChangeWatchedFiles`), advertised at initialize
 pub rec Server {
@@ -84,6 +86,7 @@ pub rec Server {
     rd:            json.Reader;
     q:             jobs.Queue;
     stop:          i64;
+    deferred:      bool;
     watch_dynamic: bool;
     watch_state:   u8;
 }
@@ -110,6 +113,7 @@ pub fun init(srv: *Server, alloc: *Allocator) bool {
     project.attach_documents(?srv.ws, ?srv.docs);
     if (!json.reader_init(?srv.rd, alloc)) { ret false; }
     srv.stop = 0;
+    srv.deferred = false;
     if (!jobs.init(?srv.q, alloc)) { ret false; }
     ret true;
 }
@@ -192,6 +196,14 @@ fun handle_job(ctx: ptr, body: str, len: usize) {
     if (parsed.valid) { dispatch(srv, ?parsed.root); }
     or { reply_parse_error(srv); }
     json.release(?srv.rd);
+
+    # a coalesced burst leaves the newest text unanalyzed; the moment the queue
+    # drains is when that debt comes due, whatever the last message happened to
+    # be. deferring analysis must never mean skipping it.
+    if (srv.deferred && jobs.depth(?srv.q) == 0 && srv.status == STATUS_RUNNING) {
+        srv.deferred = false;
+        republish_all(srv);
+    }
     trace.logf("server: handled message in {}ms", (trace.now_ns() - started_ns) / 1000000);
 
     if (srv.status == STATUS_EXITED || transport.write_failed()) {
@@ -460,6 +472,19 @@ fun publish_for(srv: *Server, uri: str, text: str, version: i64, is_open: bool) 
         trace.log("project: failed to mirror document overlay\n");
         ret;
     }
+
+    # The document's text and revision are recorded above; analyzing it is what
+    # costs. While more input is already queued, that analysis would be thrown
+    # away by the very next message, so a burst of keystrokes coalesces into one
+    # analysis of the newest text instead of one per revision. The message that
+    # finds the queue empty is the one that publishes, so the newest state is
+    # always analyzed - deferring is never dropping.
+    if (jobs.depth(?srv.q) > 0) {
+        srv.deferred = true;
+        trace.log("server: newer input queued, deferring analysis\n");
+        ret;
+    }
+    srv.deferred = false;
     republish_root(srv, project.root_for(?srv.ws, doc.uri), doc);
 }
 

--- a/src/server.mach
+++ b/src/server.mach
@@ -43,6 +43,9 @@ pub val STATUS_UNINITIALIZED: u8 = 0;
 pub val STATUS_RUNNING:       u8 = 1;
 pub val STATUS_SHUTTING_DOWN: u8 = 2;
 pub val STATUS_EXITED:        u8 = 3;
+val WATCH_FALLBACK: u8 = 0;
+val WATCH_PENDING:  u8 = 1;
+val WATCH_ACTIVE:   u8 = 2;
 
 # the long-lived server state
 # ---
@@ -64,6 +67,7 @@ pub rec Server {
     docs:          documents.Store;
     ws:            project.Workspace;
     watch_dynamic: bool;
+    watch_state:   u8;
 }
 
 # build a server over the given allocator
@@ -76,6 +80,7 @@ pub fun init(srv: *Server, alloc: *Allocator) bool {
     srv.exit_code = 0;
     srv.alloc = alloc;
     srv.watch_dynamic = false;
+    srv.watch_state = WATCH_FALLBACK;
 
     val sr: Result[sess.Session, str] = sess.init(alloc);
     if (is_err[sess.Session, str](sr)) { ret false; }
@@ -83,7 +88,8 @@ pub fun init(srv: *Server, alloc: *Allocator) bool {
 
     srv.es = editor.init(?srv.s);
     srv.docs = documents.init(?srv.es, alloc);
-    srv.ws = project.init(?srv.s, ?srv.es, alloc);
+    srv.ws = project.init(?srv.s, alloc);
+    project.attach_documents(?srv.ws, ?srv.docs);
     ret true;
 }
 
@@ -142,7 +148,7 @@ pub fun run(srv: *Server) i64 {
 fun dispatch(srv: *Server, msg: *transport.Message) {
     val body: str = msg.body;
     val method: str = json.extract_string(body, "\"method\"", srv.alloc);
-    if (method == nil) { ret; }
+    if (method == nil) { handle_response(srv, body); ret; }
 
     if (str_equals(method, "initialize")) {
         json.free_str(method, srv.alloc);
@@ -188,6 +194,7 @@ fun dispatch(srv: *Server, msg: *transport.Message) {
     }
     if (str_equals(method, "textDocument/didSave")) {
         json.free_str(method, srv.alloc);
+        handle_did_save(srv, body);
         ret;
     }
     if (str_equals(method, "workspace/didChangeConfiguration")) {
@@ -271,9 +278,34 @@ fun handle_initialized(srv: *Server) {
     if (!srv.watch_dynamic) { ret; }
     val reg: str = "{\"jsonrpc\":\"2.0\",\"id\":\"mls/registerWatchers\",\"method\":\"client/registerCapability\",\"params\":{\"registrations\":[{\"id\":\"mls-watched-files\",\"method\":\"workspace/didChangeWatchedFiles\",\"registerOptions\":{\"watchers\":[{\"globPattern\":\"**/mach.toml\"},{\"globPattern\":\"**/mach.lock\"},{\"globPattern\":\"**/*.mach\"}]}}]}}";
     transport.send_message(reg, srv.alloc);
-    # the watcher now covers manifest / lockfile changes; skip the per-request
-    # mtime fallback check.
+    srv.watch_state = WATCH_PENDING;
+}
+
+# accept dynamic watching only after the client acknowledges registration;
+# rejection keeps conservative fallback invalidation enabled
+fun handle_response(srv: *Server, body: str) {
+    if (srv.watch_state != WATCH_PENDING) { ret; }
+    val id: str = json.extract_raw(body, "\"id\"", srv.alloc);
+    if (id == nil) { ret; }
+    val ours: bool = str_equals(id, "\"mls/registerWatchers\"");
+    json.free_str(id, srv.alloc);
+    if (!ours) { ret; }
+    val er: str = json.extract_raw(body, "\"error\"", srv.alloc);
+    if (er != nil) {
+        json.free_str(er, srv.alloc);
+        srv.watch_state = WATCH_FALLBACK;
+        project.set_watch_active(?srv.ws, false);
+        ret;
+    }
+    srv.watch_state = WATCH_ACTIVE;
     project.set_watch_active(?srv.ws, true);
+}
+
+fun handle_did_save(srv: *Server, body: str) {
+    val uri: str = json.extract_after(body, "\"textDocument\"", "\"uri\"", srv.alloc);
+    if (uri == nil) { ret; }
+    project.invalidate_uri(?srv.ws, uri);
+    json.free_str(uri, srv.alloc);
 }
 
 # invalidate every project root whose tree
@@ -316,7 +348,9 @@ fun handle_did_open(srv: *Server, body: str) {
     val text: str = json.extract_after(body, "\"textDocument\"", "\"text\"", srv.alloc);
     if (text == nil) { json.free_str(uri, srv.alloc); ret; }
 
-    publish_for(srv, uri, text, true);
+    var version: i64 = 0;
+    if (!document_version(srv, body, ?version)) { json.free_str(text, srv.alloc); json.free_str(uri, srv.alloc); ret; }
+    publish_for(srv, uri, text, version, true);
 
     json.free_str(text, srv.alloc);
     json.free_str(uri, srv.alloc);
@@ -331,10 +365,22 @@ fun handle_did_change(srv: *Server, body: str) {
     val text: str = json.extract_after(body, "\"contentChanges\"", "\"text\"", srv.alloc);
     if (text == nil) { json.free_str(uri, srv.alloc); ret; }
 
-    publish_for(srv, uri, text, false);
+    var version: i64 = 0;
+    if (!document_version(srv, body, ?version)) { json.free_str(text, srv.alloc); json.free_str(uri, srv.alloc); ret; }
+    publish_for(srv, uri, text, version, false);
 
     json.free_str(text, srv.alloc);
     json.free_str(uri, srv.alloc);
+}
+
+# read the required TextDocumentItem/VersionedTextDocumentIdentifier version,
+# distinguishing a missing field from the valid numeric value zero
+fun document_version(srv: *Server, body: str, out: *i64) bool {
+    val raw: str = json.extract_raw(body, "\"version\"", srv.alloc);
+    if (raw == nil) { ret false; }
+    json.free_str(raw, srv.alloc);
+    @out = json.extract_number_after(body, "\"textDocument\"", "\"version\"", srv.alloc);
+    ret true;
 }
 
 # retire the document, reclaim its cached resolve result, and
@@ -342,10 +388,11 @@ fun handle_did_change(srv: *Server, body: str) {
 fun handle_did_close(srv: *Server, body: str) {
     val uri: str = json.extract_after(body, "\"textDocument\"", "\"uri\"", srv.alloc);
     if (uri == nil) { ret; }
-    val doc: *documents.Document = documents.find(?srv.docs, uri);
-    if (doc != nil) { project.free_cached(?srv.ws, doc.file_id); }
+    val doc: *documents.Document = documents.closing(?srv.docs, uri);
+    if (doc != nil) { project.document_closed(?srv.ws, doc); }
     documents.close(?srv.docs, uri);
     diagnostics.clear(srv.alloc, uri);
+    republish_loaded(srv);
     json.free_str(uri, srv.alloc);
 }
 
@@ -394,7 +441,7 @@ fun republish_loaded(srv: *Server) {
     for (i < n) {
         val d: *documents.Document = documents.at(?srv.docs, i);
         if (d != nil && d.in_use && d.uri != nil) {
-            diagnostics.publish(?srv.ws, ?srv.es, project.sources(?srv.ws), srv.alloc, d.uri, d.file_id);
+            diagnostics.publish(?srv.ws, ?srv.es, srv.alloc, d);
         }
         i = i + 1;
     }
@@ -402,10 +449,13 @@ fun republish_loaded(srv: *Server) {
 
 # register/update `uri`'s buffer and publish its diagnostics.
 # `is_open` selects open vs change registration; both end in a publish
-fun publish_for(srv: *Server, uri: str, text: str, is_open: bool) {
+fun publish_for(srv: *Server, uri: str, text: str, version: i64, is_open: bool) {
+    val path: str = project.path_of_uri(srv.alloc, uri);
+    if (path == nil) { ret; }
     var dr: Result[*documents.Document, str];
-    if (is_open) { dr = documents.open(?srv.docs, uri, text); }
-    or { dr = documents.change(?srv.docs, uri, text); }
+    if (is_open) { dr = documents.open(?srv.docs, uri, path, text, version); }
+    or { dr = documents.change(?srv.docs, uri, text, version); }
+    json.free_str(path, srv.alloc);
 
     if (is_err[*documents.Document, str](dr)) {
         trace.log("documents: ");
@@ -414,7 +464,12 @@ fun publish_for(srv: *Server, uri: str, text: str, is_open: bool) {
         ret;
     }
     val doc: *documents.Document = unwrap_ok[*documents.Document, str](dr);
-    diagnostics.publish(?srv.ws, ?srv.es, project.sources(?srv.ws), srv.alloc, uri, doc.file_id);
+    val cr: Result[bool, str] = project.document_changed(?srv.ws, doc);
+    if (is_err[bool, str](cr)) {
+        trace.log("project: failed to mirror document overlay\n");
+        ret;
+    }
+    republish_loaded(srv);
 }
 
 # send a JSON-RPC error response for a request that carries an id;

--- a/src/server.mach
+++ b/src/server.mach
@@ -294,11 +294,9 @@ fun handle_response(srv: *Server, body: str) {
     if (er != nil) {
         json.free_str(er, srv.alloc);
         srv.watch_state = WATCH_FALLBACK;
-        project.set_watch_active(?srv.ws, false);
         ret;
     }
     srv.watch_state = WATCH_ACTIVE;
-    project.set_watch_active(?srv.ws, true);
 }
 
 fun handle_did_save(srv: *Server, body: str) {
@@ -405,11 +403,8 @@ fun handle_did_close(srv: *Server, body: str) {
 fun handle_feature(srv: *Server, body: str, which: i64) {
     val uri: str = json.extract_after(body, "\"textDocument\"", "\"uri\"", srv.alloc);
 
-    # a feature request resolves dep-aware via project.root_for, which loads the
-    # governing project lazily on first use; a type-aware feature additionally
-    # sema's the closure lazily (ensure_sema). snapshot both the load epoch and the
-    # sema epoch so a load (#96) or a first sema (#113) triggered here re-publishes
-    # the now-loaded / now-typed buffers' diagnostics
+    # snapshot compiler epochs so a feature-triggered rebuild republishes the
+    # now-current diagnostics for every affected open document
     val epoch_before: u32 = project.load_epoch(?srv.ws);
     val sema_before:  u32 = project.sema_epoch(?srv.ws);
 
@@ -418,7 +413,7 @@ fun handle_feature(srv: *Server, body: str, which: i64) {
     or (which == 2) { language.references(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, body, uri); }
     or (which == 3) { language.rename(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, body, uri); }
     or (which == 4) { language.prepare_rename(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, body, uri); }
-    or (which == 5) { language.document_symbol(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, body, uri); }
+    or (which == 5) { language.document_symbol(?srv.es, srv.alloc, ?srv.docs, body, uri); }
     or (which == 6) { language.completion(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, body, uri); }
 
     if (uri != nil) { json.free_str(uri, srv.alloc); }

--- a/src/server.mach
+++ b/src/server.mach
@@ -107,13 +107,15 @@ pub fun run(srv: *Server) i64 {
 
     for (srv.status != STATUS_EXITED) {
         var msg: transport.Message;
-        val ok: bool = transport.read_message(?msg, srv.alloc);
-        if (!ok) {
-            if (srv.status == STATUS_SHUTTING_DOWN) {
+        val read_status: transport.ReadStatus = transport.read_message(?msg, srv.alloc);
+        if (read_status != transport.READ_OK) {
+            if (read_status == transport.READ_EOF && srv.status == STATUS_SHUTTING_DOWN) {
                 srv.status = STATUS_EXITED;
                 brk;
             }
-            trace.log("transport: read failed\n");
+            if (read_status == transport.READ_EOF) { trace.log("transport: input closed before shutdown\n"); }
+            or (read_status == transport.READ_MALFORMED) { trace.log("transport: malformed input frame\n"); }
+            or { trace.log("transport: input error\n"); }
             srv.exit_code = 1;
             srv.status = STATUS_EXITED;
             brk;
@@ -125,6 +127,11 @@ pub fun run(srv: *Server) i64 {
 
         dispatch(srv, ?msg);
         transport.message_free(?msg, srv.alloc);
+        if (transport.write_failed()) {
+            trace.log("transport: output failed\n");
+            srv.exit_code = 1;
+            srv.status = STATUS_EXITED;
+        }
     }
 
     trace.log("=== mach-lsp exiting ===\n");

--- a/src/server.mach
+++ b/src/server.mach
@@ -32,6 +32,7 @@ use editor: mach.lang.editor;
 
 use transport:   mls.transport;
 use json:        mls.json;
+use sj:          std.data.json;
 use documents:   mls.documents;
 use diagnostics: mls.diagnostics;
 use language:    mls.language;
@@ -43,6 +44,15 @@ pub val STATUS_UNINITIALIZED: u8 = 0;
 pub val STATUS_RUNNING:       u8 = 1;
 pub val STATUS_SHUTTING_DOWN: u8 = 2;
 pub val STATUS_EXITED:        u8 = 3;
+# language features, as dispatch selectors
+val FEATURE_HOVER:           u8 = 0;
+val FEATURE_DEFINITION:      u8 = 1;
+val FEATURE_REFERENCES:      u8 = 2;
+val FEATURE_RENAME:          u8 = 3;
+val FEATURE_PREPARE_RENAME:  u8 = 4;
+val FEATURE_DOCUMENT_SYMBOL: u8 = 5;
+val FEATURE_COMPLETION:      u8 = 6;
+
 val WATCH_FALLBACK: u8 = 0;
 val WATCH_PENDING:  u8 = 1;
 val WATCH_ACTIVE:   u8 = 2;
@@ -56,6 +66,7 @@ val WATCH_ACTIVE:   u8 = 2;
 # es:            editor session over `s` (per-buffer analysis)
 # docs:          URI -> editor buffer registry
 # ws:            per-root project graphs backing cross-module analysis
+# rd:            per-message JSON parse arena
 # watch_dynamic: whether the client supports dynamic file-watch registration
 #                (`workspace/didChangeWatchedFiles`), advertised at initialize
 pub rec Server {
@@ -66,6 +77,7 @@ pub rec Server {
     es:            editor.EditorSession;
     docs:          documents.Store;
     ws:            project.Workspace;
+    rd:            json.Reader;
     watch_dynamic: bool;
     watch_state:   u8;
 }
@@ -90,6 +102,7 @@ pub fun init(srv: *Server, alloc: *Allocator) bool {
     srv.docs = documents.init(?srv.es, alloc);
     srv.ws = project.init(?srv.s, alloc);
     project.attach_documents(?srv.ws, ?srv.docs);
+    if (!json.reader_init(?srv.rd, alloc)) { ret false; }
     ret true;
 }
 
@@ -97,6 +110,7 @@ pub fun init(srv: *Server, alloc: *Allocator) bool {
 # ---
 # srv: server to tear down
 pub fun dnit(srv: *Server) {
+    json.reader_dnit(?srv.rd);
     documents.dnit(?srv.docs);
     project.dnit(?srv.ws);
     editor.dnit(?srv.es);
@@ -132,7 +146,10 @@ pub fun run(srv: *Server) i64 {
         trace.log("\n");
 
         val started_ns: i64 = trace.now_ns();
-        dispatch(srv, ?msg);
+        var parsed: json.Message = json.read(?srv.rd, msg.body, msg.body_len);
+        if (parsed.valid) { dispatch(srv, ?parsed.root); }
+        or { reply_parse_error(srv); }
+        json.release(?srv.rd);
         trace.logf("server: handled message in {}ms", (trace.now_ns() - started_ns) / 1000000);
         transport.message_free(?msg, srv.alloc);
         if (transport.write_failed()) {
@@ -146,136 +163,74 @@ pub fun run(srv: *Server) i64 {
     ret srv.exit_code;
 }
 
-# route one message body by its `method` field
-fun dispatch(srv: *Server, msg: *transport.Message) {
-    val body: str = msg.body;
-    val method: str = json.extract_string(body, "\"method\"", srv.alloc);
-    if (method == nil) { handle_response(srv, body); ret; }
+# route one parsed message by its `method` member
+#
+# a message with no `method` is a response to something the server asked for.
+# an unknown method gets a JSON-RPC method-not-found error when it carries an
+# id, and is dropped when it does not - a notification owes no response.
+fun dispatch(srv: *Server, root: *sj.Value) {
+    val a: *Allocator = srv.alloc;
+    val method_v: *sj.Value = json.member(root, "method");
+    if (method_v == nil) { handle_response(srv, root); ret; }
+    val method: str = json.text(method_v, a);
+    if (method == nil) { reply_invalid_request(srv, root); ret; }
+    val params: *sj.Value = json.member(root, "params");
 
-    if (str_equals(method, "initialize")) {
-        json.free_str(method, srv.alloc);
-        handle_initialize(srv, body);
-        ret;
-    }
-    if (str_equals(method, "initialized")) {
-        json.free_str(method, srv.alloc);
-        handle_initialized(srv);
-        ret;
-    }
-    if (str_equals(method, "shutdown")) {
-        json.free_str(method, srv.alloc);
-        handle_shutdown(srv, body);
-        ret;
-    }
-    if (str_equals(method, "exit")) {
-        json.free_str(method, srv.alloc);
-        handle_exit(srv);
-        ret;
-    }
+    if (str_equals(method, "initialize"))  { json.free_str(method, a); handle_initialize(srv, root, params); ret; }
+    if (str_equals(method, "initialized")) { json.free_str(method, a); handle_initialized(srv); ret; }
+    if (str_equals(method, "shutdown"))    { json.free_str(method, a); handle_shutdown(srv, root); ret; }
+    if (str_equals(method, "exit"))        { json.free_str(method, a); handle_exit(srv); ret; }
 
     if (srv.status != STATUS_RUNNING) {
-        json.free_str(method, srv.alloc);
-        reply_error(srv, body, -32002, "server not initialized");
+        json.free_str(method, a);
+        reply_error(srv, root, -32002, "server not initialized");
         ret;
     }
 
-    if (str_equals(method, "textDocument/didOpen")) {
-        json.free_str(method, srv.alloc);
-        handle_did_open(srv, body);
-        ret;
-    }
-    if (str_equals(method, "textDocument/didChange")) {
-        json.free_str(method, srv.alloc);
-        handle_did_change(srv, body);
-        ret;
-    }
-    if (str_equals(method, "textDocument/didClose")) {
-        json.free_str(method, srv.alloc);
-        handle_did_close(srv, body);
-        ret;
-    }
-    if (str_equals(method, "textDocument/didSave")) {
-        json.free_str(method, srv.alloc);
-        handle_did_save(srv, body);
-        ret;
-    }
-    if (str_equals(method, "workspace/didChangeConfiguration")) {
-        json.free_str(method, srv.alloc);
-        ret;
-    }
-    if (str_equals(method, "workspace/didChangeWatchedFiles")) {
-        json.free_str(method, srv.alloc);
-        handle_did_change_watched_files(srv, body);
-        ret;
-    }
+    if (str_equals(method, "textDocument/didOpen"))   { json.free_str(method, a); handle_did_open(srv, params); ret; }
+    if (str_equals(method, "textDocument/didChange")) { json.free_str(method, a); handle_did_change(srv, params); ret; }
+    if (str_equals(method, "textDocument/didClose"))  { json.free_str(method, a); handle_did_close(srv, params); ret; }
+    if (str_equals(method, "textDocument/didSave"))   { json.free_str(method, a); handle_did_save(srv, params); ret; }
+    if (str_equals(method, "workspace/didChangeConfiguration")) { json.free_str(method, a); ret; }
+    if (str_equals(method, "workspace/didChangeWatchedFiles"))  { json.free_str(method, a); handle_did_change_watched_files(srv, params); ret; }
 
-    if (str_equals(method, "textDocument/hover")) {
-        json.free_str(method, srv.alloc);
-        handle_feature(srv, body, 0);
-        ret;
-    }
-    if (str_equals(method, "textDocument/definition")) {
-        json.free_str(method, srv.alloc);
-        handle_feature(srv, body, 1);
-        ret;
-    }
-    if (str_equals(method, "textDocument/references")) {
-        json.free_str(method, srv.alloc);
-        handle_feature(srv, body, 2);
-        ret;
-    }
-    if (str_equals(method, "textDocument/rename")) {
-        json.free_str(method, srv.alloc);
-        handle_feature(srv, body, 3);
-        ret;
-    }
-    if (str_equals(method, "textDocument/prepareRename")) {
-        json.free_str(method, srv.alloc);
-        handle_feature(srv, body, 4);
-        ret;
-    }
-    if (str_equals(method, "textDocument/documentSymbol")) {
-        json.free_str(method, srv.alloc);
-        handle_feature(srv, body, 5);
-        ret;
-    }
-    if (str_equals(method, "textDocument/completion")) {
-        json.free_str(method, srv.alloc);
-        handle_feature(srv, body, 6);
-        ret;
-    }
+    if (str_equals(method, "textDocument/hover"))          { json.free_str(method, a); handle_feature(srv, root, params, FEATURE_HOVER); ret; }
+    if (str_equals(method, "textDocument/definition"))     { json.free_str(method, a); handle_feature(srv, root, params, FEATURE_DEFINITION); ret; }
+    if (str_equals(method, "textDocument/references"))     { json.free_str(method, a); handle_feature(srv, root, params, FEATURE_REFERENCES); ret; }
+    if (str_equals(method, "textDocument/rename"))         { json.free_str(method, a); handle_feature(srv, root, params, FEATURE_RENAME); ret; }
+    if (str_equals(method, "textDocument/prepareRename"))  { json.free_str(method, a); handle_feature(srv, root, params, FEATURE_PREPARE_RENAME); ret; }
+    if (str_equals(method, "textDocument/documentSymbol")) { json.free_str(method, a); handle_feature(srv, root, params, FEATURE_DOCUMENT_SYMBOL); ret; }
+    if (str_equals(method, "textDocument/completion"))     { json.free_str(method, a); handle_feature(srv, root, params, FEATURE_COMPLETION); ret; }
 
-    trace.log("unhandled method: ");
-    trace.log(method);
-    trace.log("\n");
-    json.free_str(method, srv.alloc);
-    reply_error(srv, body, -32601, "method not found");
+    trace.logf("server: unhandled method {}", method);
+    json.free_str(method, a);
+    if (json.member(root, "id") != nil) { reply_error(srv, root, -32601, "method not found"); }
 }
 
-# answer the initialize request with the server's
-# capabilities (full-text document sync) and mark the server running
-fun handle_initialize(srv: *Server, body: str) {
-    val id: str = json.extract_raw(body, "\"id\"", srv.alloc);
-    if (id == nil) { ret; }
-
+# answer the initialize request with the server's capabilities (full-text
+# document sync) and mark the server running
+fun handle_initialize(srv: *Server, root: *sj.Value, params: *sj.Value) {
     # remember whether the client can accept a dynamic watch registration, so
     # `initialized` only sends one when it will be honoured.
-    srv.watch_dynamic = json.extract_bool_after(body, "\"didChangeWatchedFiles\"", "\"dynamicRegistration\"", srv.alloc);
+    val watched: *sj.Value = json.member(
+        json.member2(params, "capabilities", "workspace"), "didChangeWatchedFiles");
+    srv.watch_dynamic = json.boolean(json.member(watched, "dynamicRegistration"), false);
 
-    val prefix: str = "{\"jsonrpc\":\"2.0\",\"id\":";
-    val result: str = ",\"result\":{\"capabilities\":{\"textDocumentSync\":1,\"hoverProvider\":true,\"definitionProvider\":true,\"referencesProvider\":true,\"renameProvider\":{\"prepareProvider\":true},\"documentSymbolProvider\":true,\"completionProvider\":{\"triggerCharacters\":[\".\"]}},\"serverInfo\":{\"name\":\"mach-lsp\"}}}";
-    send_concat2(srv, prefix, id, result);
-    json.free_str(id, srv.alloc);
+    var b: json.Buf = json.buf_init(srv.alloc);
+    json.buf_push(?b, "{\"jsonrpc\":\"2.0\",\"id\":");
+    json.buf_push_id(?b, json.member(root, "id"));
+    json.buf_push(?b, ",\"result\":{\"capabilities\":{\"textDocumentSync\":1,\"hoverProvider\":true,\"definitionProvider\":true,\"referencesProvider\":true,\"renameProvider\":{\"prepareProvider\":true},\"documentSymbolProvider\":true,\"completionProvider\":{\"triggerCharacters\":[\".\"]}},\"serverInfo\":{\"name\":\"mach-lsp\"}}}");
+    send_buf(srv, ?b);
 
     srv.status = STATUS_RUNNING;
     trace.log("initialized\n");
 }
 
-# once the client signals it is ready, register file
-# watchers for the manifest, lockfile, and source trees so a dep-graph change
-# (pulling deps, editing a dep source) triggers `workspace/didChangeWatchedFiles`
-# and the affected project root is rebuilt. only sent when the client advertised
-# dynamic registration; clients without it fall back to the server's mtime check
+# once the client signals it is ready, register file watchers for the manifest,
+# lockfile, and source trees so a dep-graph change (pulling deps, editing a dep
+# source) triggers `workspace/didChangeWatchedFiles` and the affected project
+# root is rebuilt. only sent when the client advertised dynamic registration;
+# clients without it fall back to the server's fingerprint check
 fun handle_initialized(srv: *Server) {
     if (!srv.watch_dynamic) { ret; }
     val reg: str = "{\"jsonrpc\":\"2.0\",\"id\":\"mls/registerWatchers\",\"method\":\"client/registerCapability\",\"params\":{\"registrations\":[{\"id\":\"mls-watched-files\",\"method\":\"workspace/didChangeWatchedFiles\",\"registerOptions\":{\"watchers\":[{\"globPattern\":\"**/mach.toml\"},{\"globPattern\":\"**/mach.lock\"},{\"globPattern\":\"**/*.mach\"}]}}]}}";
@@ -285,51 +240,46 @@ fun handle_initialized(srv: *Server) {
 
 # accept dynamic watching only after the client acknowledges registration;
 # rejection keeps conservative fallback invalidation enabled
-fun handle_response(srv: *Server, body: str) {
+fun handle_response(srv: *Server, root: *sj.Value) {
     if (srv.watch_state != WATCH_PENDING) { ret; }
-    val id: str = json.extract_raw(body, "\"id\"", srv.alloc);
-    if (id == nil) { ret; }
-    val ours: bool = str_equals(id, "\"mls/registerWatchers\"");
-    json.free_str(id, srv.alloc);
-    if (!ours) { ret; }
-    val er: str = json.extract_raw(body, "\"error\"", srv.alloc);
-    if (er != nil) {
-        json.free_str(er, srv.alloc);
-        srv.watch_state = WATCH_FALLBACK;
-        ret;
-    }
+    if (!json.text_equals(json.member(root, "id"), "mls/registerWatchers", srv.alloc)) { ret; }
+    if (json.member(root, "error") != nil) { srv.watch_state = WATCH_FALLBACK; ret; }
     srv.watch_state = WATCH_ACTIVE;
 }
 
-fun handle_did_save(srv: *Server, body: str) {
-    val uri: str = json.extract_after(body, "\"textDocument\"", "\"uri\"", srv.alloc);
+# a save makes the buffer's disk state authoritative again for its root
+fun handle_did_save(srv: *Server, params: *sj.Value) {
+    val uri: str = json.text(json.member2(params, "textDocument", "uri"), srv.alloc);
     if (uri == nil) { ret; }
     project.invalidate_uri(?srv.ws, uri);
     json.free_str(uri, srv.alloc);
 }
 
-# invalidate every project root whose tree
-# contains a changed file, so the next request rebuilds it from disk. each
-# `uri` in the notification's `changes` array is invalidated in turn
-fun handle_did_change_watched_files(srv: *Server, body: str) {
-    var i: u32 = 0;
-    for (true) {
-        val uri: str = json.extract_string_seq(body, "\"uri\"", i, srv.alloc);
-        if (uri == nil) { brk; }
-        project.invalidate_uri(?srv.ws, uri);
-        json.free_str(uri, srv.alloc);
+# invalidate every project root whose tree contains a changed file, so the next
+# request rebuilds it from disk. each entry of the notification's `changes`
+# array is invalidated in turn
+fun handle_did_change_watched_files(srv: *Server, params: *sj.Value) {
+    val changes: *sj.Value = json.member(params, "changes");
+    val n: usize = json.count(changes);
+    var i: usize = 0;
+    for (i < n) {
+        val uri: str = json.text(json.member(json.element(changes, i), "uri"), srv.alloc);
+        if (uri != nil) {
+            project.invalidate_uri(?srv.ws, uri);
+            json.free_str(uri, srv.alloc);
+        }
         i = i + 1;
     }
 }
 
 # acknowledge a shutdown request and enter the shutting-down phase
-fun handle_shutdown(srv: *Server, body: str) {
-    val id: str = json.extract_raw(body, "\"id\"", srv.alloc);
-    if (id != nil) {
-        val prefix: str = "{\"jsonrpc\":\"2.0\",\"id\":";
-        val result: str = ",\"result\":null}";
-        send_concat2(srv, prefix, id, result);
-        json.free_str(id, srv.alloc);
+fun handle_shutdown(srv: *Server, root: *sj.Value) {
+    if (json.member(root, "id") != nil) {
+        var b: json.Buf = json.buf_init(srv.alloc);
+        json.buf_push(?b, "{\"jsonrpc\":\"2.0\",\"id\":");
+        json.buf_push_id(?b, json.member(root, "id"));
+        json.buf_push(?b, ",\"result\":null}");
+        send_buf(srv, ?b);
     }
     srv.status = STATUS_SHUTTING_DOWN;
 }
@@ -342,51 +292,39 @@ fun handle_exit(srv: *Server) {
 }
 
 # register the opened document and publish its diagnostics
-fun handle_did_open(srv: *Server, body: str) {
-    val uri: str = json.extract_after(body, "\"textDocument\"", "\"uri\"", srv.alloc);
+fun handle_did_open(srv: *Server, params: *sj.Value) {
+    val doc: *sj.Value = json.member(params, "textDocument");
+    val uri: str = json.text(json.member(doc, "uri"), srv.alloc);
     if (uri == nil) { ret; }
-    val text: str = json.extract_after(body, "\"textDocument\"", "\"text\"", srv.alloc);
+    val text: str = json.text(json.member(doc, "text"), srv.alloc);
     if (text == nil) { json.free_str(uri, srv.alloc); ret; }
-
-    var version: i64 = 0;
-    if (!document_version(srv, body, ?version)) { json.free_str(text, srv.alloc); json.free_str(uri, srv.alloc); ret; }
-    publish_for(srv, uri, text, version, true);
-
+    val version_v: *sj.Value = json.member(doc, "version");
+    if (version_v != nil) { publish_for(srv, uri, text, json.number(version_v, 0), true); }
     json.free_str(text, srv.alloc);
     json.free_str(uri, srv.alloc);
 }
 
-# apply the document's new full text and republish diagnostics.
-# only full-document sync (textDocumentSync = 1) is advertised, so the change is
-# the entire new text
-fun handle_did_change(srv: *Server, body: str) {
-    val uri: str = json.extract_after(body, "\"textDocument\"", "\"uri\"", srv.alloc);
+# apply the document's new full text and republish diagnostics. only
+# full-document sync (textDocumentSync = 1) is advertised, so the last change
+# entry carries the entire new text
+fun handle_did_change(srv: *Server, params: *sj.Value) {
+    val doc: *sj.Value = json.member(params, "textDocument");
+    val uri: str = json.text(json.member(doc, "uri"), srv.alloc);
     if (uri == nil) { ret; }
-    val text: str = json.extract_after(body, "\"contentChanges\"", "\"text\"", srv.alloc);
+    val changes: *sj.Value = json.member(params, "contentChanges");
+    val n: usize = json.count(changes);
+    if (n == 0) { json.free_str(uri, srv.alloc); ret; }
+    val text: str = json.text(json.member(json.element(changes, n - 1), "text"), srv.alloc);
     if (text == nil) { json.free_str(uri, srv.alloc); ret; }
-
-    var version: i64 = 0;
-    if (!document_version(srv, body, ?version)) { json.free_str(text, srv.alloc); json.free_str(uri, srv.alloc); ret; }
-    publish_for(srv, uri, text, version, false);
-
+    val version_v: *sj.Value = json.member(doc, "version");
+    if (version_v != nil) { publish_for(srv, uri, text, json.number(version_v, 0), false); }
     json.free_str(text, srv.alloc);
     json.free_str(uri, srv.alloc);
 }
 
-# read the required TextDocumentItem/VersionedTextDocumentIdentifier version,
-# distinguishing a missing field from the valid numeric value zero
-fun document_version(srv: *Server, body: str, out: *i64) bool {
-    val raw: str = json.extract_raw(body, "\"version\"", srv.alloc);
-    if (raw == nil) { ret false; }
-    json.free_str(raw, srv.alloc);
-    @out = json.extract_number_after(body, "\"textDocument\"", "\"version\"", srv.alloc);
-    ret true;
-}
-
-# retire the document, reclaim its cached resolve result, and
-# clear its diagnostics
-fun handle_did_close(srv: *Server, body: str) {
-    val uri: str = json.extract_after(body, "\"textDocument\"", "\"uri\"", srv.alloc);
+# retire the document, reclaim its cached analysis, and clear its diagnostics
+fun handle_did_close(srv: *Server, params: *sj.Value) {
+    val uri: str = json.text(json.member2(params, "textDocument", "uri"), srv.alloc);
     if (uri == nil) { ret; }
     val doc: *documents.Document = documents.closing(?srv.docs, uri);
     if (doc != nil) { project.document_closed(?srv.ws, doc); }
@@ -396,27 +334,27 @@ fun handle_did_close(srv: *Server, body: str) {
     json.free_str(uri, srv.alloc);
 }
 
-# route a language-feature request to its handler in `language`.
-# the document uri is extracted once here and passed through; the feature code
-# resolves the buffer, pivots the cursor, and replies. `which` selects the
-# feature: 0 hover, 1 definition, 2 references, 3 rename, 4 prepareRename,
-# 5 documentSymbol, 6 completion. an unknown / unopened uri still gets a
-# null / empty reply from the feature so the client is never left waiting
-fun handle_feature(srv: *Server, body: str, which: i64) {
-    val uri: str = json.extract_after(body, "\"textDocument\"", "\"uri\"", srv.alloc);
+# route a language-feature request to its handler in `language`
+#
+# the document uri is read once here and passed through; the feature code
+# resolves the buffer, pivots the cursor, and replies. an unknown or unopened
+# uri still gets a null / empty reply, so the client is never left waiting
+fun handle_feature(srv: *Server, root: *sj.Value, params: *sj.Value, which: u8) {
+    val uri: str = json.text(json.member2(params, "textDocument", "uri"), srv.alloc);
+    val id: *sj.Value = json.member(root, "id");
 
     # snapshot compiler epochs so a feature-triggered rebuild republishes the
     # now-current diagnostics for every affected open document
     val epoch_before: u32 = project.load_epoch(?srv.ws);
     val sema_before:  u32 = project.sema_epoch(?srv.ws);
 
-    if (which == 0) { language.hover(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, body, uri); }
-    or (which == 1) { language.definition(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, body, uri); }
-    or (which == 2) { language.references(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, body, uri); }
-    or (which == 3) { language.rename(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, body, uri); }
-    or (which == 4) { language.prepare_rename(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, body, uri); }
-    or (which == 5) { language.document_symbol(?srv.es, srv.alloc, ?srv.docs, body, uri); }
-    or (which == 6) { language.completion(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, body, uri); }
+    if (which == FEATURE_HOVER)           { language.hover(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, id, params, uri); }
+    or (which == FEATURE_DEFINITION)      { language.definition(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, id, params, uri); }
+    or (which == FEATURE_REFERENCES)      { language.references(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, id, params, uri); }
+    or (which == FEATURE_RENAME)          { language.rename(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, id, params, uri); }
+    or (which == FEATURE_PREPARE_RENAME)  { language.prepare_rename(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, id, params, uri); }
+    or (which == FEATURE_DOCUMENT_SYMBOL) { language.document_symbol(?srv.es, srv.alloc, ?srv.docs, id, params, uri); }
+    or (which == FEATURE_COMPLETION)      { language.completion(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, id, params, uri); }
 
     if (uri != nil) { json.free_str(uri, srv.alloc); }
 
@@ -469,63 +407,43 @@ fun publish_for(srv: *Server, uri: str, text: str, version: i64, is_open: bool) 
     republish_loaded(srv);
 }
 
-# send a JSON-RPC error response for a request that carries an id;
-# a no-op for a notification (no id)
-fun reply_error(srv: *Server, body: str, code: i64, message: str) {
-    val id: str = json.extract_raw(body, "\"id\"", srv.alloc);
+# send a JSON-RPC error response for a request that carries an id
+#
+# a notification owes no response, so one without an id is dropped.
+fun reply_error(srv: *Server, root: *sj.Value, code: i64, message: str) {
+    val id: *sj.Value = json.member(root, "id");
     if (id == nil) { ret; }
-
-    val code_str: str = json.format_i64(code, srv.alloc);
-    val qmsg: str = json.quote(message, srv.alloc);
-    val p1: str = "{\"jsonrpc\":\"2.0\",\"id\":";
-    val p2: str = ",\"error\":{\"code\":";
-    val p3: str = ",\"message\":";
-    val p4: str = "}}";
-
-    send_concat(srv, p1, id, p2, code_str, p3, qmsg, p4);
-
-    json.free_str(qmsg, srv.alloc);
-    json.free_str(code_str, srv.alloc);
-    json.free_str(id, srv.alloc);
+    send_error(srv, id, code, message);
 }
 
-# frame and send `a + b + c`
-fun send_concat2(srv: *Server, a: str, b: str, c: str) {
-    send_concat(srv, a, b, c, nil, nil, nil, nil);
+# a parse error names no id: the body never became a tree, so there is nothing
+# to echo. the spec answers this with a null id
+fun reply_parse_error(srv: *Server) {
+    trace.log("server: message body is not valid JSON\n");
+    send_error(srv, nil, -32700, "parse error");
 }
 
-# frame and send the concatenation of up to seven fragments,
-# skipping nil fragments
-fun send_concat(srv: *Server, a: str, b: str, c: str, d: str, e: str, f: str, g: str) {
-    val total: usize = flen(a) + flen(b) + flen(c) + flen(d) + flen(e) + flen(f) + flen(g);
-    val r: Result[*u8, str] = allocate[u8](srv.alloc, total + 1);
-    if (is_err[*u8, str](r)) { ret; }
-    val buf: *u8 = unwrap_ok[*u8, str](r);
-
-    var off: usize = 0;
-    off = fappend(buf, off, a);
-    off = fappend(buf, off, b);
-    off = fappend(buf, off, c);
-    off = fappend(buf, off, d);
-    off = fappend(buf, off, e);
-    off = fappend(buf, off, f);
-    off = fappend(buf, off, g);
-    buf[off] = 0;
-
-    transport.send_message(buf::str, srv.alloc);
-    deallocate[u8](srv.alloc, buf, total + 1);
+# a tree that is not a usable JSON-RPC envelope
+fun reply_invalid_request(srv: *Server, root: *sj.Value) {
+    send_error(srv, json.member(root, "id"), -32600, "invalid request");
 }
 
-# length of `s`, treating nil as 0
-fun flen(s: str) usize {
-    if (s == nil) { ret 0; }
-    ret str_len(s);
+# frame and send one JSON-RPC error object
+fun send_error(srv: *Server, id: *sj.Value, code: i64, message: str) {
+    var b: json.Buf = json.buf_init(srv.alloc);
+    json.buf_push(?b, "{\"jsonrpc\":\"2.0\",\"id\":");
+    json.buf_push_id(?b, id);
+    json.buf_push(?b, ",\"error\":{\"code\":");
+    json.buf_push_i64(?b, code);
+    json.buf_push(?b, ",\"message\":");
+    json.buf_push_quoted(?b, message);
+    json.buf_push(?b, "}}");
+    send_buf(srv, ?b);
 }
 
-# copy `s` into `buf` at `offset`, returning the new offset
-fun fappend(buf: *u8, offset: usize, s: str) usize {
-    if (s == nil) { ret offset; }
-    val n: usize = str_len(s);
-    if (n > 0) { mem.raw_copy((buf::usize + offset)::ptr, s::ptr, n); }
-    ret offset + n;
+# frame and send a buffer's contents, then release it
+fun send_buf(srv: *Server, b: *json.Buf) {
+    val msg: str = json.buf_str(b);
+    if (msg != nil) { transport.send_message(msg, srv.alloc); }
+    json.buf_dnit(b);
 }

--- a/src/server.mach
+++ b/src/server.mach
@@ -35,6 +35,7 @@ use json:        mls.json;
 use sj:          std.data.json;
 use jobs:        mls.jobs;
 use atomic:      std.sync.atomic;
+use exec:        std.process.exec;
 use documents:   mls.documents;
 use diagnostics: mls.diagnostics;
 use language:    mls.language;
@@ -337,6 +338,17 @@ fun handle_exit(srv: *Server) {
     if (srv.status == STATUS_SHUTTING_DOWN) { srv.exit_code = 0; }
     or { srv.exit_code = 1; }
     srv.status = STATUS_EXITED;
+    atomic.store(?srv.stop, 1);
+
+    # `exit` means terminate, and the client is entitled to keep its end of the
+    # pipe open while it waits for that. The reading thread is parked in
+    # `read(2)` on stdin and nothing this thread can do reliably wakes it -
+    # closing the descriptor under a blocked reader does not - so the orderly
+    # return through `run` is not reachable here. Ending the process is what the
+    # notification asked for; responses are written unbuffered, so nothing that
+    # was owed to the client is still pending.
+    trace.log("=== mach-lsp exiting ===\n");
+    exec.exit(srv.exit_code);
 }
 
 # register the opened document and publish its diagnostics

--- a/src/server.mach
+++ b/src/server.mach
@@ -330,7 +330,7 @@ fun handle_did_close(srv: *Server, params: *sj.Value) {
     if (doc != nil) { project.document_closed(?srv.ws, doc); }
     documents.close(?srv.docs, uri);
     diagnostics.clear(srv.alloc, uri);
-    republish_loaded(srv);
+    republish_all(srv);
     json.free_str(uri, srv.alloc);
 }
 
@@ -358,19 +358,39 @@ fun handle_feature(srv: *Server, root: *sj.Value, params: *sj.Value, which: u8) 
 
     if (uri != nil) { json.free_str(uri, srv.alloc); }
 
-    if (project.load_epoch(?srv.ws) != epoch_before || project.sema_epoch(?srv.ws) != sema_before) { republish_loaded(srv); }
+    if (project.load_epoch(?srv.ws) != epoch_before || project.sema_epoch(?srv.ws) != sema_before) { republish_all(srv); }
 }
 
-# re-publish diagnostics for every open document now governed
-# by a loaded project root. run after a feature request triggers a lazy load (#96)
-# or the first whole-closure sema (#113): the buffers under the freshly-loaded root
-# were published parse-only on open, so a load upgrades them to dep-aware
-# resolution diagnostics - including any out-of-closure import the load now flags -
-# and a completed sema further layers their type diagnostics, all without the user
-# touching the file. the publish path is load-free, so a buffer under no loaded
-# root simply re-publishes its parse-only diagnostics (unchanged), and nothing new
-# is built
-fun republish_loaded(srv: *Server) {
+# re-publish diagnostics for every open document the given root governs
+#
+# A rebuild can move diagnostics for any document mirrored into that root's
+# session - an unsaved export change in one module introduces or clears errors
+# in the modules importing it - so the whole root is republished, not just the
+# document that changed. Documents under OTHER roots are untouched: their
+# snapshots did not move, and republishing them would emit one notification per
+# open buffer per keystroke.
+#
+# A nil root is the standalone case, where `only` is the whole set.
+fun republish_root(srv: *Server, root: *project.Root, only: *documents.Document) {
+    val n: usize = documents.slot_count(?srv.docs);
+    var i: usize = 0;
+    for (i < n) {
+        val d: *documents.Document = documents.at(?srv.docs, i);
+        if (d != nil && d.in_use && d.uri != nil) {
+            if (root == nil) {
+                if (d == only) { diagnostics.publish(?srv.ws, ?srv.es, srv.alloc, d); }
+            }
+            or (project.root_covers_document(?srv.ws, root, d)) {
+                diagnostics.publish(?srv.ws, ?srv.es, srv.alloc, d);
+            }
+        }
+        i = i + 1;
+    }
+}
+
+# re-publish every open document, for the events that can move any root at once
+# (a watched-file change, a close that returns a buffer to disk authority)
+fun republish_all(srv: *Server) {
     val n: usize = documents.slot_count(?srv.docs);
     var i: usize = 0;
     for (i < n) {
@@ -404,7 +424,7 @@ fun publish_for(srv: *Server, uri: str, text: str, version: i64, is_open: bool) 
         trace.log("project: failed to mirror document overlay\n");
         ret;
     }
-    republish_loaded(srv);
+    republish_root(srv, project.root_for(?srv.ws, doc.uri), doc);
 }
 
 # send a JSON-RPC error response for a request that carries an id

--- a/src/trace.mach
+++ b/src/trace.mach
@@ -17,9 +17,14 @@ use std.types.size.usize;
 use std.types.bool.bool;
 use std.types.bool.true;
 use std.types.bool.false;
+use std.types.result.Result;
+use std.types.result.ok;
 
-use os:  std.system.os;
-use env: std.process.env;
+use os:     std.system.os;
+use env:    std.process.env;
+use chrono: std.chrono.time;
+use fmtstr: std.format;
+use writer: std.io.writer;
 
 # fixed file the trace log is appended to
 val LOG_PATH: str = "/tmp/mach-lsp.log";
@@ -74,4 +79,42 @@ pub fun log(msg: str) {
     if (len == 0) { ret; }
 
     os.write(LOG_FD::i32, msg::*u8, len);
+}
+
+# whether tracing is on, so a caller can skip building a message it would drop
+# ---
+# ret: true when MLS_TRACE is set and the log is open
+pub fun enabled() bool {
+    if (!LOG_CHECKED) {
+        LOG_CHECKED = true;
+        LOG_ENABLED = trace_enabled();
+        if (LOG_ENABLED) { LOG_FD = trace_open(); }
+    }
+    ret LOG_ENABLED && LOG_FD >= 0;
+}
+
+# monotonic nanoseconds, for span timing
+# ---
+# ret: the monotonic clock reading in nanoseconds
+pub fun now_ns() i64 {
+    ret chrono.time_unix_nsec(chrono.monotonic());
+}
+
+# writer sink appending straight to the open trace descriptor
+fun trace_sink(ctx: ptr, p: *u8, len: usize) Result[usize, str] {
+    os.write(LOG_FD::i32, p, len);
+    ret ok[usize, str](len);
+}
+
+# append one formatted line to the trace log; a no-op when tracing is off
+# ---
+# fmt: std.format hole syntax
+# va:  comptime variadic argument pack
+pub fun logf(fmt: str, va: ...) {
+    if (!enabled()) { ret; }
+    var w: writer.Writer;
+    w.ctx = nil;
+    w.f_write = trace_sink;
+    fmtstr.vformat(?w, fmt, va...);
+    os.write(LOG_FD::i32, "\n"::*u8, 1);
 }

--- a/src/transport.mach
+++ b/src/transport.mach
@@ -1,9 +1,9 @@
-# LSP base-protocol framing over stdin/stdout
+# bounded LSP base-protocol framing over stdin/stdout
 #
-# every message is a set of `Header: value\r\n` lines, a blank line, then a
-# body of exactly `Content-Length` bytes. this module reads one framed message
-# at a time from stdin and writes one framed message to stdout. it owns no
-# protocol semantics - the body is opaque JSON the server layer interprets.
+# reads one `Content-Length` frame at a time, distinguishes clean EOF from a
+# truncated / malformed frame and an OS error, and caps both headers and bodies
+# before allocating from attacker-controlled lengths. writes are latched: once
+# stdout fails, every later send reports false without attempting more output.
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -17,7 +17,6 @@ use std.types.result.unwrap_ok;
 
 use std.allocator.Allocator;
 use std.allocator.allocate;
-use std.allocator.reallocate;
 use std.allocator.deallocate;
 
 use os:  std.system.os;
@@ -25,230 +24,270 @@ use mem: std.memory;
 
 use trace: mls.trace;
 
-# one received LSP message. `body` is the owned, nil-terminated JSON
-# payload of length `body_len`; free it with `message_free`
-# ---
-# body:     owned nil-terminated JSON body
-# body_len: length of the body in bytes (excluding the terminator)
+# one received message. `body` is owned and nil-terminated
 pub rec Message {
     body:     str;
     body_len: usize;
 }
 
-# the only response header the server emits
-val HEADER_PREFIX: str = "Content-Length: ";
-# the header/body separator
-val CRLF_CRLF: str = "\r\n\r\n";
-# starting capacity for the header accumulation buffer
-val HEADER_BUF_INITIAL: usize = 256;
-# lowercased Content-Length header name for case-insensitive matching
-val CL_KEY: str = "content-length";
+# read_message outcomes
+pub def ReadStatus: u8;
+pub val READ_OK:        ReadStatus = 0;
+pub val READ_EOF:       ReadStatus = 1;
+pub val READ_MALFORMED: ReadStatus = 2;
+pub val READ_ERROR:     ReadStatus = 3;
 
-# release a message's owned body
+# protocol resource bounds. 8 KiB is ample for LSP headers; 16 MiB admits large
+# full-text didOpen/didChange messages without allowing an advertised length to
+# drive an unbounded allocation
+val HEADER_MAX: usize = 8 * 1024;
+val BODY_MAX:   usize = 16 * 1024 * 1024;
+
+val HEADER_PREFIX: str = "Content-Length: ";
+val CRLF_CRLF:     str = "\r\n\r\n";
+val CL_KEY:        str = "content-length";
+
+# output has one process-wide destination (stdout). latching its first failure
+# prevents later handlers from silently pretending that a response was sent
+var WRITE_FAILED: bool = false;
+
+# release a message's owned body and zero it
 # ---
-# msg:   message whose body is freed and zeroed
-# alloc: allocator the body was read with
+# msg:   message returned by read_message
+# alloc: allocator passed to read_message
 pub fun message_free(msg: *Message, alloc: *Allocator) {
-    if (msg.body != nil && msg.body_len > 0) {
-        deallocate[u8](alloc, msg.body::*u8, msg.body_len + 1);
-    }
+    if (msg.body != nil) { deallocate[u8](alloc, msg.body::*u8, msg.body_len + 1); }
     msg.body = nil;
     msg.body_len = 0;
 }
 
-# read one framed message from stdin into `msg`
+# whether any response write has failed during this process
 # ---
-# msg:   message to populate; its body is owned by `alloc` on success
-# alloc: allocator for the header scratch buffer and the body
-# ret:   true on a complete message, false on EOF or a malformed frame
-pub fun read_message(msg: *Message, alloc: *Allocator) bool {
+# ret: true after the first failed allocation or stdout write
+pub fun write_failed() bool {
+    ret WRITE_FAILED;
+}
+
+# read one bounded frame from stdin
+# ---
+# msg:   output message, owned on READ_OK and zeroed otherwise
+# alloc: allocator for bounded header and body storage
+# ret:   READ_OK, clean READ_EOF, READ_MALFORMED, or READ_ERROR
+pub fun read_message(msg: *Message, alloc: *Allocator) ReadStatus {
     msg.body = nil;
     msg.body_len = 0;
 
-    var hdr_cap: usize = HEADER_BUF_INITIAL;
-    val hr: Result[*u8, str] = allocate[u8](alloc, hdr_cap);
-    if (is_err[*u8, str](hr)) { ret false; }
-    var hdr_buf: *u8 = unwrap_ok[*u8, str](hr);
+    val hr: Result[*u8, str] = allocate[u8](alloc, HEADER_MAX);
+    if (is_err[*u8, str](hr)) { ret READ_ERROR; }
+    val header: *u8 = unwrap_ok[*u8, str](hr);
 
-    var hdr_len: usize = 0;
-    var done: bool = false;
-    for (!done) {
+    var header_len: usize = 0;
+    for (true) {
+        if (header_len >= HEADER_MAX) {
+            deallocate[u8](alloc, header, HEADER_MAX);
+            ret READ_MALFORMED;
+        }
         var c: u8;
-        val n: i64 = os.read(os.STDIN_FD, ?c, 1);
-        if (n <= 0) {
-            deallocate[u8](alloc, hdr_buf, hdr_cap);
-            ret false;
+        val n: i64 = read_retry(?c, 1);
+        if (n == 0) {
+            deallocate[u8](alloc, header, HEADER_MAX);
+            if (header_len == 0) { ret READ_EOF; }
+            ret READ_MALFORMED;
         }
-        hdr_buf[hdr_len] = c;
-        hdr_len = hdr_len + 1;
+        if (n < 0) {
+            deallocate[u8](alloc, header, HEADER_MAX);
+            ret READ_ERROR;
+        }
+        header[header_len] = c;
+        header_len = header_len + 1;
 
-        if (hdr_len >= hdr_cap) {
-            val new_cap: usize = hdr_cap * 2;
-            val gr: Result[*u8, str] = reallocate[u8](alloc, hdr_buf, hdr_cap, new_cap);
-            if (is_err[*u8, str](gr)) {
-                deallocate[u8](alloc, hdr_buf, hdr_cap);
-                ret false;
-            }
-            hdr_buf = unwrap_ok[*u8, str](gr);
-            hdr_cap = new_cap;
-        }
-
-        if (hdr_len >= 4 &&
-            hdr_buf[hdr_len - 4] == '\r' && hdr_buf[hdr_len - 3] == '\n' &&
-            hdr_buf[hdr_len - 2] == '\r' && hdr_buf[hdr_len - 1] == '\n') {
-            done = true;
-        }
+        if (header_len >= 4
+            && header[header_len - 4] == '\r' && header[header_len - 3] == '\n'
+            && header[header_len - 2] == '\r' && header[header_len - 1] == '\n') { brk; }
     }
 
-    val content_length: i64 = parse_content_length(hdr_buf, hdr_len);
-    deallocate[u8](alloc, hdr_buf, hdr_cap);
-    if (content_length <= 0) {
-        trace.log("transport: missing or invalid Content-Length\n");
-        ret false;
+    val body_len_r: i64 = parse_content_length(header, header_len);
+    deallocate[u8](alloc, header, HEADER_MAX);
+    if (body_len_r <= 0 || body_len_r::usize > BODY_MAX) {
+        trace.log("transport: missing, invalid, or oversized Content-Length\n");
+        ret READ_MALFORMED;
     }
-    val body_len: usize = content_length::usize;
+    val body_len: usize = body_len_r::usize;
 
+    # body_len is capped below usize max, so the terminator addition cannot wrap
     val br: Result[*u8, str] = allocate[u8](alloc, body_len + 1);
-    if (is_err[*u8, str](br)) { ret false; }
-    val body_buf: *u8 = unwrap_ok[*u8, str](br);
+    if (is_err[*u8, str](br)) { ret READ_ERROR; }
+    val body: *u8 = unwrap_ok[*u8, str](br);
 
     var got: usize = 0;
     for (got < body_len) {
-        val n: i64 = os.read(os.STDIN_FD, (body_buf::usize + got)::*u8, body_len - got);
-        if (n <= 0) {
-            deallocate[u8](alloc, body_buf, body_len + 1);
-            ret false;
+        val n: i64 = read_retry((body::usize + got)::*u8, body_len - got);
+        if (n == 0) {
+            deallocate[u8](alloc, body, body_len + 1);
+            ret READ_MALFORMED;
+        }
+        if (n < 0) {
+            deallocate[u8](alloc, body, body_len + 1);
+            ret READ_ERROR;
         }
         got = got + n::usize;
     }
-    body_buf[body_len] = 0;
-
-    msg.body = body_buf::str;
+    body[body_len] = 0;
+    msg.body = body::str;
     msg.body_len = body_len;
-    ret true;
+    ret READ_OK;
 }
 
-# write `body` as one framed message to stdout
+# frame and write `body`
 # ---
-# body:  nil-terminated JSON body to send; nil / empty is a no-op
-# alloc: allocator for the send buffer
-pub fun send_message(body: str, alloc: *Allocator) {
-    if (body == nil) { ret; }
+# body:  nil-terminated JSON payload
+# alloc: allocator for the combined header/body frame
+# ret:   true when fully written, false on allocation or stdout failure
+pub fun send_message(body: str, alloc: *Allocator) bool {
+    if (WRITE_FAILED) { ret false; }
+    if (body == nil || str_len(body) == 0) { ret true; }
     val body_len: usize = str_len(body);
-    if (body_len == 0) { ret; }
 
     var digits: [20]u8;
     val digit_len: usize = usize_to_buf(?digits[0], 20, body_len);
     val digit_start: usize = 20 - digit_len;
-
     val prefix_len: usize = str_len(HEADER_PREFIX);
     val sep_len: usize = str_len(CRLF_CRLF);
-    val total: usize = prefix_len + digit_len + sep_len + body_len;
+    # the response body is server-owned and bounded by available address space;
+    # guard the two fixed-size additions before allocating the frame
+    val fixed: usize = prefix_len + digit_len + sep_len;
+    val usize_max: usize = ~(0::usize);
+    if (body_len > usize_max - fixed) { WRITE_FAILED = true; ret false; }
+    val total: usize = fixed + body_len;
 
     val r: Result[*u8, str] = allocate[u8](alloc, total);
-    if (is_err[*u8, str](r)) { ret; }
+    if (is_err[*u8, str](r)) { WRITE_FAILED = true; ret false; }
     val buf: *u8 = unwrap_ok[*u8, str](r);
-
     var off: usize = 0;
-    mem.raw_copy((buf::usize + off)::ptr, HEADER_PREFIX::ptr, prefix_len);
-    off = off + prefix_len;
-    mem.raw_copy((buf::usize + off)::ptr, (?digits[digit_start])::ptr, digit_len);
-    off = off + digit_len;
-    mem.raw_copy((buf::usize + off)::ptr, CRLF_CRLF::ptr, sep_len);
-    off = off + sep_len;
+    mem.raw_copy((buf::usize + off)::ptr, HEADER_PREFIX::ptr, prefix_len); off = off + prefix_len;
+    mem.raw_copy((buf::usize + off)::ptr, (?digits[digit_start])::ptr, digit_len); off = off + digit_len;
+    mem.raw_copy((buf::usize + off)::ptr, CRLF_CRLF::ptr, sep_len); off = off + sep_len;
     mem.raw_copy((buf::usize + off)::ptr, body::ptr, body_len);
 
-    trace.log("send: ");
-    trace.log(body);
-    trace.log("\n");
-
-    write_all(buf, total);
+    trace.log("send: "); trace.log(body); trace.log("\n");
+    val ok: bool = write_all(buf, total);
     deallocate[u8](alloc, buf, total);
+    if (!ok) { WRITE_FAILED = true; }
+    ret ok;
 }
 
-# write exactly `len` bytes of `buf` to stdout, retrying short writes
-fun write_all(buf: *u8, len: usize) {
+# write exactly `len`, accepting short writes. os.write retries EINTR on every
+# supported backend; a zero/negative result is a terminal output failure
+fun write_all(buf: *u8, len: usize) bool {
     var off: usize = 0;
     for (off < len) {
-        val n: i64 = os.write(os.STDOUT_FD, (buf::usize + off)::*u8, len - off);
-        if (n <= 0) { ret; }
+        val n: i64 = write_retry((buf::usize + off)::*u8, len - off);
+        if (n <= 0) { ret false; }
         off = off + n::usize;
     }
+    ret true;
 }
 
-# scan accumulated header bytes for a Content-Length value
-# (case-insensitive key), or -1 when absent / unparseable
-fun parse_content_length(hdr: *u8, hdr_len: usize) i64 {
-    val cl_len: usize = str_len(CL_KEY);
+# std.system.os retries EINTR internally with a bounded guard. If signals exhaust
+# that guard, retry the operation rather than turning an interruption into an LSP
+# transport failure
+fun read_retry(buf: *u8, len: usize) i64 {
+    for (true) {
+        val n: i64 = os.read(os.STDIN_FD, buf, len);
+        if (n != os.EINTR) { ret n; }
+    }
+    ret os.EINTR;
+}
+
+fun write_retry(buf: *u8, len: usize) i64 {
+    for (true) {
+        val n: i64 = os.write(os.STDOUT_FD, buf, len);
+        if (n != os.EINTR) { ret n; }
+    }
+    ret os.EINTR;
+}
+
+# parse exactly one decimal Content-Length, rejecting duplicate fields, trailing
+# junk, values outside BODY_MAX, and overflow before multiplication
+fun parse_content_length(header: *u8, header_len: usize) i64 {
+    val key_len: usize = str_len(CL_KEY);
+    var found: bool = false;
+    var result: usize = 0;
     var line_start: usize = 0;
     var i: usize = 0;
-    for (i <= hdr_len) {
-        val at_end: bool = (i == hdr_len);
-        val is_nl: bool = (!at_end && hdr[i] == '\n');
-        if (at_end || is_nl) {
+    for (i <= header_len) {
+        val at_end: bool = i == header_len;
+        val at_nl: bool = !at_end && header[i] == '\n';
+        if (at_end || at_nl) {
             var line_end: usize = i;
-            if (line_end > line_start && hdr[line_end - 1] == '\r') { line_end = line_end - 1; }
-
-            var colon: i64 = -1;
+            if (line_end > line_start && header[line_end - 1] == '\r') { line_end = line_end - 1; }
+            var colon: usize = line_end;
             var j: usize = line_start;
             for (j < line_end) {
-                if (hdr[j] == ':') { colon = j::i64; brk; }
+                if (header[j] == ':') { colon = j; brk; }
                 j = j + 1;
             }
-            if (colon >= 0) {
-                val key_len: usize = (colon::usize) - line_start;
-                if (key_len == cl_len) {
-                    var match: bool = true;
-                    var k: usize = 0;
-                    for (k < key_len) {
-                        var ch: u8 = hdr[line_start + k];
-                        if (ch >= 'A' && ch <= 'Z') { ch = ch + 32; }
-                        if (ch != CL_KEY[k]) { match = false; brk; }
-                        k = k + 1;
-                    }
-                    if (match) {
-                        var vs: usize = (colon::usize) + 1;
-                        for (vs < line_end) {
-                            val c: u8 = hdr[vs];
-                            if (c != ' ' && c != '\t') { brk; }
-                            vs = vs + 1;
-                        }
-                        var result: i64 = 0;
-                        var valid: bool = false;
-                        var d: usize = vs;
-                        for (d < line_end) {
-                            val digit: u8 = hdr[d];
-                            if (digit >= '0' && digit <= '9') {
-                                result = result * 10 + ((digit - '0')::i64);
-                                valid = true;
-                            }
-                            or { brk; }
-                            d = d + 1;
-                        }
-                        if (valid) { ret result; }
-                    }
+            if (colon < line_end && colon - line_start == key_len && key_equals(header, line_start, key_len)) {
+                if (found) { ret -1; }
+                found = true;
+                var d: usize = colon + 1;
+                for (d < line_end && (header[d] == ' ' || header[d] == '\t')) { d = d + 1; }
+                if (d == line_end) { ret -1; }
+                for (d < line_end) {
+                    val digit: u8 = header[d];
+                    if (digit < '0' || digit > '9') { ret -1; }
+                    val value: usize = (digit - '0')::usize;
+                    # cap while parsing: this bounds arithmetic as well as allocation
+                    if (result > (BODY_MAX - value) / 10) { ret -1; }
+                    result = result * 10 + value;
+                    d = d + 1;
                 }
             }
             line_start = i + 1;
         }
         i = i + 1;
     }
-    ret -1;
+    if (!found || result == 0 || result > BODY_MAX) { ret -1; }
+    ret result::i64;
 }
 
-# write `value` in base 10 right-aligned into the tail of `buf`,
-# returning the number of digits written
-fun usize_to_buf(buf: *u8, buf_cap: usize, value: usize) usize {
-    if (value == 0) {
-        buf[buf_cap - 1] = '0';
-        ret 1;
+fun key_equals(header: *u8, start: usize, len: usize) bool {
+    var i: usize = 0;
+    for (i < len) {
+        var c: u8 = header[start + i];
+        if (c >= 'A' && c <= 'Z') { c = c + 32; }
+        if (c != CL_KEY[i]) { ret false; }
+        i = i + 1;
     }
+    ret true;
+}
+
+fun usize_to_buf(buf: *u8, cap: usize, value: usize) usize {
+    if (value == 0) { buf[cap - 1] = '0'; ret 1; }
     var v: usize = value;
-    var pos: usize = buf_cap;
+    var pos: usize = cap;
     for (v > 0 && pos > 0) {
         pos = pos - 1;
         buf[pos] = ('0' + (v % 10))::u8;
         v = v / 10;
     }
-    ret buf_cap - pos;
+    ret cap - pos;
+}
+
+test "mls.transport.parse_content_length:bounded_strict_decimal" {
+    val valid: str = "content-type: application/vscode-jsonrpc; charset=utf-8\r\nCONTENT-LENGTH: 42\r\n\r\n";
+    if (parse_content_length(valid::*u8, str_len(valid)) != 42) { ret 1; }
+
+    val duplicate: str = "Content-Length: 4\r\ncontent-length: 4\r\n\r\n";
+    if (parse_content_length(duplicate::*u8, str_len(duplicate)) >= 0) { ret 1; }
+
+    val trailing: str = "Content-Length: 12junk\r\n\r\n";
+    if (parse_content_length(trailing::*u8, str_len(trailing)) >= 0) { ret 1; }
+
+    val oversized: str = "Content-Length: 16777217\r\n\r\n";
+    if (parse_content_length(oversized::*u8, str_len(oversized)) >= 0) { ret 1; }
+
+    val overflow: str = "Content-Length: 999999999999999999999999999999999999\r\n\r\n";
+    if (parse_content_length(overflow::*u8, str_len(overflow)) >= 0) { ret 1; }
+    ret 0;
 }

--- a/src/transport.mach
+++ b/src/transport.mach
@@ -275,8 +275,11 @@ fun usize_to_buf(buf: *u8, cap: usize, value: usize) usize {
 }
 
 test "mls.transport.parse_content_length:bounded_strict_decimal" {
-    val valid: str = "content-type: application/vscode-jsonrpc; charset=utf-8\r\nCONTENT-LENGTH: 42\r\n\r\n";
+    val valid: str = "content-type: application/vscode-jsonrpc; charset=utf-8\r\nCoNtEnT-LeNgTh:\t 42\r\n\r\n";
     if (parse_content_length(valid::*u8, str_len(valid)) != 42) { ret 1; }
+
+    val boundary: str = "Content-Length: 16777216\r\n\r\n";
+    if (parse_content_length(boundary::*u8, str_len(boundary)) != BODY_MAX::i64) { ret 1; }
 
     val duplicate: str = "Content-Length: 4\r\ncontent-length: 4\r\n\r\n";
     if (parse_content_length(duplicate::*u8, str_len(duplicate)) >= 0) { ret 1; }

--- a/src/transport.mach
+++ b/src/transport.mach
@@ -247,7 +247,7 @@ fun usize_to_buf(buf: *u8, buf_cap: usize, value: usize) usize {
     var pos: usize = buf_cap;
     for (v > 0 && pos > 0) {
         pos = pos - 1;
-        buf[pos] = ('0' + (v % 10))::u8;
+        buf[pos] = ('0'::usize + (v % 10))::u8;
         v = v / 10;
     }
     ret buf_cap - pos;

--- a/test/lsp_protocol.py
+++ b/test/lsp_protocol.py
@@ -464,8 +464,7 @@ def main() -> int:
         closed_stdout_status = probe_closed_stdout(server, args.timeout, True)
         suppressed_status = probe_closed_stdout(server, args.timeout, False)
         require(suppressed_status == 1, f"suppressed SIGPIPE: expected exit 1, got {suppressed_status}")
-        if os.name != "posix" or closed_stdout_status != -signal.SIGPIPE:
-            require(closed_stdout_status == 1, f"closed stdout reader: expected exit 1, got {closed_stdout_status}")
+        require(closed_stdout_status == 1, f"closed stdout reader: expected exit 1, got {closed_stdout_status}")
     except Exception as error:
         print(f"protocol smoke: FAIL: {error}", file=sys.stderr)
         return 1
@@ -473,10 +472,7 @@ def main() -> int:
     print("  clean EOF after shutdown: exit 0")
     print("  malformed/oversized frames: 8 rejected with exit 1")
     print("  closed stdout reader with inherited SIG_IGN: exit 1")
-    if os.name == "posix" and closed_stdout_status == -signal.SIGPIPE:
-        print("  closed stdout reader: SIGPIPE (blocked by mach-std#468)")
-    else:
-        print("  closed stdout reader: exit 1")
+    print("  closed stdout reader: exit 1")
     for label, duration in timings:
         print(f"  {label}: {duration:.3f}s")
     return 0

--- a/test/lsp_protocol.py
+++ b/test/lsp_protocol.py
@@ -7,6 +7,7 @@ import argparse
 import json
 import os
 import queue
+import signal
 import subprocess
 import sys
 import tempfile
@@ -14,6 +15,9 @@ import threading
 import time
 from pathlib import Path
 from typing import Any, Callable
+
+HEADER_MAX = 8 * 1024
+BODY_MAX = 16 * 1024 * 1024
 
 
 class ProtocolError(RuntimeError):
@@ -155,11 +159,12 @@ class LspSession:
             f"diagnostics for {uri}",
         )
 
-    def finish(self) -> tuple[int, float, int]:
+    def finish(self, send_exit: bool = True) -> tuple[int, float, int]:
         """Perform shutdown/exit and return process telemetry."""
         response = self.request("shutdown")
         require(response.get("result", object()) is None, f"invalid shutdown response: {response!r}")
-        self.notify("exit")
+        if send_exit:
+            self.notify("exit")
         self.proc.stdin.close()
         try:
             code = self.proc.wait(timeout=self.timeout)
@@ -362,6 +367,84 @@ def run_smoke(server: Path, timeout: float) -> tuple[tuple[int, float, int], lis
                 session.abort()
 
 
+def run_bad_frame(server: Path, frame: bytes, timeout: float, label: str) -> None:
+    """Require one malformed or oversized frame to terminate with status 1."""
+    with tempfile.TemporaryDirectory(prefix="mls-protocol-bad-") as directory:
+        try:
+            result = subprocess.run(
+                [str(server)],
+                cwd=directory,
+                input=frame,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as error:
+            raise ProtocolError(f"{label}: server did not terminate") from error
+    require(result.returncode == 1, f"{label}: expected exit 1, got {result.returncode}")
+    require(result.stdout == b"", f"{label}: server emitted a partial response")
+
+
+def run_clean_eof(server: Path, timeout: float) -> None:
+    """A clean EOF after shutdown is not a malformed-frame failure."""
+    with tempfile.TemporaryDirectory(prefix="mls-protocol-eof-") as directory:
+        root = Path(directory).resolve()
+        session = LspSession(server, root, timeout)
+        finished = False
+        try:
+            session.request("initialize", {"rootUri": root.as_uri(), "capabilities": {}})
+            exit_code, _, _ = session.finish(send_exit=False)
+            require(exit_code == 0, f"clean EOF after shutdown exited {exit_code}")
+            finished = True
+        finally:
+            if not finished:
+                session.abort()
+
+
+def run_transport_regressions(server: Path, timeout: float) -> None:
+    """Exercise malformed/truncated and resource-bounded input framing."""
+    cases = (
+        (b"X-Header: value\r\n\r\n", "missing Content-Length"),
+        (b"Content-Length: 12junk\r\n\r\n", "malformed Content-Length"),
+        (b"Content-Length: 4\r\nContent-Length: 4\r\n\r\nnull", "duplicate Content-Length"),
+        (b"Content-Length: 20\r\n\r\n{}", "truncated body"),
+        (f"Content-Length: {BODY_MAX + 1}\r\n\r\n".encode(), "oversized body"),
+        (b"Content-Length: 999999999999999999999999999999999999\r\n\r\n", "overflowing length"),
+        (b"X-Fill: " + (b"x" * HEADER_MAX), "oversized header"),
+    )
+    for frame, label in cases:
+        run_bad_frame(server, frame, timeout, label)
+
+
+def probe_closed_stdout(server: Path, timeout: float, restore_signals: bool) -> int:
+    """Close the client read end, trigger output, and return the process status."""
+    with tempfile.TemporaryDirectory(prefix="mls-protocol-pipe-") as directory:
+        read_fd, write_fd = os.pipe()
+        proc = subprocess.Popen(
+            [str(server)],
+            cwd=directory,
+            stdin=subprocess.PIPE,
+            stdout=write_fd,
+            stderr=subprocess.PIPE,
+            close_fds=True,
+            restore_signals=restore_signals,
+        )
+        os.close(write_fd)
+        os.close(read_fd)
+        assert proc.stdin is not None
+        payload = json.dumps({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}).encode()
+        try:
+            proc.stdin.write(f"Content-Length: {len(payload)}\r\n\r\n".encode() + payload)
+            proc.stdin.flush()
+            proc.stdin.close()
+            return proc.wait(timeout=timeout)
+        except subprocess.TimeoutExpired as error:
+            proc.kill()
+            proc.wait()
+            raise ProtocolError("closed stdout reader: server did not terminate") from error
+
+
 def main() -> int:
     """Run the suite and print request timing plus process-exit telemetry."""
     parser = argparse.ArgumentParser(description=__doc__)
@@ -375,10 +458,24 @@ def main() -> int:
         parser.error("--timeout must be positive")
     try:
         (exit_code, elapsed, message_count), timings = run_smoke(server, args.timeout)
+        run_clean_eof(server, args.timeout)
+        run_transport_regressions(server, args.timeout)
+        closed_stdout_status = probe_closed_stdout(server, args.timeout, True)
+        suppressed_status = probe_closed_stdout(server, args.timeout, False)
+        require(suppressed_status == 1, f"suppressed SIGPIPE: expected exit 1, got {suppressed_status}")
+        if os.name != "posix" or closed_stdout_status != -signal.SIGPIPE:
+            require(closed_stdout_status == 1, f"closed stdout reader: expected exit 1, got {closed_stdout_status}")
     except Exception as error:
         print(f"protocol smoke: FAIL: {error}", file=sys.stderr)
         return 1
     print(f"protocol smoke: PASS ({message_count} messages, exit {exit_code}, {elapsed:.3f}s)")
+    print("  clean EOF after shutdown: exit 0")
+    print("  malformed/oversized frames: 7 rejected with exit 1")
+    print("  closed stdout reader with inherited SIG_IGN: exit 1")
+    if os.name == "posix" and closed_stdout_status == -signal.SIGPIPE:
+        print("  closed stdout reader: SIGPIPE (blocked by mach-std#468)")
+    else:
+        print("  closed stdout reader: exit 1")
     for label, duration in timings:
         print(f"  {label}: {duration:.3f}s")
     return 0

--- a/test/lsp_protocol.py
+++ b/test/lsp_protocol.py
@@ -121,6 +121,11 @@ class LspSession:
             raise ProtocolError(f"{method} returned {response['error']!r}")
         return response
 
+    def respond_error(self, request: dict[str, Any], code: int, message: str) -> None:
+        """Reject one server-initiated request."""
+        self._send({"jsonrpc": "2.0", "id": request.get("id"),
+                    "error": {"code": code, "message": message}})
+
     def wait_for(
         self,
         predicate: Callable[[dict[str, Any]], bool],
@@ -215,11 +220,13 @@ def assert_range(value: Any, label: str) -> None:
     assert_position(value.get("end"), f"{label}.end")
 
 
-def assert_diagnostics(message: dict[str, Any], nonempty: bool) -> None:
+def assert_diagnostics(message: dict[str, Any], nonempty: bool, version: int | None = None) -> None:
     """Check publishDiagnostics and the shape of every entry."""
     params = message.get("params")
     require(isinstance(params, dict), "diagnostics params are missing")
     diagnostics = params.get("diagnostics")
+    require(params.get("version") == version if version is not None else "version" not in params,
+            f"unexpected diagnostics version: {params.get('version')!r}")
     require(isinstance(diagnostics, list), "diagnostics is not an array")
     require(bool(diagnostics) == nonempty, f"unexpected diagnostics: {diagnostics!r}")
     for index, diagnostic in enumerate(diagnostics):
@@ -264,23 +271,39 @@ need = []
 """,
         encoding="utf-8",
     )
-    text = f"""use {project_id}.defs.answer;
+    alias = "vals" if project_id == "beta" else "rootmod"
+    import_line = (f"use {alias}: {project_id}.defs;\n"
+                   f"use {project_id}.defs.answer;\n"
+                   f"use {project_id}.defs.Box;\n"
+                   f"use {project_id}.defs.take;")
+    answer_expr = "answer"
+    text = f"""{import_line}
 
 pub fun main() i32 {{
-    ret answer;
+    var b: Box[i32];
+    b.v = {value};
+    ret take[i32](b) + {answer_expr} + {alias}.answer;
 }}
 """
     main = source / "main.mach"
     definition = source / "defs.mach"
     main.write_text(text, encoding="utf-8")
-    definition.write_text(f"pub val answer: i32 = {value};\n", encoding="utf-8")
+    definition.write_text(
+        f'''$if ($project.target.os != "linux") {{ $error("wrong selected target"); }}
+$if ($bin.name != "app") {{ $error("wrong selected artifact"); }}
+pub val answer: i32 = {value};
+pub rec Box[T] {{ v: T; }}
+pub fun take[T](b: Box[T]) i32 {{ ret 7; }}
+''',
+        encoding="utf-8",
+    )
     return main, definition, text
 
 
 def assert_definition(session: LspSession, main: Path, definition: Path, text: str) -> None:
     """Check that `answer` resolves into the expected project root."""
     lines = text.splitlines()
-    line = next(index for index, value in enumerate(lines) if "ret answer" in value)
+    line = next(index for index, value in enumerate(lines) if " + answer + " in value)
     response = session.request(
         "textDocument/definition",
         {
@@ -294,19 +317,37 @@ def assert_definition(session: LspSession, main: Path, definition: Path, text: s
     assert_range(result.get("range"), "definition.range")
 
 
+def definition(session: LspSession, path: Path, text: str, name: str) -> dict[str, Any]:
+    """Request a definition at the last occurrence of name."""
+    lines = text.splitlines()
+    line = next(index for index in range(len(lines) - 1, -1, -1) if name in lines[index])
+    response = session.request(
+        "textDocument/definition",
+        {"textDocument": {"uri": path.as_uri()},
+         "position": {"line": line, "character": lines[line].index(name) + 1}},
+    )
+    result = response.get("result")
+    require(isinstance(result, dict), f"definition for {name} is not a Location: {result!r}")
+    return result
+
+
 def run_smoke(server: Path, timeout: float) -> tuple[tuple[int, float, int], list[tuple[str, float]]]:
     """Run lifecycle, diagnostics, synchronization, and multi-root coverage."""
     with tempfile.TemporaryDirectory(prefix="mls-protocol-") as directory:
         root = Path(directory).resolve()
         alpha = write_project(root, "alpha", 11)
         beta = write_project(root, "beta", 22)
+        shared_left = write_project(root / "left", "shared", 31)
+        shared_right = write_project(root / "right", "shared", 41)
         scratch_uri = (root / "scratch.mach").as_uri()
         session = LspSession(server, root, timeout)
         finished = False
         try:
             response = session.request(
                 "initialize",
-                {"processId": os.getpid(), "rootUri": root.as_uri(), "capabilities": {}},
+                {"processId": os.getpid(), "rootUri": root.as_uri(),
+                 "capabilities": {"workspace": {"didChangeWatchedFiles": {
+                     "dynamicRegistration": True}}}},
             )
             result = response.get("result")
             require(isinstance(result, dict), f"invalid initialize result: {result!r}")
@@ -314,6 +355,11 @@ def run_smoke(server: Path, timeout: float) -> tuple[tuple[int, float, int], lis
             require(isinstance(capabilities, dict), "initialize capabilities are missing")
             require(capabilities.get("textDocumentSync") == 1, "full-text sync is not advertised")
             session.notify("initialized", {})
+            registration = session.wait_for(
+                lambda item: item.get("method") == "client/registerCapability",
+                "dynamic watcher registration",
+            )
+            session.respond_error(registration, -32601, "watch registration rejected")
 
             session.notify(
                 "textDocument/didOpen",
@@ -326,7 +372,7 @@ def run_smoke(server: Path, timeout: float) -> tuple[tuple[int, float, int], lis
                     }
                 },
             )
-            assert_diagnostics(session.diagnostics(scratch_uri), True)
+            assert_diagnostics(session.diagnostics(scratch_uri), True, 1)
             session.notify(
                 "textDocument/didChange",
                 {
@@ -334,7 +380,7 @@ def run_smoke(server: Path, timeout: float) -> tuple[tuple[int, float, int], lis
                     "contentChanges": [{"text": "pub fun fixed() i32 { ret 0; }\n"}],
                 },
             )
-            assert_diagnostics(session.diagnostics(scratch_uri), False)
+            assert_diagnostics(session.diagnostics(scratch_uri), False, 2)
             session.notify("textDocument/didClose", {"textDocument": {"uri": scratch_uri}})
             assert_diagnostics(session.diagnostics(scratch_uri), False)
 
@@ -350,13 +396,102 @@ def run_smoke(server: Path, timeout: float) -> tuple[tuple[int, float, int], lis
                         }
                     },
                 )
-                assert_diagnostics(session.diagnostics(main.as_uri()), False)
+                assert_diagnostics(session.diagnostics(main.as_uri()), False, 1)
 
             assert_definition(session, *alpha)
             assert_definition(session, *beta)
             assert_definition(session, *alpha)
+            for main, _, text in (shared_left, shared_right):
+                session.notify(
+                    "textDocument/didOpen",
+                    {"textDocument": {"uri": main.as_uri(), "languageId": "mach",
+                                      "version": 1, "text": text}},
+                )
+                assert_diagnostics(session.diagnostics(main.as_uri()), False, 1)
+            assert_definition(session, *shared_left)
+            assert_definition(session, *shared_right)
+            assert_definition(session, *shared_left)
+
+            # A rejected dynamic registration must leave manifest fingerprint
+            # fallback active: a broken manifest disables the snapshot, and a
+            # restored one is retried without a watcher notification.
+            alpha_manifest = alpha[0].parents[1] / "mach.toml"
+            manifest_text = alpha_manifest.read_text(encoding="utf-8")
+            alpha_manifest.write_text(manifest_text + "\n[broken\n", encoding="utf-8")
+            broken = session.request(
+                "textDocument/definition",
+                {"textDocument": {"uri": alpha[0].as_uri()},
+                 "position": {"line": 3, "character": 9}},
+            )
+            require(broken.get("result") is None,
+                    f"watcher rejection disabled manifest fallback: {broken!r}")
+            alpha_manifest.write_text(manifest_text, encoding="utf-8")
+            assert_definition(session, *alpha)
+
+            # An unsaved export change in one module must be visible from another
+            # open module through the retained compiler snapshot, not editor fallback.
+            alpha_main, alpha_def, alpha_text = alpha
+            defs_v1 = alpha_def.read_text(encoding="utf-8")
+            session.notify(
+                "textDocument/didOpen",
+                {"textDocument": {"uri": alpha_def.as_uri(), "languageId": "mach",
+                                  "version": 1, "text": defs_v1}},
+            )
+            session.diagnostics(alpha_def.as_uri())
+            defs_v2 = defs_v1 + "pub val live: i32 = 33;\n"
+            main_v2 = alpha_text.replace(" + answer + ", " + answer + live + ").replace(
+                "use alpha.defs.answer;", "use alpha.defs.answer;\nuse alpha.defs.live;")
+            session.notify(
+                "textDocument/didChange",
+                {"textDocument": {"uri": alpha_def.as_uri(), "version": 2},
+                 "contentChanges": [{"text": defs_v2}]},
+            )
+            session.diagnostics(alpha_def.as_uri())
+            session.notify(
+                "textDocument/didChange",
+                {"textDocument": {"uri": alpha_main.as_uri(), "version": 2},
+                 "contentChanges": [{"text": main_v2}]},
+            )
+            session.diagnostics(alpha_main.as_uri())
+            live_result = definition(session, alpha_main, main_v2, "live")
+            require(live_result.get("uri") == alpha_def.as_uri(),
+                    f"unsaved imported export did not resolve: {live_result!r}")
+
+            # Standalone buffers retain the upstream editor feature path.
+            standalone = root / "standalone.mach"
+            standalone_text = "pub val item: i32 = 1;\npub fun get() i32 { ret item; }\n"
+            session.notify(
+                "textDocument/didOpen",
+                {"textDocument": {"uri": standalone.as_uri(), "languageId": "mach",
+                                  "version": 1, "text": standalone_text}},
+            )
+            session.diagnostics(standalone.as_uri())
+            stand_def = definition(session, standalone, standalone_text, "item")
+            require(stand_def.get("uri") == standalone.as_uri(),
+                    f"standalone definition failed: {stand_def!r}")
+            symbol_response = session.request(
+                "textDocument/documentSymbol", {"textDocument": {"uri": standalone.as_uri()}},
+            )
+            require(isinstance(symbol_response.get("result"), list) and symbol_response["result"],
+                    f"standalone document symbols failed: {symbol_response!r}")
+            completion = session.request(
+                "textDocument/completion",
+                {"textDocument": {"uri": standalone.as_uri()},
+                 "position": {"line": 1, "character": 30}},
+            )
+            completion_result = completion.get("result")
+            require(isinstance(completion_result, dict)
+                    and isinstance(completion_result.get("items"), list)
+                    and completion_result["items"],
+                    f"standalone completion failed: {completion!r}")
+            session.notify("textDocument/didClose", {"textDocument": {"uri": standalone.as_uri()}})
+            assert_diagnostics(session.diagnostics(standalone.as_uri()), False)
+
             for main, _, _ in (alpha, beta):
                 session.notify("textDocument/didClose", {"textDocument": {"uri": main.as_uri()}})
+            for main, _, _ in (shared_left, shared_right):
+                session.notify("textDocument/didClose", {"textDocument": {"uri": main.as_uri()}})
+            session.notify("textDocument/didClose", {"textDocument": {"uri": alpha_def.as_uri()}})
 
             telemetry = session.finish()
             finished = True

--- a/test/lsp_protocol.py
+++ b/test/lsp_protocol.py
@@ -172,6 +172,35 @@ class LspSession:
             f"diagnostics for {uri}",
         )
 
+    def quiet_diagnostics(self, settle: float = 0.4) -> list[dict[str, Any]]:
+        """Return any diagnostics published since the last wait.
+
+        Diagnostics belong to document state, so a feature request must not
+        produce one. Anything a request republished is already in `pending`
+        (the request's own reply drained the inbox past it); `settle` also
+        catches a publish still in flight behind that reply.
+        """
+        found = [m for m in self.pending
+                 if m.get("method") == "textDocument/publishDiagnostics"]
+        self.pending = [m for m in self.pending
+                        if m.get("method") != "textDocument/publishDiagnostics"]
+        deadline = time.monotonic() + settle
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return found
+            try:
+                item = self.inbox.get(timeout=remaining)
+            except queue.Empty:
+                return found
+            if item is None or isinstance(item, BaseException):
+                return found
+            self.message_count += 1
+            if item.get("method") == "textDocument/publishDiagnostics":
+                found.append(item)
+            else:
+                self.pending.append(item)
+
     def finish(self, send_exit: bool = True) -> tuple[int, float, int]:
         """Perform shutdown/exit and return process telemetry."""
         response = self.request("shutdown")
@@ -595,12 +624,19 @@ def run_smoke(server: Path, timeout: float) -> tuple[tuple[int, float, int], lis
                 {"textDocument": {"uri": alpha_main.as_uri(), "version": 2},
                  "contentChanges": [{"text": main_v2}]},
             )
-            session.diagnostics(alpha_main.as_uri(), 2)
+            # the change itself publishes every open document of the affected
+            # root at its own version: diagnostics follow document state, and
+            # the analysis they need is driven here rather than by whichever
+            # feature request happens to come next
+            assert_diagnostics(session.diagnostics(alpha_main.as_uri(), 2), False, 2)
+            assert_diagnostics(session.diagnostics(alpha_def.as_uri(), 2), False, 2)
+            session.quiet_diagnostics()
             live_result = definition(session, alpha_main, main_v2, "live")
             require(live_result.get("uri") == alpha_def.as_uri(),
                     f"unsaved imported export did not resolve: {live_result!r}")
-            assert_diagnostics(session.diagnostics(alpha_main.as_uri(), 2), False, 2)
-            assert_diagnostics(session.diagnostics(alpha_def.as_uri(), 2), False, 2)
+            republished = session.quiet_diagnostics()
+            require(not republished,
+                    f"a feature request republished diagnostics: {republished!r}")
 
             broken_text = main_v2 + "\nuse alpha.missing.nope;\n"
             session.notify(
@@ -639,9 +675,8 @@ def run_smoke(server: Path, timeout: float) -> tuple[tuple[int, float, int], lis
                 {"textDocument": {"uri": alpha_main.as_uri(), "version": 5},
                  "contentChanges": [{"text": alpha_text}]},
             )
-            session.diagnostics(alpha_main.as_uri(), 5)
-            assert_definition(session, alpha_main, alpha_def, alpha_text)
             assert_diagnostics(session.diagnostics(alpha_main.as_uri(), 5), False, 5)
+            assert_definition(session, alpha_main, alpha_def, alpha_text)
 
             # A dependency opened before its ancestor graph is loaded must still
             # enter that graph through a filesystem overlay. Current `[dep.*]`

--- a/test/lsp_protocol.py
+++ b/test/lsp_protocol.py
@@ -7,7 +7,6 @@ import argparse
 import json
 import os
 import queue
-import signal
 import subprocess
 import sys
 import tempfile

--- a/test/lsp_protocol.py
+++ b/test/lsp_protocol.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+"""Minimal live-stdio protocol smoke test for mach-lsp."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import queue
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+
+class ProtocolError(RuntimeError):
+    """Raised when the live protocol session violates an asserted contract."""
+
+
+class LspSession:
+    """Drive one language-server process using LSP stdio framing."""
+
+    def __init__(self, server: Path, cwd: Path, timeout: float) -> None:
+        env = os.environ.copy()
+        env.pop("MLS_TRACE", None)
+        self.timeout = timeout
+        self.started = time.monotonic()
+        self.proc = subprocess.Popen(
+            [str(server)],
+            cwd=cwd,
+            env=env,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        assert self.proc.stdin is not None
+        assert self.proc.stdout is not None
+        assert self.proc.stderr is not None
+        self.inbox: queue.Queue[object] = queue.Queue()
+        self.pending: list[dict[str, Any]] = []
+        self.stderr_chunks: list[bytes] = []
+        self.next_id = 1
+        self.message_count = 0
+        self.timings: list[tuple[str, float]] = []
+        self.reader = threading.Thread(target=self._read_loop, daemon=True)
+        self.stderr_reader = threading.Thread(target=self._stderr_loop, daemon=True)
+        self.reader.start()
+        self.stderr_reader.start()
+
+    def _read_loop(self) -> None:
+        try:
+            while True:
+                headers: dict[bytes, bytes] = {}
+                while True:
+                    line = self.proc.stdout.readline()
+                    if not line:
+                        return
+                    if line in (b"\r\n", b"\n"):
+                        break
+                    name, separator, value = line.partition(b":")
+                    if not separator:
+                        raise ProtocolError(f"malformed response header: {line!r}")
+                    headers[name.strip().lower()] = value.strip()
+                raw_length = headers.get(b"content-length")
+                if raw_length is None:
+                    raise ProtocolError("response has no Content-Length header")
+                length = int(raw_length)
+                body = self.proc.stdout.read(length)
+                if length <= 0 or len(body) != length:
+                    raise ProtocolError("response body length does not match Content-Length")
+                message = json.loads(body)
+                if not isinstance(message, dict):
+                    raise ProtocolError(f"JSON-RPC message is not an object: {message!r}")
+                self.inbox.put(message)
+        except BaseException as error:
+            self.inbox.put(error)
+        finally:
+            self.inbox.put(None)
+
+    def _stderr_loop(self) -> None:
+        while True:
+            chunk = self.proc.stderr.read(4096)
+            if not chunk:
+                return
+            self.stderr_chunks.append(chunk)
+
+    def _send(self, message: dict[str, Any]) -> None:
+        payload = json.dumps(message, separators=(",", ":"), ensure_ascii=False).encode()
+        frame = f"Content-Length: {len(payload)}\r\n\r\n".encode() + payload
+        try:
+            self.proc.stdin.write(frame)
+            self.proc.stdin.flush()
+        except (BrokenPipeError, OSError) as error:
+            raise ProtocolError(f"server stdin closed; stderr: {self.stderr_text()}") from error
+
+    def notify(self, method: str, params: dict[str, Any] | None = None) -> None:
+        """Send a JSON-RPC notification."""
+        message: dict[str, Any] = {"jsonrpc": "2.0", "method": method}
+        if params is not None:
+            message["params"] = params
+        self._send(message)
+
+    def request(self, method: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Send a request, await its id, and retain its latency."""
+        request_id = self.next_id
+        self.next_id += 1
+        message: dict[str, Any] = {"jsonrpc": "2.0", "id": request_id, "method": method}
+        if params is not None:
+            message["params"] = params
+        started = time.monotonic()
+        self._send(message)
+        response = self.wait_for(lambda item: item.get("id") == request_id, f"response to {method}")
+        self.timings.append((f"{method}#{request_id}", time.monotonic() - started))
+        if "error" in response:
+            raise ProtocolError(f"{method} returned {response['error']!r}")
+        return response
+
+    def wait_for(
+        self,
+        predicate: Callable[[dict[str, Any]], bool],
+        description: str,
+    ) -> dict[str, Any]:
+        """Wait for one message while retaining unrelated notifications."""
+        for index, message in enumerate(self.pending):
+            if predicate(message):
+                return self.pending.pop(index)
+        deadline = time.monotonic() + self.timeout
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise ProtocolError(f"timed out waiting for {description}; stderr: {self.stderr_text()}")
+            try:
+                item = self.inbox.get(timeout=remaining)
+            except queue.Empty as error:
+                raise ProtocolError(f"timed out waiting for {description}") from error
+            if item is None:
+                raise ProtocolError(f"server exited while waiting for {description}; stderr: {self.stderr_text()}")
+            if isinstance(item, BaseException):
+                raise ProtocolError(f"response reader failed: {item}") from item
+            assert isinstance(item, dict)
+            self.message_count += 1
+            if predicate(item):
+                return item
+            self.pending.append(item)
+
+    def diagnostics(self, uri: str) -> dict[str, Any]:
+        """Wait for the next diagnostics notification for a document."""
+        return self.wait_for(
+            lambda item: item.get("method") == "textDocument/publishDiagnostics"
+            and isinstance(item.get("params"), dict)
+            and item["params"].get("uri") == uri,
+            f"diagnostics for {uri}",
+        )
+
+    def finish(self) -> tuple[int, float, int]:
+        """Perform shutdown/exit and return process telemetry."""
+        response = self.request("shutdown")
+        require(response.get("result", object()) is None, f"invalid shutdown response: {response!r}")
+        self.notify("exit")
+        self.proc.stdin.close()
+        try:
+            code = self.proc.wait(timeout=self.timeout)
+        except subprocess.TimeoutExpired as error:
+            self.proc.kill()
+            self.proc.wait()
+            raise ProtocolError("server did not exit after shutdown") from error
+        self._join()
+        require(code == 0, f"server exited with {code}; stderr: {self.stderr_text()}")
+        return code, time.monotonic() - self.started, self.message_count
+
+    def abort(self) -> None:
+        """Stop a failed session without hiding its assertion."""
+        if self.proc.poll() is None:
+            self.proc.terminate()
+            try:
+                self.proc.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                self.proc.kill()
+                self.proc.wait()
+        self._join()
+
+    def _join(self) -> None:
+        self.reader.join(timeout=1)
+        self.stderr_reader.join(timeout=1)
+
+    def stderr_text(self) -> str:
+        """Return captured server stderr."""
+        return b"".join(self.stderr_chunks).decode(errors="replace").strip()
+
+
+def require(condition: bool, message: str) -> None:
+    """Raise a readable protocol assertion failure."""
+    if not condition:
+        raise ProtocolError(message)
+
+
+def assert_position(value: Any, label: str) -> None:
+    """Check the JSON shape of an LSP Position."""
+    require(isinstance(value, dict), f"{label} is not an object")
+    for field in ("line", "character"):
+        require(type(value.get(field)) is int and value[field] >= 0, f"{label}.{field} is invalid")
+
+
+def assert_range(value: Any, label: str) -> None:
+    """Check the JSON shape of an LSP Range."""
+    require(isinstance(value, dict), f"{label} is not an object")
+    assert_position(value.get("start"), f"{label}.start")
+    assert_position(value.get("end"), f"{label}.end")
+
+
+def assert_diagnostics(message: dict[str, Any], nonempty: bool) -> None:
+    """Check publishDiagnostics and the shape of every entry."""
+    params = message.get("params")
+    require(isinstance(params, dict), "diagnostics params are missing")
+    diagnostics = params.get("diagnostics")
+    require(isinstance(diagnostics, list), "diagnostics is not an array")
+    require(bool(diagnostics) == nonempty, f"unexpected diagnostics: {diagnostics!r}")
+    for index, diagnostic in enumerate(diagnostics):
+        label = f"diagnostics[{index}]"
+        require(isinstance(diagnostic, dict), f"{label} is not an object")
+        assert_range(diagnostic.get("range"), f"{label}.range")
+        severity = diagnostic.get("severity")
+        require(type(severity) is int and 1 <= severity <= 4, f"{label}.severity is invalid")
+        require(diagnostic.get("source") == "mach", f"{label}.source is invalid")
+        require(bool(diagnostic.get("message")), f"{label}.message is empty")
+
+
+def write_project(parent: Path, project_id: str, value: int) -> tuple[Path, Path, str]:
+    """Create a temporary dependency-free Mach project."""
+    root = parent / project_id
+    source = root / "src"
+    source.mkdir(parents=True)
+    (root / "mach.toml").write_text(
+        f"""[project]
+id = "{project_id}"
+version = "0.1.0"
+src = "src"
+out = "out/{{target.name}}/{{profile.name}}"
+
+[target.linux-x86_64]
+isa = "x86_64"
+os = "linux"
+abi = "sysv64"
+
+[profile.debug]
+opt = 0
+debug = true
+simd = "scalarize"
+
+[artifact.app]
+kind = "bin"
+entry = "main.mach"
+out = "bin/app"
+targets = ["*"]
+link = []
+need = []
+""",
+        encoding="utf-8",
+    )
+    text = f"""use {project_id}.defs.answer;
+
+pub fun main() i32 {{
+    ret answer;
+}}
+"""
+    main = source / "main.mach"
+    definition = source / "defs.mach"
+    main.write_text(text, encoding="utf-8")
+    definition.write_text(f"pub val answer: i32 = {value};\n", encoding="utf-8")
+    return main, definition, text
+
+
+def assert_definition(session: LspSession, main: Path, definition: Path, text: str) -> None:
+    """Check that `answer` resolves into the expected project root."""
+    lines = text.splitlines()
+    line = next(index for index, value in enumerate(lines) if "ret answer" in value)
+    response = session.request(
+        "textDocument/definition",
+        {
+            "textDocument": {"uri": main.as_uri()},
+            "position": {"line": line, "character": lines[line].index("answer") + 1},
+        },
+    )
+    result = response.get("result")
+    require(isinstance(result, dict), f"definition is not a Location: {result!r}")
+    require(result.get("uri") == definition.as_uri(), f"definition escaped its root: {result!r}")
+    assert_range(result.get("range"), "definition.range")
+
+
+def run_smoke(server: Path, timeout: float) -> tuple[tuple[int, float, int], list[tuple[str, float]]]:
+    """Run lifecycle, diagnostics, synchronization, and multi-root coverage."""
+    with tempfile.TemporaryDirectory(prefix="mls-protocol-") as directory:
+        root = Path(directory).resolve()
+        alpha = write_project(root, "alpha", 11)
+        beta = write_project(root, "beta", 22)
+        scratch_uri = (root / "scratch.mach").as_uri()
+        session = LspSession(server, root, timeout)
+        finished = False
+        try:
+            response = session.request(
+                "initialize",
+                {"processId": os.getpid(), "rootUri": root.as_uri(), "capabilities": {}},
+            )
+            result = response.get("result")
+            require(isinstance(result, dict), f"invalid initialize result: {result!r}")
+            capabilities = result.get("capabilities")
+            require(isinstance(capabilities, dict), "initialize capabilities are missing")
+            require(capabilities.get("textDocumentSync") == 1, "full-text sync is not advertised")
+            session.notify("initialized", {})
+
+            session.notify(
+                "textDocument/didOpen",
+                {
+                    "textDocument": {
+                        "uri": scratch_uri,
+                        "languageId": "mach",
+                        "version": 1,
+                        "text": "pub fun broken(",
+                    }
+                },
+            )
+            assert_diagnostics(session.diagnostics(scratch_uri), True)
+            session.notify(
+                "textDocument/didChange",
+                {
+                    "textDocument": {"uri": scratch_uri, "version": 2},
+                    "contentChanges": [{"text": "pub fun fixed() i32 { ret 0; }\n"}],
+                },
+            )
+            assert_diagnostics(session.diagnostics(scratch_uri), False)
+            session.notify("textDocument/didClose", {"textDocument": {"uri": scratch_uri}})
+            assert_diagnostics(session.diagnostics(scratch_uri), False)
+
+            for main, _, text in (alpha, beta):
+                session.notify(
+                    "textDocument/didOpen",
+                    {
+                        "textDocument": {
+                            "uri": main.as_uri(),
+                            "languageId": "mach",
+                            "version": 1,
+                            "text": text,
+                        }
+                    },
+                )
+                assert_diagnostics(session.diagnostics(main.as_uri()), False)
+
+            assert_definition(session, *alpha)
+            assert_definition(session, *beta)
+            assert_definition(session, *alpha)
+            for main, _, _ in (alpha, beta):
+                session.notify("textDocument/didClose", {"textDocument": {"uri": main.as_uri()}})
+
+            telemetry = session.finish()
+            finished = True
+            return telemetry, session.timings
+        finally:
+            if not finished:
+                session.abort()
+
+
+def main() -> int:
+    """Run the suite and print request timing plus process-exit telemetry."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("server", type=Path, help="path to the debug mls executable")
+    parser.add_argument("--timeout", type=float, default=30.0, help="seconds allowed per response")
+    args = parser.parse_args()
+    server = args.server.resolve()
+    if not server.is_file() or not os.access(server, os.X_OK):
+        parser.error(f"server is not executable: {server}")
+    if args.timeout <= 0:
+        parser.error("--timeout must be positive")
+    try:
+        (exit_code, elapsed, message_count), timings = run_smoke(server, args.timeout)
+    except Exception as error:
+        print(f"protocol smoke: FAIL: {error}", file=sys.stderr)
+        return 1
+    print(f"protocol smoke: PASS ({message_count} messages, exit {exit_code}, {elapsed:.3f}s)")
+    for label, duration in timings:
+        print(f"  {label}: {duration:.3f}s")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/lsp_protocol.py
+++ b/test/lsp_protocol.py
@@ -406,6 +406,7 @@ def run_transport_regressions(server: Path, timeout: float) -> None:
     """Exercise malformed/truncated and resource-bounded input framing."""
     cases = (
         (b"X-Header: value\r\n\r\n", "missing Content-Length"),
+        (b"Content-Length: 4\r\n", "truncated header"),
         (b"Content-Length: 12junk\r\n\r\n", "malformed Content-Length"),
         (b"Content-Length: 4\r\nContent-Length: 4\r\n\r\nnull", "duplicate Content-Length"),
         (b"Content-Length: 20\r\n\r\n{}", "truncated body"),
@@ -470,7 +471,7 @@ def main() -> int:
         return 1
     print(f"protocol smoke: PASS ({message_count} messages, exit {exit_code}, {elapsed:.3f}s)")
     print("  clean EOF after shutdown: exit 0")
-    print("  malformed/oversized frames: 7 rejected with exit 1")
+    print("  malformed/oversized frames: 8 rejected with exit 1")
     print("  closed stdout reader with inherited SIG_IGN: exit 1")
     if os.name == "posix" and closed_stdout_status == -signal.SIGPIPE:
         print("  closed stdout reader: SIGPIPE (blocked by mach-std#468)")

--- a/test/lsp_protocol.py
+++ b/test/lsp_protocol.py
@@ -17,6 +17,7 @@ from typing import Any, Callable
 
 HEADER_MAX = 8 * 1024
 BODY_MAX = 16 * 1024 * 1024
+ANY_VERSION = object()
 
 
 class ProtocolError(RuntimeError):
@@ -158,12 +159,16 @@ class LspSession:
                 return item
             self.pending.append(item)
 
-    def diagnostics(self, uri: str) -> dict[str, Any]:
+    def diagnostics(self, uri: str, version: object = ANY_VERSION) -> dict[str, Any]:
         """Wait for the next diagnostics notification for a document."""
         return self.wait_for(
-            lambda item: item.get("method") == "textDocument/publishDiagnostics"
-            and isinstance(item.get("params"), dict)
-            and item["params"].get("uri") == uri,
+            lambda item: (item.get("method") == "textDocument/publishDiagnostics"
+                          and isinstance(item.get("params"), dict)
+                          and item["params"].get("uri") == uri
+                          and (version is ANY_VERSION
+                               or (item["params"].get("version") == version
+                                   if version is not None
+                                   else "version" not in item["params"]))),
             f"diagnostics for {uri}",
         )
 
@@ -277,17 +282,17 @@ need = []
     )
     alias = "vals" if project_id == "beta" else "rootmod"
     import_line = (f"use {alias}: {project_id}.defs;\n"
-                   f"use {project_id}.defs.answer;\n"
+                   f"use direct: {project_id}.defs.answer;\n"
+                   f"use forwarded: {project_id}.bridge.answer;\n"
                    f"use {project_id}.defs.Box;\n"
                    f"use {project_id}.defs.take;\n"
                    f"use {project_id}.defs.watched;")
-    answer_expr = "answer"
     text = f"""{import_line}
 
 pub fun main() i32 {{
     var b: Box[i32];
     b.v = {value};
-    ret take[i32](b) + {answer_expr} + {alias}.answer + watched;
+    ret take[i32](b) + direct + {alias}.answer + forwarded + watched;
 }}
 """
     main = source / "main.mach"
@@ -303,24 +308,107 @@ pub fun take[T](b: Box[T]) i32 {{ ret 7; }}
 ''',
         encoding="utf-8",
     )
+    (source / "bridge.mach").write_text(
+        f"fwd {project_id}.defs.answer;\n", encoding="utf-8",
+    )
     return main, definition, text
+
+
+def write_vendored_project(parent: Path) -> tuple[Path, Path, str, str]:
+    """Create an app with a current-syntax vendored path dependency."""
+    root = parent / "vendor-app"
+    source = root / "src"
+    dep_root = root / "dep" / "vendorlib"
+    dep_source = dep_root / "src"
+    source.mkdir(parents=True)
+    dep_source.mkdir(parents=True)
+    (root / "mach.toml").write_text(
+        """[project]
+id = "vendorapp"
+version = "0.1.0"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+
+[target.linux]
+isa = "x86_64"
+os = "linux"
+abi = "sysv64"
+
+[profile.debug]
+opt = 0
+debug = true
+simd = "scalarize"
+
+[artifact.app]
+kind = "bin"
+entry = "main.mach"
+out = "bin/app"
+targets = ["*"]
+link = []
+need = []
+
+[dep.vendorlib]
+path = "dep/vendorlib"
+""",
+        encoding="utf-8",
+    )
+    (dep_root / "mach.toml").write_text(
+        """[project]
+id = "vendorlib"
+version = "0.1.0"
+src = "./src"
+out = "out/{target.name}/{profile.name}"
+
+[artifact.lib]
+kind = "static"
+entry = "defs.mach"
+out = "lib/vendorlib"
+targets = ["*"]
+link = []
+need = []
+""",
+        encoding="utf-8",
+    )
+    main_text = "use vendorlib.defs.live;\npub fun main() i32 { ret live::i32; }\n"
+    disk_dep_text = "pub val stable: i32 = 1;\n"
+    live_dep_text = disk_dep_text + "pub val live: i64 = 77;\n"
+    main = source / "main.mach"
+    dep = dep_source / "defs.mach"
+    main.write_text(main_text, encoding="utf-8")
+    dep.write_text(disk_dep_text, encoding="utf-8")
+    return main, dep, main_text, live_dep_text
 
 
 def assert_definition(session: LspSession, main: Path, definition: Path, text: str) -> None:
     """Check that `answer` resolves into the expected project root."""
     lines = text.splitlines()
-    line = next(index for index, value in enumerate(lines) if " + answer + " in value)
+    line = next(index for index, value in enumerate(lines) if " + direct + " in value)
     response = session.request(
         "textDocument/definition",
         {
             "textDocument": {"uri": main.as_uri()},
-            "position": {"line": line, "character": lines[line].index("answer") + 1},
+            "position": {"line": line, "character": lines[line].index("direct") + 1},
         },
     )
     result = response.get("result")
     require(isinstance(result, dict), f"definition is not a Location: {result!r}")
     require(result.get("uri") == definition.as_uri(), f"definition escaped its root: {result!r}")
     assert_range(result.get("range"), "definition.range")
+
+
+def definition_after(session: LspSession, path: Path, text: str, prefix: str) -> dict[str, Any]:
+    """Request definition of the member immediately following prefix."""
+    lines = text.splitlines()
+    line = next(i for i, value in enumerate(lines) if prefix in value and "use " not in value)
+    character = lines[line].index(prefix) + len(prefix) + 1
+    response = session.request(
+        "textDocument/definition",
+        {"textDocument": {"uri": path.as_uri()},
+         "position": {"line": line, "character": character}},
+    )
+    result = response.get("result")
+    require(isinstance(result, dict), f"definition after {prefix!r} is not a Location: {result!r}")
+    return result
 
 
 def definition(session: LspSession, path: Path, text: str, name: str) -> dict[str, Any]:
@@ -351,6 +439,7 @@ def run_smoke(server: Path, timeout: float) -> tuple[tuple[int, float, int], lis
         shared_left = write_project(root / "left", "shared", 31)
         shared_right = write_project(root / "right", "shared", 41)
         nested = write_project(alpha[0].parent / "nested", "nested", 51)
+        vendored = write_vendored_project(root)
         scratch_uri = (root / "scratch.mach").as_uri()
         session = LspSession(server, root, timeout)
         finished = False
@@ -384,7 +473,7 @@ def run_smoke(server: Path, timeout: float) -> tuple[tuple[int, float, int], lis
                     }
                 },
             )
-            assert_diagnostics(session.diagnostics(scratch_uri), True, 1)
+            assert_diagnostics(session.diagnostics(scratch_uri, 1), True, 1)
             session.notify(
                 "textDocument/didChange",
                 {
@@ -392,9 +481,9 @@ def run_smoke(server: Path, timeout: float) -> tuple[tuple[int, float, int], lis
                     "contentChanges": [{"text": "pub fun fixed() i32 { ret 0; }\n"}],
                 },
             )
-            assert_diagnostics(session.diagnostics(scratch_uri), False, 2)
+            assert_diagnostics(session.diagnostics(scratch_uri, 2), False, 2)
             session.notify("textDocument/didClose", {"textDocument": {"uri": scratch_uri}})
-            assert_diagnostics(session.diagnostics(scratch_uri), False)
+            assert_diagnostics(session.diagnostics(scratch_uri, None), False)
 
             for main, _, text in (alpha, beta):
                 session.notify(
@@ -408,9 +497,32 @@ def run_smoke(server: Path, timeout: float) -> tuple[tuple[int, float, int], lis
                         }
                     },
                 )
-                assert_diagnostics(session.diagnostics(main.as_uri()), False, 1)
+                assert_diagnostics(session.diagnostics(main.as_uri(), 1), False, 1)
+
+            # documentSymbol is syntax-only: it must succeed without materializing
+            # a compiler root, even while that root's manifest cannot load.
+            alpha_manifest = alpha[0].parents[1] / "mach.toml"
+            alpha_manifest_text = alpha_manifest.read_text(encoding="utf-8")
+            alpha_manifest.write_text(alpha_manifest_text + "\n[broken\n", encoding="utf-8")
+            started = time.monotonic()
+            symbols = session.request(
+                "textDocument/documentSymbol",
+                {"textDocument": {"uri": alpha[0].as_uri()}},
+            )
+            require(time.monotonic() - started < 1.0,
+                    "syntax-only documentSymbol blocked on project analysis")
+            require(isinstance(symbols.get("result"), list) and symbols["result"],
+                    f"documentSymbol depended on project loading: {symbols!r}")
+            alpha_manifest.write_text(alpha_manifest_text, encoding="utf-8")
 
             assert_definition(session, *alpha)
+            for result in (
+                definition(session, alpha[0], alpha[2], "direct"),
+                definition(session, alpha[0], alpha[2], "forwarded"),
+                definition_after(session, alpha[0], alpha[2], "rootmod."),
+            ):
+                require(result.get("uri") == alpha[1].as_uri(),
+                        f"alias/re-export definition missed canonical declaration: {result!r}")
             assert_definition(session, *beta)
             assert_definition(session, *alpha)
             session.notify(
@@ -418,7 +530,7 @@ def run_smoke(server: Path, timeout: float) -> tuple[tuple[int, float, int], lis
                 {"textDocument": {"uri": nested[0].as_uri(), "languageId": "mach",
                                   "version": 1, "text": nested[2]}},
             )
-            assert_diagnostics(session.diagnostics(nested[0].as_uri()), False, 1)
+            assert_diagnostics(session.diagnostics(nested[0].as_uri(), 1), False, 1)
             assert_definition(session, *nested)
             assert_definition(session, *alpha)
             for main, _, text in (shared_left, shared_right):
@@ -427,7 +539,7 @@ def run_smoke(server: Path, timeout: float) -> tuple[tuple[int, float, int], lis
                     {"textDocument": {"uri": main.as_uri(), "languageId": "mach",
                                       "version": 1, "text": text}},
                 )
-                assert_diagnostics(session.diagnostics(main.as_uri()), False, 1)
+                assert_diagnostics(session.diagnostics(main.as_uri(), 1), False, 1)
             assert_definition(session, *shared_left)
             assert_definition(session, *shared_right)
             assert_definition(session, *shared_left)
@@ -437,7 +549,7 @@ def run_smoke(server: Path, timeout: float) -> tuple[tuple[int, float, int], lis
                 {"textDocument": {"uri": shared_left[0].as_uri(), "version": 2},
                  "contentChanges": [{"text": shared_left_v2}]},
             )
-            session.diagnostics(shared_left[0].as_uri())
+            session.diagnostics(shared_left[0].as_uri(), 2)
             assert_definition(session, shared_left[0], shared_left[1], shared_left_v2)
             assert_definition(session, *shared_right)
             assert_definition(session, shared_left[0], shared_left[1], shared_left_v2)
@@ -467,25 +579,110 @@ def run_smoke(server: Path, timeout: float) -> tuple[tuple[int, float, int], lis
                 {"textDocument": {"uri": alpha_def.as_uri(), "languageId": "mach",
                                   "version": 1, "text": defs_v1}},
             )
-            session.diagnostics(alpha_def.as_uri())
+            session.diagnostics(alpha_def.as_uri(), 1)
             defs_v2 = defs_v1 + "pub val live: i32 = 33;\n"
-            main_v2 = alpha_text.replace(" + answer + ", " + answer + live + ").replace(
-                "use alpha.defs.answer;", "use alpha.defs.answer;\nuse alpha.defs.live;")
+            main_v2 = alpha_text.replace(" + direct + ", " + direct + live + ").replace(
+                "use direct: alpha.defs.answer;",
+                "use direct: alpha.defs.answer;\nuse alpha.defs.live;")
             session.notify(
                 "textDocument/didChange",
                 {"textDocument": {"uri": alpha_def.as_uri(), "version": 2},
                  "contentChanges": [{"text": defs_v2}]},
             )
-            session.diagnostics(alpha_def.as_uri())
+            session.diagnostics(alpha_def.as_uri(), 2)
             session.notify(
                 "textDocument/didChange",
                 {"textDocument": {"uri": alpha_main.as_uri(), "version": 2},
                  "contentChanges": [{"text": main_v2}]},
             )
-            session.diagnostics(alpha_main.as_uri())
+            session.diagnostics(alpha_main.as_uri(), 2)
             live_result = definition(session, alpha_main, main_v2, "live")
             require(live_result.get("uri") == alpha_def.as_uri(),
                     f"unsaved imported export did not resolve: {live_result!r}")
+            assert_diagnostics(session.diagnostics(alpha_main.as_uri(), 2), False, 2)
+            assert_diagnostics(session.diagnostics(alpha_def.as_uri(), 2), False, 2)
+
+            broken_text = main_v2 + "\nuse alpha.missing.nope;\n"
+            session.notify(
+                "textDocument/didChange",
+                {"textDocument": {"uri": alpha_main.as_uri(), "version": 3},
+                 "contentChanges": [{"text": broken_text}]},
+            )
+            session.diagnostics(alpha_main.as_uri(), 3)
+            broken_overlay = session.request(
+                "textDocument/definition",
+                {"textDocument": {"uri": alpha_main.as_uri()},
+                 "position": {"line": 8, "character": 30}},
+            )
+            require(broken_overlay.get("result") is None,
+                    f"invalid unsaved import unexpectedly analyzed: {broken_overlay!r}")
+            session.notify(
+                "textDocument/didChange",
+                {"textDocument": {"uri": alpha_main.as_uri(), "version": 4},
+                 "contentChanges": [{"text": main_v2}]},
+            )
+            session.diagnostics(alpha_main.as_uri(), 4)
+            require(definition(session, alpha_main, main_v2, "live").get("uri") == alpha_def.as_uri(),
+                    "failed snapshot did not retry after the next unsaved revision")
+
+            session.notify("textDocument/didClose", {"textDocument": {"uri": alpha_def.as_uri()}})
+            assert_diagnostics(session.diagnostics(alpha_def.as_uri(), None), False)
+            after_close = session.request(
+                "textDocument/definition",
+                {"textDocument": {"uri": alpha_main.as_uri()},
+                 "position": {"line": 5, "character": 35}},
+            )
+            require(after_close.get("result") is None,
+                    f"closed unsaved export remained authoritative: {after_close!r}")
+            session.notify(
+                "textDocument/didChange",
+                {"textDocument": {"uri": alpha_main.as_uri(), "version": 5},
+                 "contentChanges": [{"text": alpha_text}]},
+            )
+            session.diagnostics(alpha_main.as_uri(), 5)
+            assert_definition(session, alpha_main, alpha_def, alpha_text)
+            assert_diagnostics(session.diagnostics(alpha_main.as_uri(), 5), False, 5)
+
+            # A dependency opened before its ancestor graph is loaded must still
+            # enter that graph through a filesystem overlay. Current `[dep.*]`
+            # routing, a raw `src = "./src"` spelling, sema, and read-only rename
+            # are all exercised by the unsaved i64 export.
+            vendor_main, vendor_dep, vendor_text, vendor_live = vendored
+            session.notify(
+                "textDocument/didOpen",
+                {"textDocument": {"uri": vendor_dep.as_uri(), "languageId": "mach",
+                                  "version": 1, "text": vendor_live}},
+            )
+            assert_diagnostics(session.diagnostics(vendor_dep.as_uri(), 1), False, 1)
+            session.notify(
+                "textDocument/didOpen",
+                {"textDocument": {"uri": vendor_main.as_uri(), "languageId": "mach",
+                                  "version": 1, "text": vendor_text}},
+            )
+            assert_diagnostics(session.diagnostics(vendor_main.as_uri(), 1), False, 1)
+            vendor_definition = definition(session, vendor_main, vendor_text, "live")
+            require(vendor_definition.get("uri") == vendor_dep.as_uri(),
+                    f"vendored unsaved export did not resolve: {vendor_definition!r}")
+            vendor_lines = vendor_text.splitlines()
+            vendor_line = next(i for i, value in enumerate(vendor_lines)
+                               if "live" in value and "use " not in value)
+            vendor_char = vendor_lines[vendor_line].index("live") + 1
+            vendor_hover = session.request(
+                "textDocument/hover",
+                {"textDocument": {"uri": vendor_main.as_uri()},
+                 "position": {"line": vendor_line, "character": vendor_char}},
+            )
+            require("i64" in json.dumps(vendor_hover.get("result")),
+                    f"vendored overlay did not participate in sema: {vendor_hover!r}")
+            vendor_rename = session.request(
+                "textDocument/rename",
+                {"textDocument": {"uri": vendor_main.as_uri()},
+                 "position": {"line": vendor_line, "character": vendor_char}, "newName": "changed"},
+            )
+            changes = vendor_rename.get("result", {}).get("changes")
+            require(changes == {}, f"vendored dependency rename was writable: {vendor_rename!r}")
+            session.notify("textDocument/didClose", {"textDocument": {"uri": vendor_main.as_uri()}})
+            session.notify("textDocument/didClose", {"textDocument": {"uri": vendor_dep.as_uri()}})
 
             # Standalone buffers retain the upstream editor feature path.
             standalone = root / "standalone.mach"
@@ -495,7 +692,7 @@ def run_smoke(server: Path, timeout: float) -> tuple[tuple[int, float, int], lis
                 {"textDocument": {"uri": standalone.as_uri(), "languageId": "mach",
                                   "version": 1, "text": standalone_text}},
             )
-            session.diagnostics(standalone.as_uri())
+            session.diagnostics(standalone.as_uri(), 1)
             stand_def = definition(session, standalone, standalone_text, "item")
             require(stand_def.get("uri") == standalone.as_uri(),
                     f"standalone definition failed: {stand_def!r}")
@@ -515,13 +712,12 @@ def run_smoke(server: Path, timeout: float) -> tuple[tuple[int, float, int], lis
                     and completion_result["items"],
                     f"standalone completion failed: {completion!r}")
             session.notify("textDocument/didClose", {"textDocument": {"uri": standalone.as_uri()}})
-            assert_diagnostics(session.diagnostics(standalone.as_uri()), False)
+            assert_diagnostics(session.diagnostics(standalone.as_uri(), None), False)
 
             for main, _, _ in (alpha, beta):
                 session.notify("textDocument/didClose", {"textDocument": {"uri": main.as_uri()}})
             for main, _, _ in (shared_left, shared_right):
                 session.notify("textDocument/didClose", {"textDocument": {"uri": main.as_uri()}})
-            session.notify("textDocument/didClose", {"textDocument": {"uri": alpha_def.as_uri()}})
             session.notify("textDocument/didClose", {"textDocument": {"uri": nested[0].as_uri()}})
 
             telemetry = session.finish()
@@ -556,12 +752,13 @@ def run_active_watcher_fallback(server: Path, timeout: float) -> None:
                 {"textDocument": {"uri": main.as_uri(), "languageId": "mach",
                                   "version": 1, "text": text}},
             )
-            session.diagnostics(main.as_uri())
+            session.diagnostics(main.as_uri(), 1)
             assert_definition(session, main, defs, text)
 
             changed = defs.read_text(encoding="utf-8").replace(
                 "pub val watched: i32", "pub val watched: i64")
             defs.write_text(changed, encoding="utf-8")
+            time.sleep(0.3)
             lines = text.splitlines()
             line = next(i for i, value in enumerate(lines) if "watched" in value and "use " not in value)
             hover = session.request(
@@ -571,6 +768,58 @@ def run_active_watcher_fallback(server: Path, timeout: float) -> None:
             )
             require("i64" in json.dumps(hover.get("result")),
                     f"active watcher suppressed source fingerprint fallback: {hover!r}")
+
+            broken = changed + "use watch.missing.nope;\n"
+            defs.write_text(broken, encoding="utf-8")
+            time.sleep(0.3)
+            failed = session.request(
+                "textDocument/definition",
+                {"textDocument": {"uri": main.as_uri()},
+                 "position": {"line": line, "character": lines[line].index("watched") + 1}},
+            )
+            require(failed.get("result") is None,
+                    f"broken on-disk source retained a stale snapshot: {failed!r}")
+            defs.write_text(changed, encoding="utf-8")
+            time.sleep(0.3)
+            repaired = definition(session, main, text, "watched")
+            require(repaired.get("uri") == defs.as_uri(),
+                    f"failed root did not retry after disk source repair: {repaired!r}")
+            session.finish()
+            finished = True
+        finally:
+            if not finished:
+                session.abort()
+
+
+def run_same_fqn_reverse(server: Path, timeout: float) -> None:
+    """Load colliding project IDs in reverse order and invalidate the first."""
+    with tempfile.TemporaryDirectory(prefix="mls-fqn-reverse-") as directory:
+        root = Path(directory).resolve()
+        left = write_project(root / "left", "shared", 61)
+        right = write_project(root / "right", "shared", 71)
+        session = LspSession(server, root, timeout)
+        finished = False
+        try:
+            session.request("initialize", {"rootUri": root.as_uri(), "capabilities": {}})
+            session.notify("initialized", {})
+            for main, definition_path, text in (right, left):
+                session.notify(
+                    "textDocument/didOpen",
+                    {"textDocument": {"uri": main.as_uri(), "languageId": "mach",
+                                      "version": 1, "text": text}},
+                )
+                assert_diagnostics(session.diagnostics(main.as_uri(), 1), False, 1)
+                assert_definition(session, main, definition_path, text)
+            assert_definition(session, *right)
+            right_v2 = right[2] + "\n"
+            session.notify(
+                "textDocument/didChange",
+                {"textDocument": {"uri": right[0].as_uri(), "version": 2},
+                 "contentChanges": [{"text": right_v2}]},
+            )
+            session.diagnostics(right[0].as_uri(), 2)
+            assert_definition(session, right[0], right[1], right_v2)
+            assert_definition(session, *left)
             session.finish()
             finished = True
         finally:
@@ -671,6 +920,7 @@ def main() -> int:
     try:
         (exit_code, elapsed, message_count), timings = run_smoke(server, args.timeout)
         run_active_watcher_fallback(server, args.timeout)
+        run_same_fqn_reverse(server, args.timeout)
         run_clean_eof(server, args.timeout)
         run_transport_regressions(server, args.timeout)
         closed_stdout_status = probe_closed_stdout(server, args.timeout, True)

--- a/test/lsp_protocol.py
+++ b/test/lsp_protocol.py
@@ -126,6 +126,10 @@ class LspSession:
         self._send({"jsonrpc": "2.0", "id": request.get("id"),
                     "error": {"code": code, "message": message}})
 
+    def respond_result(self, request: dict[str, Any], result: Any = None) -> None:
+        """Acknowledge one server-initiated request."""
+        self._send({"jsonrpc": "2.0", "id": request.get("id"), "result": result})
+
     def wait_for(
         self,
         predicate: Callable[[dict[str, Any]], bool],
@@ -275,14 +279,15 @@ need = []
     import_line = (f"use {alias}: {project_id}.defs;\n"
                    f"use {project_id}.defs.answer;\n"
                    f"use {project_id}.defs.Box;\n"
-                   f"use {project_id}.defs.take;")
+                   f"use {project_id}.defs.take;\n"
+                   f"use {project_id}.defs.watched;")
     answer_expr = "answer"
     text = f"""{import_line}
 
 pub fun main() i32 {{
     var b: Box[i32];
     b.v = {value};
-    ret take[i32](b) + {answer_expr} + {alias}.answer;
+    ret take[i32](b) + {answer_expr} + {alias}.answer + watched;
 }}
 """
     main = source / "main.mach"
@@ -292,6 +297,7 @@ pub fun main() i32 {{
         f'''$if ($project.target.os != "linux") {{ $error("wrong selected target"); }}
 $if ($bin.name != "app") {{ $error("wrong selected artifact"); }}
 pub val answer: i32 = {value};
+pub val watched: i32 = {value};
 pub rec Box[T] {{ v: T; }}
 pub fun take[T](b: Box[T]) i32 {{ ret 7; }}
 ''',
@@ -336,9 +342,15 @@ def run_smoke(server: Path, timeout: float) -> tuple[tuple[int, float, int], lis
     with tempfile.TemporaryDirectory(prefix="mls-protocol-") as directory:
         root = Path(directory).resolve()
         alpha = write_project(root, "alpha", 11)
+        alpha_manifest_path = alpha[0].parents[1] / "mach.toml"
+        alpha_manifest_path.write_text(
+            alpha_manifest_path.read_text(encoding="utf-8").replace('src = "src"', 'src = "./src"'),
+            encoding="utf-8",
+        )
         beta = write_project(root, "beta", 22)
         shared_left = write_project(root / "left", "shared", 31)
         shared_right = write_project(root / "right", "shared", 41)
+        nested = write_project(alpha[0].parent / "nested", "nested", 51)
         scratch_uri = (root / "scratch.mach").as_uri()
         session = LspSession(server, root, timeout)
         finished = False
@@ -401,6 +413,14 @@ def run_smoke(server: Path, timeout: float) -> tuple[tuple[int, float, int], lis
             assert_definition(session, *alpha)
             assert_definition(session, *beta)
             assert_definition(session, *alpha)
+            session.notify(
+                "textDocument/didOpen",
+                {"textDocument": {"uri": nested[0].as_uri(), "languageId": "mach",
+                                  "version": 1, "text": nested[2]}},
+            )
+            assert_diagnostics(session.diagnostics(nested[0].as_uri()), False, 1)
+            assert_definition(session, *nested)
+            assert_definition(session, *alpha)
             for main, _, text in (shared_left, shared_right):
                 session.notify(
                     "textDocument/didOpen",
@@ -411,6 +431,16 @@ def run_smoke(server: Path, timeout: float) -> tuple[tuple[int, float, int], lis
             assert_definition(session, *shared_left)
             assert_definition(session, *shared_right)
             assert_definition(session, *shared_left)
+            shared_left_v2 = shared_left[2] + "\n"
+            session.notify(
+                "textDocument/didChange",
+                {"textDocument": {"uri": shared_left[0].as_uri(), "version": 2},
+                 "contentChanges": [{"text": shared_left_v2}]},
+            )
+            session.diagnostics(shared_left[0].as_uri())
+            assert_definition(session, shared_left[0], shared_left[1], shared_left_v2)
+            assert_definition(session, *shared_right)
+            assert_definition(session, shared_left[0], shared_left[1], shared_left_v2)
 
             # A rejected dynamic registration must leave manifest fingerprint
             # fallback active: a broken manifest disables the snapshot, and a
@@ -492,10 +522,57 @@ def run_smoke(server: Path, timeout: float) -> tuple[tuple[int, float, int], lis
             for main, _, _ in (shared_left, shared_right):
                 session.notify("textDocument/didClose", {"textDocument": {"uri": main.as_uri()}})
             session.notify("textDocument/didClose", {"textDocument": {"uri": alpha_def.as_uri()}})
+            session.notify("textDocument/didClose", {"textDocument": {"uri": nested[0].as_uri()}})
 
             telemetry = session.finish()
             finished = True
             return telemetry, session.timings
+        finally:
+            if not finished:
+                session.abort()
+
+
+def run_active_watcher_fallback(server: Path, timeout: float) -> None:
+    """Prove a missed source event is recovered even after watcher ACK."""
+    with tempfile.TemporaryDirectory(prefix="mls-watch-") as directory:
+        root = Path(directory).resolve()
+        main, defs, text = write_project(root, "watch", 9)
+        session = LspSession(server, root, timeout)
+        finished = False
+        try:
+            session.request(
+                "initialize",
+                {"rootUri": root.as_uri(), "capabilities": {"workspace": {
+                    "didChangeWatchedFiles": {"dynamicRegistration": True}}}},
+            )
+            session.notify("initialized", {})
+            registration = session.wait_for(
+                lambda item: item.get("method") == "client/registerCapability",
+                "watch registration",
+            )
+            session.respond_result(registration)
+            session.notify(
+                "textDocument/didOpen",
+                {"textDocument": {"uri": main.as_uri(), "languageId": "mach",
+                                  "version": 1, "text": text}},
+            )
+            session.diagnostics(main.as_uri())
+            assert_definition(session, main, defs, text)
+
+            changed = defs.read_text(encoding="utf-8").replace(
+                "pub val watched: i32", "pub val watched: i64")
+            defs.write_text(changed, encoding="utf-8")
+            lines = text.splitlines()
+            line = next(i for i, value in enumerate(lines) if "watched" in value and "use " not in value)
+            hover = session.request(
+                "textDocument/hover",
+                {"textDocument": {"uri": main.as_uri()},
+                 "position": {"line": line, "character": lines[line].index("watched") + 1}},
+            )
+            require("i64" in json.dumps(hover.get("result")),
+                    f"active watcher suppressed source fingerprint fallback: {hover!r}")
+            session.finish()
+            finished = True
         finally:
             if not finished:
                 session.abort()
@@ -593,6 +670,7 @@ def main() -> int:
         parser.error("--timeout must be positive")
     try:
         (exit_code, elapsed, message_count), timings = run_smoke(server, args.timeout)
+        run_active_watcher_fallback(server, args.timeout)
         run_clean_eof(server, args.timeout)
         run_transport_regressions(server, args.timeout)
         closed_stdout_status = probe_closed_stdout(server, args.timeout, True)

--- a/test/lsp_protocol.py
+++ b/test/lsp_protocol.py
@@ -881,6 +881,52 @@ def run_bad_frame(server: Path, frame: bytes, timeout: float, label: str) -> Non
     require(result.stdout == b"", f"{label}: server emitted a partial response")
 
 
+def run_exit_paths(server: Path, timeout: float) -> None:
+    """Every lifecycle ending must terminate, with the documented code.
+
+    `exit` means terminate, and a client may hold its end of the pipe open while
+    it waits. With analysis on a worker the reading thread is parked in read(2),
+    so an `exit` that only set a flag would leave the process alive until the
+    client happened to close stdin.
+    """
+    cases = (
+        (("shutdown", "exit"), False, 0),
+        (("shutdown", "exit"), True, 0),
+        (("exit",), False, 1),
+        (("shutdown",), True, 0),
+        ((), True, 1),
+    )
+    for steps, close_stdin, expected in cases:
+        with tempfile.TemporaryDirectory(prefix="mls-exit-") as directory:
+            root = Path(directory).resolve()
+            session = LspSession(server, root, timeout)
+            try:
+                session.request("initialize", {"rootUri": root.as_uri(), "capabilities": {}})
+                session.notify("initialized", {})
+                if "shutdown" in steps:
+                    response = session.request("shutdown")
+                    require(response.get("result", object()) is None,
+                            f"invalid shutdown response: {response!r}")
+                if "exit" in steps:
+                    session.notify("exit")
+                if close_stdin:
+                    session.proc.stdin.close()
+                try:
+                    code = session.proc.wait(timeout=timeout)
+                except subprocess.TimeoutExpired as error:
+                    session.proc.kill()
+                    session.proc.wait()
+                    raise ProtocolError(
+                        f"server did not terminate for {steps!r} "
+                        f"(stdin closed: {close_stdin})") from error
+                require(code == expected,
+                        f"{steps!r} (stdin closed: {close_stdin}) exited {code}, want {expected}")
+            finally:
+                if session.proc.poll() is None:
+                    session.proc.kill()
+                    session.proc.wait()
+
+
 def run_clean_eof(server: Path, timeout: float) -> None:
     """A clean EOF after shutdown is not a malformed-frame failure."""
     with tempfile.TemporaryDirectory(prefix="mls-protocol-eof-") as directory:
@@ -957,6 +1003,7 @@ def main() -> int:
         run_active_watcher_fallback(server, args.timeout)
         run_same_fqn_reverse(server, args.timeout)
         run_clean_eof(server, args.timeout)
+        run_exit_paths(server, args.timeout)
         run_transport_regressions(server, args.timeout)
         closed_stdout_status = probe_closed_stdout(server, args.timeout, True)
         suppressed_status = probe_closed_stdout(server, args.timeout, False)
@@ -967,6 +1014,7 @@ def main() -> int:
         return 1
     print(f"protocol smoke: PASS ({message_count} messages, exit {exit_code}, {elapsed:.3f}s)")
     print("  clean EOF after shutdown: exit 0")
+    print("  all five lifecycle endings terminate with the documented code")
     print("  malformed/oversized frames: 8 rejected with exit 1")
     print("  closed stdout reader with inherited SIG_IGN: exit 1")
     print("  closed stdout reader: exit 1")


### PR DESCRIPTION
Integration merge for the 0.11.0 release. See the CHANGELOG entry for the full set; the cycle's headline is perf (#95), diagnostics correctness (#142), and responsiveness (#143, #155), on top of the #141 snapshot architecture.

Carries one documented known issue: ~4.2 MiB of resident growth per analysis, entirely inside the compiler's `begin_build` and reproducible with no LSP code involved (briar-systems/mach#3012). The LSP side is clean.