### PR TITLE
feat(definition/hover): navigate use and fwd import paths

### DIFF
--- a/src/features.mach
+++ b/src/features.mach
@@ -78,7 +78,7 @@ pub rec SymbolRef {
 # own:    this buffer's module id (Symbol.origin equals it for local symbols)
 # offset: byte offset into the buffer
 # ret:    some(SymbolRef) for a resolved position, or none
-pub fun ref_at(a: *ast.Ast, rr: *res.ResolveResult, own: sess.ModuleId, offset: usize) Option[SymbolRef] {
+pub fun ref_at(a: *ast.Ast, rr: *res.ResolveResult, own: sess.ModuleId, file: *src.SourceFile, offset: usize) Option[SymbolRef] {
     val eid: id.ExprId = ast.offset_to_expr(a, offset);
     if (eid != id.EXPR_NIL && rr.expr_resolved != nil && eid::u32 < rr.expr_count) {
         val sid: res.SymbolId = rr.expr_resolved[eid];
@@ -127,9 +127,54 @@ pub fun ref_at(a: *ast.Ast, rr: *res.ResolveResult, own: sess.ModuleId, offset: 
         # cursor on one of those binding names through the symbol table
         val bo: Option[SymbolRef] = binding_ref_in_decl(a, rr, own, did, offset);
         if (is_some[SymbolRef](bo)) { ret bo; }
+
+        # a `use` / `fwd` path is neither an expr nor a type, and an import decl
+        # has no name span, so nothing above reaches it - yet decl_symbol holds
+        # exactly the symbol the import binds
+        val io: Option[SymbolRef] = import_ref_in_decl(a, rr, own, did, file, offset);
+        if (is_some[SymbolRef](io)) { ret io; }
     }
 
     ret none[SymbolRef]();
+}
+
+# a SymbolRef when `offset` falls on an import declaration's alias or anywhere in
+# its dotted path, or none
+#
+# The resolver binds a single-symbol import under the path's leaf and records the
+# imported symbol in `decl_symbol`, so the whole import line resolves to one
+# symbol. The reported name span is the leaf rather than the cursor's own token:
+# a rename must rewrite the leaf, and hover wants the symbol's own name, not the
+# package qualifier the cursor happened to land on.
+# ---
+# a:      the Ast holding the decl
+# rr:     the ResolveResult side tables
+# own:    the buffer's module id
+# did:    decl id under the cursor
+# file:   source file backing the import path, to locate the leaf
+# offset: cursor byte offset
+# ret:    some(ref) when the cursor is on an import path or alias, else none
+fun import_ref_in_decl(a: *ast.Ast, rr: *res.ResolveResult, own: sess.ModuleId, did: id.DeclId, file: *src.SourceFile, offset: usize) Option[SymbolRef] {
+    if (file == nil) { ret none[SymbolRef](); }
+    if (rr.decl_symbol == nil || did::u32 >= rr.decl_count) { ret none[SymbolRef](); }
+    val sid: res.SymbolId = rr.decl_symbol[did];
+    if (sid == res.SYMBOL_NIL || sid >= rr.symbol_count) { ret none[SymbolRef](); }
+
+    val d_opt: Option[*decl.Decl] = ast.get_decl(a, did);
+    if (!is_some[*decl.Decl](d_opt)) { ret none[SymbolRef](); }
+    val d: *decl.Decl = unwrap[*decl.Decl](d_opt);
+
+    var path:  token.Span;
+    var alias: token.Span;
+    if (d.kind == decl.DECL_KIND_USE) { path = d.data.use_.path; alias = d.data.use_.alias; }
+    or (d.kind == decl.DECL_KIND_FWD) { path = d.data.fwd_.path; alias = d.data.fwd_.alias; }
+    or { ret none[SymbolRef](); }
+
+    val on_path:  bool = ast.span_contains(path, offset);
+    val on_alias: bool = alias.len > 0 && ast.span_contains(alias, offset);
+    if (!on_path && !on_alias) { ret none[SymbolRef](); }
+
+    ret some[SymbolRef](make_ref(rr, own, sid, import_leaf_span(file, path)));
 }
 
 # a SymbolRef when `offset` falls on a function

--- a/src/language.mach
+++ b/src/language.mach
@@ -43,6 +43,8 @@ use std.allocator.deallocate;
 use mem: std.memory;
 
 use sess:   mach.lang.session;
+use strutil: std.text.string;
+use trace:   mls.trace;
 use src:    mach.lang.source;
 use intern: mach.lang.intern;
 use editor: mach.lang.editor;
@@ -94,7 +96,7 @@ pub fun hover(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocat
     if (!is_some[usize](off_o)) { reply_null(alloc, id_raw); ret; }
     val offset: usize = unwrap[usize](off_o);
 
-    val ro: Option[features.SymbolRef] = features.ref_at(an.a, an.rr, an.own, offset);
+    val ro: Option[features.SymbolRef] = features.ref_at(an.a, an.rr, an.own, an.file, offset);
     if (!is_some[features.SymbolRef](ro)) {
         # name resolution leaves a value-field access unbound, so a cursor on a
         # field name yields no SymbolRef - fall through to the type-driven field
@@ -290,6 +292,15 @@ fun compose_field_hover(name: str, ty: str, doc: str, alloc: *Allocator) str {
 fun hover_markdown(ws: *project.Workspace, an: Analyzed, sym: *res.Symbol, uri: str, alloc: *Allocator) str {
     var sig: str = nil;
     var doc: str = nil;
+
+    # a module alias's decl is the `use` line the cursor is already on, so
+    # rendering it back is no answer. name the module instead.
+    var mid: sess.ModuleId;
+    if (module_alias_target(sym, ?mid) && an.root != nil) {
+        val fqn: str = project.module_fqn(ws, an.root, mid);
+        if (fqn != nil) { ret module_hover_markdown(fqn, alloc); }
+    }
+
     val site_o: Option[project.Site] = project.site_of(ws, an.root, an.own, an.a, an.file, uri, sym);
     if (is_some[project.Site](site_o)) {
         var site: project.Site = unwrap[project.Site](site_o);
@@ -472,7 +483,7 @@ pub fun definition(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Al
     if (!is_some[usize](off_o)) { reply_null(alloc, id_raw); ret; }
     val offset: usize = unwrap[usize](off_o);
 
-    val ro: Option[features.SymbolRef] = features.ref_at(an.a, an.rr, an.own, offset);
+    val ro: Option[features.SymbolRef] = features.ref_at(an.a, an.rr, an.own, an.file, offset);
     if (!is_some[features.SymbolRef](ro)) {
         # name resolution leaves a value-field access unbound, so a cursor on a
         # field name yields no SymbolRef - fall through to the type-driven field
@@ -485,6 +496,12 @@ pub fun definition(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Al
     val so: Option[*res.Symbol] = features.symbol(an.rr, sr.sym_id);
     if (!is_some[*res.Symbol](so)) { reply_null(alloc, id_raw); ret; }
     val sym: *res.Symbol = unwrap[*res.Symbol](so);
+
+    # a module alias names a file, not a declaration: `sym.decl` is the `use`
+    # line the cursor is already on, and the module has no name span to point
+    # at. its target ModuleId rides `sym.slot`, so answer with the module's own
+    # file at its start.
+    if (module_definition(ws, an, sym, alloc, id_raw)) { ret; }
 
     val site_o: Option[project.Site] = project.site_of(ws, an.root, an.own, an.a, an.file, uri, sym);
     if (!is_some[project.Site](site_o)) { reply_null(alloc, id_raw); ret; }
@@ -505,6 +522,71 @@ pub fun definition(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Al
 
     json.free_str(loc, alloc);
     json.free_str(id_raw, alloc);
+}
+
+# `module <fqn>` as a fenced hover body
+fun module_hover_markdown(fqn: str, alloc: *Allocator) str {
+    var b: json.Buf = json.buf_init(alloc);
+    json.buf_push(?b, "```mach\nmodule ");
+    json.buf_push(?b, fqn);
+    json.buf_push(?b, "\n```");
+    val view: str = json.buf_str(?b);
+    if (view == nil) { json.buf_dnit(?b); ret nil; }
+    val n: usize = str_len(view);
+    val r: Result[*u8, str] = allocate[u8](alloc, n + 1);
+    if (is_err[*u8, str](r)) { json.buf_dnit(?b); ret nil; }
+    val out: *u8 = unwrap_ok[*u8, str](r);
+    if (n > 0) { mem.raw_copy(out::ptr, view::ptr, n); }
+    out[n] = 0;
+    json.buf_dnit(?b);
+    ret out::str;
+}
+
+# whether `sym` is a module alias (`use json: mls.json;`) rather than a symbol
+# import (`use std.types.string.str_equals;`), and the module it names
+#
+# The two forms are distinguished by kind, not by a flag: a module alias binds
+# SYM_USE carrying the target ModuleId in `slot`, while a symbol import binds
+# SYM_IMPORTED carrying the imported declaration. `SYM_FLAG_MODULE` is set on
+# the PublicSymbol snapshot of a re-exported alias, not on the local symbol, so
+# it is not the discriminator here.
+# ---
+# sym: the symbol under the cursor
+# out: receives the aliased module id
+# ret: true when `sym` is a module alias
+fun module_alias_target(sym: *res.Symbol, out: *sess.ModuleId) bool {
+    if (sym.kind != res.SYM_USE) { ret false; }
+    @out = sym.slot::sess.ModuleId;
+    ret true;
+}
+
+# emit the Location of the module `sym` aliases, at the start of its file
+# ---
+# ws:     the workspace
+# an:     the analyzed request document
+# sym:    the symbol under the cursor
+# alloc:  request allocator
+# id_raw: the raw JSON request id, consumed on success
+# ret:    true when a module Location was emitted and replied
+fun module_definition(ws: *project.Workspace, an: Analyzed, sym: *res.Symbol, alloc: *Allocator, id_raw: str) bool {
+    var mid: sess.ModuleId;
+    if (!module_alias_target(sym, ?mid)) { ret false; }
+    if (an.root == nil) { ret false; }
+    val muri: str = project.module_uri(ws, an.root, mid);
+    if (muri == nil) { ret false; }
+
+    var b: json.Buf = json.buf_init(alloc);
+    json.buf_push(?b, "{\"jsonrpc\":\"2.0\",\"id\":");
+    json.buf_push(?b, id_raw);
+    json.buf_push(?b, ",\"result\":{\"uri\":");
+    json.buf_push_quoted(?b, muri);
+    json.buf_push(?b, ",\"range\":{\"start\":{\"line\":0,\"character\":0},\"end\":{\"line\":0,\"character\":0}}}}");
+    val msg: str = json.buf_str(?b);
+    if (msg != nil) { transport.send_message(msg, alloc); }
+    json.buf_dnit(?b);
+    strutil.str_free(ws.alloc, muri);
+    json.free_str(id_raw, alloc);
+    ret true;
 }
 
 # the type-driven go-to-definition path for a record / union
@@ -1021,7 +1103,7 @@ pub fun references(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Al
     if (!is_some[usize](off_o)) { reply_empty_array(alloc, id_raw); ret; }
     val offset: usize = unwrap[usize](off_o);
 
-    val ro: Option[features.SymbolRef] = features.ref_at(an.a, an.rr, an.own, offset);
+    val ro: Option[features.SymbolRef] = features.ref_at(an.a, an.rr, an.own, an.file, offset);
     if (!is_some[features.SymbolRef](ro)) {
         # name resolution leaves a value-field access unbound, so a cursor on a
         # field name yields no SymbolRef - fall through to the type-driven field
@@ -1069,7 +1151,7 @@ pub fun rename(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Alloca
     if (!is_some[usize](off_o)) { reply_empty_edit(alloc, id_raw); json.free_str(new_name, alloc); ret; }
     val offset: usize = unwrap[usize](off_o);
 
-    val ro: Option[features.SymbolRef] = features.ref_at(an.a, an.rr, an.own, offset);
+    val ro: Option[features.SymbolRef] = features.ref_at(an.a, an.rr, an.own, an.file, offset);
     if (!is_some[features.SymbolRef](ro)) {
         # a cursor on a field name yields no SymbolRef - fall through to the
         # type-driven field rename, which gates on the record's ownership.
@@ -1150,7 +1232,7 @@ pub fun prepare_rename(ws: *project.Workspace, es: *editor.EditorSession, alloc:
     if (!is_some[usize](off_o)) { reply_null(alloc, id_raw); ret; }
     val offset: usize = unwrap[usize](off_o);
 
-    val ro: Option[features.SymbolRef] = features.ref_at(an.a, an.rr, an.own, offset);
+    val ro: Option[features.SymbolRef] = features.ref_at(an.a, an.rr, an.own, an.file, offset);
     if (!is_some[features.SymbolRef](ro)) {
         # a cursor on a field name yields no SymbolRef - accept it when it resolves
         # to a field of a project-owned record (the same gate field rename uses)

--- a/src/project.mach
+++ b/src/project.mach
@@ -1495,6 +1495,24 @@ pub fun module_uri(w: *Workspace, root: *Root, mid: sess.ModuleId) str {
     ret norm_uri(w.alloc, root.mod_paths[mid::u32]);
 }
 
+# the interned FQN of a loaded module, or nil
+#
+# The name a module alias stands for. `module_uri` gives where it lives; this
+# gives what it is called, so hover can say `module std.data.json` rather than
+# echoing the `use` line the cursor is already on.
+# ---
+# w:    the workspace
+# root: the root owning the module
+# mid:  module id within that root
+# ret:  borrowed FQN text, or nil when the module is not loaded
+pub fun module_fqn(w: *Workspace, root: *Root, mid: sess.ModuleId) str {
+    val e: *driver.ModuleEntry = module_entry(root, mid);
+    if (e == nil) { ret nil; }
+    val o: Option[str] = intern.lookup(?root.s.interner, e.fqn);
+    if (!is_some[str](o)) { ret nil; }
+    ret unwrap[str](o);
+}
+
 # the loaded module in `root` whose source file is the document
 # at `uri` (matched on the normalized filesystem path), or none. This is the
 # canonical document-to-ModuleEntry identity used for routing and views.

--- a/test/lsp_protocol.py
+++ b/test/lsp_protocol.py
@@ -589,6 +589,10 @@ def run_smoke(server: Path, timeout: float) -> tuple[tuple[int, float, int], lis
             alpha_manifest = alpha[0].parents[1] / "mach.toml"
             manifest_text = alpha_manifest.read_text(encoding="utf-8")
             alpha_manifest.write_text(manifest_text + "\n[broken\n", encoding="utf-8")
+            # the fingerprint fallback coalesces to at most one scan per 250 ms
+            # per root, so a request issued inside that window is answered from
+            # the still-live snapshot. wait past it, or this asserts nothing.
+            time.sleep(0.4)
             broken = session.request(
                 "textDocument/definition",
                 {"textDocument": {"uri": alpha[0].as_uri()},
@@ -597,6 +601,9 @@ def run_smoke(server: Path, timeout: float) -> tuple[tuple[int, float, int], lis
             require(broken.get("result") is None,
                     f"watcher rejection disabled manifest fallback: {broken!r}")
             alpha_manifest.write_text(manifest_text, encoding="utf-8")
+            # and again on the way back: a failed root retries on the next
+            # fingerprint scan, not on the next request
+            time.sleep(0.4)
             assert_definition(session, *alpha)
 
             # An unsaved export change in one module must be visible from another
@@ -758,6 +765,102 @@ def run_smoke(server: Path, timeout: float) -> tuple[tuple[int, float, int], lis
             telemetry = session.finish()
             finished = True
             return telemetry, session.timings
+        finally:
+            if not finished:
+                session.abort()
+
+
+def run_import_navigation(server: Path, timeout: float) -> None:
+    """A `use` / `fwd` path must navigate like a body reference to the same symbol.
+
+    An import path is neither an expression nor a type and an import declaration
+    has no name span, so nothing in the offset pivot reached it: hover and
+    definition both answered null anywhere on a `use` line. The resolver does
+    record the bound symbol on the declaration, which is what makes this
+    answerable.
+    """
+    with tempfile.TemporaryDirectory(prefix="mls-import-") as directory:
+        root = Path(directory).resolve()
+        main, defs, text = write_project(root, "imp", 5)
+        bridge = main.parent / "bridge.mach"
+        session = LspSession(server, root, timeout)
+        finished = False
+        try:
+            session.request("initialize", {"rootUri": root.as_uri(), "capabilities": {}})
+            session.notify("initialized", {})
+            session.notify(
+                "textDocument/didOpen",
+                {"textDocument": {"uri": main.as_uri(), "languageId": "mach",
+                                  "version": 1, "text": text}},
+            )
+            session.diagnostics(main.as_uri(), 1)
+            lines = text.splitlines()
+
+            def at(needle: str, within: str) -> dict[str, Any]:
+                line = next(i for i, v in enumerate(lines) if within in v)
+                return {"textDocument": {"uri": main.as_uri()},
+                        "position": {"line": line, "character": lines[line].index(needle) + 1}}
+
+            def location(label: str, params: dict[str, Any]) -> dict[str, Any]:
+                response = session.request("textDocument/definition", params)
+                result = response.get("result")
+                require(isinstance(result, dict),
+                        f"{label}: definition on an import is not a Location: {result!r}")
+                assert_range(result.get("range"), f"{label}.range")
+                return result
+
+            def hover_text(label: str, params: dict[str, Any]) -> str:
+                response = session.request("textDocument/hover", params)
+                result = response.get("result")
+                require(isinstance(result, dict), f"{label}: hover on an import is null")
+                contents = result.get("contents")
+                require(isinstance(contents, dict), f"{label}: hover contents malformed")
+                return str(contents.get("value"))
+
+            # a plain symbol import: the leaf names a declaration in another module
+            leaf = at("Box", "use imp.defs.Box;")
+            require(location("symbol import leaf", leaf).get("uri") == defs.as_uri(),
+                    "a symbol import leaf did not resolve to its declaring module")
+            require("Box" in hover_text("symbol import leaf", leaf),
+                    "hover on a symbol import leaf did not name the symbol")
+
+            # the qualifier of the same path resolves to the same symbol, so a
+            # cursor anywhere on the line is useful rather than only on the leaf
+            require(location("import qualifier", at("imp", "use imp.defs.Box;")).get("uri")
+                    == defs.as_uri(),
+                    "the qualifier of an import path did not resolve")
+
+            # a member alias binds the imported symbol under a new name
+            require(location("member alias", at("direct", "use direct:")).get("uri")
+                    == defs.as_uri(),
+                    "a member alias did not resolve to its declaration")
+
+            # a bare-module alias names a FILE, not a declaration
+            module_alias = at("rootmod", "use rootmod:")
+            require(location("module alias", module_alias).get("uri") == defs.as_uri(),
+                    "a module alias did not resolve to the module's file")
+            require("module" in hover_text("module alias", module_alias),
+                    "hover on a module alias did not name it as a module")
+
+            # `fwd` re-export paths behave like `use` paths
+            bridge_text = bridge.read_text(encoding="utf-8")
+            session.notify(
+                "textDocument/didOpen",
+                {"textDocument": {"uri": bridge.as_uri(), "languageId": "mach",
+                                  "version": 1, "text": bridge_text}},
+            )
+            session.diagnostics(bridge.as_uri(), 1)
+            blines = bridge_text.splitlines()
+            bline = next(i for i, v in enumerate(blines) if v.startswith("fwd "))
+            fwd = {"textDocument": {"uri": bridge.as_uri()},
+                   "position": {"line": bline, "character": blines[bline].index("answer") + 1}}
+            response = session.request("textDocument/definition", fwd)
+            result = response.get("result")
+            require(isinstance(result, dict) and result.get("uri") == defs.as_uri(),
+                    f"a fwd re-export path did not resolve: {result!r}")
+
+            session.finish()
+            finished = True
         finally:
             if not finished:
                 session.abort()
@@ -1001,6 +1104,7 @@ def main() -> int:
     try:
         (exit_code, elapsed, message_count), timings = run_smoke(server, args.timeout)
         run_active_watcher_fallback(server, args.timeout)
+        run_import_navigation(server, args.timeout)
         run_same_fqn_reverse(server, args.timeout)
         run_clean_eof(server, args.timeout)
         run_exit_paths(server, args.timeout)
@@ -1013,6 +1117,7 @@ def main() -> int:
         print(f"protocol smoke: FAIL: {error}", file=sys.stderr)
         return 1
     print(f"protocol smoke: PASS ({message_count} messages, exit {exit_code}, {elapsed:.3f}s)")
+    print("  use / fwd import paths navigate to their declarations")
     print("  clean EOF after shutdown: exit 0")
     print("  all five lifecycle endings terminate with the documented code")
     print("  malformed/oversized frames: 8 rejected with exit 1")


### PR DESCRIPTION
Closes #163.

`use` lines were the one part of a Mach file the server could not navigate — hover and definition both answered null at every position on them.

An import path is neither an expression nor a type, and an import declaration has no name span, so every branch of the offset pivot missed it. `decl_symbol` held the bound symbol the whole time.

| position | before | after |
|---|---|---|
| `str_equals` in `use std.types.string.str_equals;` | null | declaration in mach-std, hover with signature + doc |
| a qualifier earlier in the same path | null | same symbol |
| `json` in `use json: mls.json;` | null | `src/json.mach`, hover `module mls.json` |
| a `fwd` re-export path | null | the re-exported declaration |

Module aliases needed a separate branch: they name a *file*, not a declaration, so there is no name span to point at. The two forms are distinguished by kind rather than a flag — a module alias binds `SYM_USE` with the target ModuleId in `slot`, a symbol import binds `SYM_IMPORTED` with the declaration. `SYM_FLAG_MODULE` turned out to be set on the *PublicSymbol snapshot* of a re-exported alias, not on the local symbol, so it is not the discriminator; I found that by tracing the actual kind/flags rather than trusting the field name.

## A latent test bug this exposed

The broken-manifest fallback assertion requested a definition at a position **inside an import path**, which returned null whether or not the manifest was broken — so it never tested what it claimed. Neither it nor the restore that follows waited past the 250 ms fingerprint-scan window either, so both were answered from the still-live snapshot.

With imports resolving, the first started returning a Location and the omission became visible. I verified the underlying behaviour is correct — with a broken manifest both a body reference and an import path return null, and both recover after the scan window — and made the test wait for the window it depends on.

## Verification

59 unit tests, full protocol suite including the new `run_import_navigation` (symbol import leaf, path qualifier, member alias, bare-module alias, `fwd` path).