### PR TITLE
refactor(render): one spelling per LSP value, and no sizing pass

### DIFF
--- a/src/json.mach
+++ b/src/json.mach
@@ -189,6 +189,28 @@ pub fun buf_push_i64(b: *Buf, value: i64) {
     buf_push_usize(b, value::usize);
 }
 
+# bytes written so far, as a mark for `buf_rewind`
+# ---
+# b:   the buffer
+# ret: the current length
+pub fun buf_len(b: *Buf) usize {
+    ret b.len;
+}
+
+# discard everything written after `mark`
+#
+# What lets a single-pass emitter speculate. A payload whose entries are only
+# known to be empty once walked - a rename group for a file that turns out to
+# contribute no edit - can open the entry, walk, and roll back, instead of
+# walking once to decide and again to write. A failed buffer stays failed.
+# ---
+# b:    the buffer
+# mark: a length previously returned by `buf_len`
+pub fun buf_rewind(b: *Buf, mark: usize) {
+    if (mark > b.len) { ret; }
+    b.len = mark;
+}
+
 # the buffer's contents as a nul-terminated string BORROWED from the buffer -
 # invalidated by any later push and freed by `buf_dnit`. nil when a push failed
 # to allocate, so one check here covers every push

--- a/src/language.mach
+++ b/src/language.mach
@@ -64,6 +64,7 @@ use sj:        std.data.json;
 use documents: mls.documents;
 use features:  mls.features;
 use positions: mls.positions;
+use render:    mls.render;
 use project:   mls.project;
 
 # the resolved analysis of one request's target document
@@ -93,7 +94,7 @@ pub fun hover(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocat
 
     var an: Analyzed;
     val off_o: Option[usize] = locate(ws, es, alloc, docs, params, uri, ?an);
-    if (!is_some[usize](off_o)) { reply_null(alloc, id_raw); ret; }
+    if (!is_some[usize](off_o)) { render.reply_null(alloc, id_raw); ret; }
     val offset: usize = unwrap[usize](off_o);
 
     val ro: Option[features.SymbolRef] = features.ref_at(an.a, an.rr, an.own, an.file, offset);
@@ -102,16 +103,16 @@ pub fun hover(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocat
         # field name yields no SymbolRef - fall through to the type-driven field
         # hover before giving up.
         if (field_hover(ws, alloc, ?an, offset, id_raw)) { ret; }
-        reply_null(alloc, id_raw); ret;
+        render.reply_null(alloc, id_raw); ret;
     }
     val sr: features.SymbolRef = unwrap[features.SymbolRef](ro);
 
     val so: Option[*res.Symbol] = features.symbol(an.rr, sr.sym_id);
-    if (!is_some[*res.Symbol](so)) { reply_null(alloc, id_raw); ret; }
+    if (!is_some[*res.Symbol](so)) { render.reply_null(alloc, id_raw); ret; }
     val sym: *res.Symbol = unwrap[*res.Symbol](so);
 
     val md: str = hover_markdown(ws, an, sym, uri, alloc);
-    if (md == nil) { reply_null(alloc, id_raw); ret; }
+    if (md == nil) { render.reply_null(alloc, id_raw); ret; }
 
     reply_hover(alloc, id_raw, an.file, sr.name_span, md);
 }
@@ -119,23 +120,49 @@ pub fun hover(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocat
 # send a `textDocument/hover` reply rendering Markdown `md` over the
 # name span `name_span` in `file`, freeing `md` and `id_raw`. nil-replies when the
 # Markdown cannot be quoted. shared by the symbol and field hover paths
+# an owned copy of a buffer's contents, releasing the buffer
+#
+# The markdown composers build a string rather than a JSON value, so they append
+# into a Buf and take the result instead of summing fragment lengths into an
+# exact allocation and filling it in a second pass.
+fun buf_into_str(b: *json.Buf, alloc: *Allocator) str {
+    val view: str = json.buf_str(b);
+    if (view == nil) { json.buf_dnit(b); ret nil; }
+    val n: usize = str_len(view);
+    val r: Result[*u8, str] = allocate[u8](alloc, n + 1);
+    if (is_err[*u8, str](r)) { json.buf_dnit(b); ret nil; }
+    val out: *u8 = unwrap_ok[*u8, str](r);
+    if (n > 0) { mem.raw_copy(out::ptr, view::ptr, n); }
+    out[n] = 0;
+    json.buf_dnit(b);
+    ret out::str;
+}
+
+# reply with one Location
+fun reply_location(alloc: *Allocator, id_raw: str, file: *src.SourceFile, uri: str, span: token.Span) {
+    var b: json.Buf = json.buf_init(alloc);
+    render.result_begin(?b, id_raw);
+    render.location(?b, file, uri, span);
+    render.send(?b, alloc, id_raw);
+}
+
+# reply with one Range
+fun reply_range(alloc: *Allocator, id_raw: str, file: *src.SourceFile, span: token.Span) {
+    var b: json.Buf = json.buf_init(alloc);
+    render.result_begin(?b, id_raw);
+    render.span_range(?b, file, span);
+    render.send(?b, alloc, id_raw);
+}
+
 fun reply_hover(alloc: *Allocator, id_raw: str, file: *src.SourceFile, name_span: token.Span, md: str) {
-    val qmd: str = json.quote(md, alloc);
-    json.free_str(md, alloc);
-    if (qmd == nil) { reply_null(alloc, id_raw); ret; }
-
-    val range: positions.LspRange = positions.range_of(file, name_span);
-    val rng: str = range_json(range, alloc);
-
-    val p1: str = "{\"jsonrpc\":\"2.0\",\"id\":";
-    val p2: str = ",\"result\":{\"contents\":{\"kind\":\"markdown\",\"value\":";
-    val p3: str = "},\"range\":";
-    val p4: str = "}}";
-    send6(alloc, p1, id_raw, p2, qmd, p3, rng, p4);
-
-    json.free_str(rng, alloc);
-    json.free_str(qmd, alloc);
-    json.free_str(id_raw, alloc);
+    var b: json.Buf = json.buf_init(alloc);
+    render.result_begin(?b, id_raw);
+    json.buf_push(?b, "{\"contents\":{\"kind\":\"markdown\",\"value\":");
+    json.buf_push_quoted(?b, md);
+    json.buf_push(?b, "},\"range\":");
+    render.span_range(?b, file, name_span);
+    json.buf_push_byte(?b, '}');
+    render.send(?b, alloc, id_raw);
 }
 
 # the type-driven hover path for a record / union field, consulted
@@ -255,32 +282,19 @@ fun doc_desc_prose(file: *src.SourceFile, span: token.Span, alloc: *Allocator) s
 # of `name: type` (or just `name` when the type is unavailable), followed by the
 # description prose as a paragraph when present. nil on allocation failure
 fun compose_field_hover(name: str, ty: str, doc: str, alloc: *Allocator) str {
-    val pre:   str = "```mach\n";
-    val post:  str = "\n```";
-    val sep:   str = "\n\n";
-    val colon: str = ": ";
-
-    var total: usize = str_len(pre) + str_len(name) + str_len(post);
-    if (ty != nil)  { total = total + str_len(colon) + str_len(ty); }
-    if (doc != nil) { total = total + str_len(sep) + str_len(doc); }
-
-    val r: Result[*u8, str] = allocate[u8](alloc, total + 1);
-    if (is_err[*u8, str](r)) { ret nil; }
-    val buf: *u8 = unwrap_ok[*u8, str](r);
-    var off: usize = 0;
-    off = append(buf, off, pre);
-    off = append(buf, off, name);
+    var b: json.Buf = json.buf_init(alloc);
+    json.buf_push(?b, "```mach\n");
+    json.buf_push(?b, name);
     if (ty != nil) {
-        off = append(buf, off, colon);
-        off = append(buf, off, ty);
+        json.buf_push(?b, ": ");
+        json.buf_push(?b, ty);
     }
-    off = append(buf, off, post);
+    json.buf_push(?b, "\n```");
     if (doc != nil) {
-        off = append(buf, off, sep);
-        off = append(buf, off, doc);
+        json.buf_push(?b, "\n\n");
+        json.buf_push(?b, doc);
     }
-    buf[off] = 0;
-    ret buf::str;
+    ret buf_into_str(?b, alloc);
 }
 
 # a fenced `mach` code block rendering the symbol at hover. it
@@ -319,26 +333,17 @@ fun hover_markdown(ws: *project.Workspace, an: Analyzed, sym: *res.Symbol, uri: 
     }
     if (sig == nil) { json.free_str(doc, alloc); ret nil; }
 
-    val pre:  str = "```mach\n";
-    val post: str = "\n```";
-    val sep:  str = "\n\n";
-    var total: usize = str_len(pre) + str_len(sig) + str_len(post);
-    if (doc != nil) { total = total + str_len(sep) + str_len(doc); }
-    val r: Result[*u8, str] = allocate[u8](alloc, total + 1);
-    if (is_err[*u8, str](r)) { json.free_str(sig, alloc); json.free_str(doc, alloc); ret nil; }
-    val buf: *u8 = unwrap_ok[*u8, str](r);
-    var off: usize = 0;
-    off = append(buf, off, pre);
-    off = append(buf, off, sig);
-    off = append(buf, off, post);
+    var b: json.Buf = json.buf_init(alloc);
+    json.buf_push(?b, "```mach\n");
+    json.buf_push(?b, sig);
+    json.buf_push(?b, "\n```");
     if (doc != nil) {
-        off = append(buf, off, sep);
-        off = append(buf, off, doc);
+        json.buf_push(?b, "\n\n");
+        json.buf_push(?b, doc);
     }
-    buf[off] = 0;
     json.free_str(sig, alloc);
     json.free_str(doc, alloc);
-    ret buf::str;
+    ret buf_into_str(?b, alloc);
 }
 
 # render a declaration's first-class doc block (`Decl.doc`) as
@@ -458,16 +463,11 @@ fun compose_kind_name(sym: *res.Symbol, interner: *intern.Interner, alloc: *Allo
     val name: str = unwrap[str](no);
     val kind: str = features.kind_label(sym.kind);
 
-    val total: usize = str_len(kind) + 1 + str_len(name);
-    val r: Result[*u8, str] = allocate[u8](alloc, total + 1);
-    if (is_err[*u8, str](r)) { ret nil; }
-    val buf: *u8 = unwrap_ok[*u8, str](r);
-    var off: usize = 0;
-    off = append(buf, off, kind);
-    buf[off] = ' '; off = off + 1;
-    off = append(buf, off, name);
-    buf[off] = 0;
-    ret buf::str;
+    var b: json.Buf = json.buf_init(alloc);
+    json.buf_push(?b, kind);
+    json.buf_push_byte(?b, ' ');
+    json.buf_push(?b, name);
+    ret buf_into_str(?b, alloc);
 }
 
 # answer textDocument/definition with the Location of the resolved
@@ -480,7 +480,7 @@ pub fun definition(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Al
 
     var an: Analyzed;
     val off_o: Option[usize] = locate(ws, es, alloc, docs, params, uri, ?an);
-    if (!is_some[usize](off_o)) { reply_null(alloc, id_raw); ret; }
+    if (!is_some[usize](off_o)) { render.reply_null(alloc, id_raw); ret; }
     val offset: usize = unwrap[usize](off_o);
 
     val ro: Option[features.SymbolRef] = features.ref_at(an.a, an.rr, an.own, an.file, offset);
@@ -489,12 +489,12 @@ pub fun definition(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Al
         # field name yields no SymbolRef - fall through to the type-driven field
         # path before giving up.
         if (field_definition(ws, alloc, ?an, uri, offset, id_raw)) { ret; }
-        reply_null(alloc, id_raw); ret;
+        render.reply_null(alloc, id_raw); ret;
     }
     val sr: features.SymbolRef = unwrap[features.SymbolRef](ro);
 
     val so: Option[*res.Symbol] = features.symbol(an.rr, sr.sym_id);
-    if (!is_some[*res.Symbol](so)) { reply_null(alloc, id_raw); ret; }
+    if (!is_some[*res.Symbol](so)) { render.reply_null(alloc, id_raw); ret; }
     val sym: *res.Symbol = unwrap[*res.Symbol](so);
 
     # a module alias names a file, not a declaration: `sym.decl` is the `use`
@@ -504,24 +504,15 @@ pub fun definition(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Al
     if (module_definition(ws, an, sym, alloc, id_raw)) { ret; }
 
     val site_o: Option[project.Site] = project.site_of(ws, an.root, an.own, an.a, an.file, uri, sym);
-    if (!is_some[project.Site](site_o)) { reply_null(alloc, id_raw); ret; }
+    if (!is_some[project.Site](site_o)) { render.reply_null(alloc, id_raw); ret; }
     var site: project.Site = unwrap[project.Site](site_o);
 
     val spo: Option[token.Span] = features.definition_name_span(site.a, sym);
-    if (!is_some[token.Span](spo)) { project.free_site(ws, ?site); reply_null(alloc, id_raw); ret; }
+    if (!is_some[token.Span](spo)) { project.free_site(ws, ?site); render.reply_null(alloc, id_raw); ret; }
     val span: token.Span = unwrap[token.Span](spo);
 
-    val loc: str = location_json(site.file, site.uri, span, alloc);
+    reply_location(alloc, id_raw, site.file, site.uri, span);
     project.free_site(ws, ?site);
-    if (loc == nil) { reply_null(alloc, id_raw); ret; }
-
-    val p1: str = "{\"jsonrpc\":\"2.0\",\"id\":";
-    val p2: str = ",\"result\":";
-    val p3: str = "}";
-    send6(alloc, p1, id_raw, p2, loc, p3, nil, nil);
-
-    json.free_str(loc, alloc);
-    json.free_str(id_raw, alloc);
 }
 
 # `module <fqn>` as a fenced hover body
@@ -631,10 +622,7 @@ fun field_definition(ws: *project.Workspace, alloc: *Allocator, an: *Analyzed, u
     val self_o: Option[FieldSelf] = field_self_at(an, offset);
     if (is_some[FieldSelf](self_o)) {
         val fs: FieldSelf = unwrap[FieldSelf](self_o);
-        val loc: str = location_json(an.file, uri, fs.name, alloc);
-        if (loc == nil) { ret false; }
-        reply_result(alloc, id_raw, loc);
-        json.free_str(loc, alloc);
+        reply_location(alloc, id_raw, an.file, uri, fs.name);
         ret true;
     }
 
@@ -695,23 +683,11 @@ fun emit_field_location(ws: *project.Workspace, alloc: *Allocator, an: *Analyzed
         owned = true;
     }
 
-    val loc: str = location_json(rs.file, furi, name, alloc);
+    reply_location(alloc, id_raw, rs.file, furi, name);
     if (owned) { json.free_str(furi, ws.alloc); }
-    if (loc == nil) { ret false; }
-    reply_result(alloc, id_raw, loc);
-    json.free_str(loc, alloc);
     ret true;
 }
 
-# send a JSON-RPC success reply carrying `result` for request
-# `id_raw`. shared by the field-definition replies
-fun reply_result(alloc: *Allocator, id_raw: str, result: str) {
-    val p1: str = "{\"jsonrpc\":\"2.0\",\"id\":";
-    val p2: str = ",\"result\":";
-    val p3: str = "}";
-    send6(alloc, p1, id_raw, p2, result, p3, nil, nil);
-    json.free_str(id_raw, alloc);
-}
 
 # a record / union field resolved from a cursor, the type-driven twin
 # of a SymbolRef for the field references / rename / prepareRename paths. carries
@@ -922,7 +898,7 @@ fun field_rename(ws: *project.Workspace, alloc: *Allocator, an: *Analyzed, uri: 
     if (!is_some[FieldTarget](to)) { ret false; }
     val t: FieldTarget = unwrap[FieldTarget](to);
 
-    if (!field_record_renameable(ws, an.root, t)) { reply_empty_edit(alloc, id_raw); ret true; }
+    if (!field_record_renameable(ws, an.root, t)) { render.reply_empty_edit(alloc, id_raw); ret true; }
 
     var cap: usize = project.module_count(an.root)::usize;
     if (cap == 0) { cap = 1; }
@@ -931,7 +907,7 @@ fun field_rename(ws: *project.Workspace, alloc: *Allocator, an: *Analyzed, uri: 
     val refs: *FieldXRef = unwrap_ok[*FieldXRef, str](ra);
 
     val n: usize = build_field_refs(ws, @an, uri, t, refs, cap);
-    if (n == 0) { deallocate[FieldXRef](alloc, refs, cap); reply_empty_edit(alloc, id_raw); ret true; }
+    if (n == 0) { deallocate[FieldXRef](alloc, refs, cap); render.reply_empty_edit(alloc, id_raw); ret true; }
 
     emit_field_rename(ws, an.root, alloc, id_raw, refs, n, t, new_name);
     free_field_refs(ws, refs, n);
@@ -967,34 +943,16 @@ fun field_prepare_span(ws: *project.Workspace, an: *Analyzed, uri: str, offset: 
 # ownership of `id_raw` and frees it
 fun emit_field_locations(ws: *project.Workspace, root: *project.Root, alloc: *Allocator, id_raw: str, refs: *FieldXRef, nref: usize, t: FieldTarget) {
     val ti: *type.TypeInterner = project.type_interner(ws, root);
-    val prefix: str = "{\"jsonrpc\":\"2.0\",\"id\":";
-    val mid:    str = ",\"result\":[";
-    val suffix: str = "]}";
+    var b: json.Buf = json.buf_init(alloc);
+    render.result_begin(?b, id_raw);
+    json.buf_push_byte(?b, '[');
 
-    var k: WalkSink = sink_init(alloc, nil, nil);
-    var si: usize = 0;
-    for (si < nref) { walk_field_sites(?refs[si], ti, t, false, ?k); si = si + 1; }
+    var k: WalkSink = sink_init(?b, alloc, nil, nil);
+    var i: usize = 0;
+    for (i < nref) { walk_field_sites(?refs[i], ti, t, false, ?k); i = i + 1; }
 
-    val total: usize = str_len(prefix) + str_len(id_raw) + str_len(mid) + k.total + str_len(suffix);
-    val br: Result[*u8, str] = allocate[u8](alloc, total + 1);
-    if (is_err[*u8, str](br)) { reply_empty_array(alloc, id_raw); ret; }
-    val buf: *u8 = unwrap_ok[*u8, str](br);
-
-    var off: usize = 0;
-    off = append(buf, off, prefix);
-    off = append(buf, off, id_raw);
-    off = append(buf, off, mid);
-    k.buf   = buf;
-    k.off   = off;
-    k.count = 0;
-    var sj: usize = 0;
-    for (sj < nref) { walk_field_sites(?refs[sj], ti, t, false, ?k); sj = sj + 1; }
-    off = k.off;
-    off = append(buf, off, suffix);
-    buf[off] = 0;
-    transport.send_message(buf::str, alloc);
-    deallocate[u8](alloc, buf, total + 1);
-    json.free_str(id_raw, alloc);
+    json.buf_push_byte(?b, ']');
+    render.send(?b, alloc, id_raw);
 }
 
 # send a WorkspaceEdit renaming the field to `new_name` across
@@ -1004,90 +962,45 @@ fun emit_field_locations(ws: *project.Workspace, root: *project.Root, alloc: *Al
 # `id_raw` and frees it
 fun emit_field_rename(ws: *project.Workspace, root: *project.Root, alloc: *Allocator, id_raw: str, refs: *FieldXRef, nref: usize, t: FieldTarget, new_name: str) {
     val ti: *type.TypeInterner = project.type_interner(ws, root);
-    val qname: str = json.quote(new_name, alloc);
-    if (qname == nil) { reply_empty_edit(alloc, id_raw); ret; }
+    var b: json.Buf = json.buf_init(alloc);
+    render.result_begin(?b, id_raw);
+    json.buf_push(?b, "{\"changes\":{");
 
-    val ga: Result[*str, str] = allocate[str](alloc, nref);
-    if (is_err[*str, str](ga)) { json.free_str(qname, alloc); reply_empty_edit(alloc, id_raw); ret; }
-    val groups: *str = unwrap_ok[*str, str](ga);
-
-    val prefix: str = "{\"jsonrpc\":\"2.0\",\"id\":";
-    val mid:    str = ",\"result\":{\"changes\":{";
-    val suffix: str = "}}}";
-    var total: usize = str_len(prefix) + str_len(id_raw) + str_len(mid) + str_len(suffix);
-    var ng: usize = 0;
-    var si: usize = 0;
-    for (si < nref) {
-        val g: str = field_rename_group_json(?refs[si], ti, t, qname, alloc);
-        if (g != nil) {
-            if (ng > 0) { total = total + 1; }
-            total = total + str_len(g);
-            groups[ng] = g;
-            ng = ng + 1;
+    var emitted: usize = 0;
+    var i: usize = 0;
+    for (i < nref) {
+        if (push_field_rename_group(?b, ?refs[i], ti, t, new_name, emitted > 0, alloc)) {
+            emitted = emitted + 1;
         }
-        si = si + 1;
+        i = i + 1;
     }
 
-    val br: Result[*u8, str] = allocate[u8](alloc, total + 1);
-    if (is_err[*u8, str](br)) {
-        free_groups(groups, ng, alloc);
-        deallocate[str](alloc, groups, nref);
-        json.free_str(qname, alloc);
-        reply_empty_edit(alloc, id_raw); ret;
-    }
-    val buf: *u8 = unwrap_ok[*u8, str](br);
-
-    var off: usize = 0;
-    off = append(buf, off, prefix);
-    off = append(buf, off, id_raw);
-    off = append(buf, off, mid);
-    var gi: usize = 0;
-    for (gi < ng) {
-        if (gi > 0) { buf[off] = ','; off = off + 1; }
-        off = append(buf, off, groups[gi]);
-        gi = gi + 1;
-    }
-    off = append(buf, off, suffix);
-    buf[off] = 0;
-    transport.send_message(buf::str, alloc);
-    deallocate[u8](alloc, buf, total + 1);
-
-    free_groups(groups, ng, alloc);
-    deallocate[str](alloc, groups, nref);
-    json.free_str(qname, alloc);
-    json.free_str(id_raw, alloc);
+    json.buf_push(?b, "}}");
+    render.send(?b, alloc, id_raw);
 }
 
-# the `changes`-map entry `"<uri>":[<edits>]` for module
-# `s`, rewriting its field sites (and, for the declaring module, the declaration
-# and doc component) to the quoted `qname`, or nil when `s` contributes no edit
-fun field_rename_group_json(s: *FieldXRef, ti: *type.TypeInterner, t: FieldTarget, qname: str, alloc: *Allocator) str {
-    val quri: str = json.quote(s.uri, alloc);
-    if (quri == nil) { ret nil; }
+# append the `changes`-map entry `"<uri>":[<edits>]` for module `s`
+#
+# Rewrites that module's field sites and, for the declaring module, the field
+# declaration and the record's matching doc component. Opened speculatively and
+# rolled back when the module contributes no edit, so one walk decides and
+# writes.
+fun push_field_rename_group(b: *json.Buf, s: *FieldXRef, ti: *type.TypeInterner, t: FieldTarget,
+                            new_name: str, comma: bool, alloc: *Allocator) bool {
+    val mark: usize = json.buf_len(b);
+    if (comma) { json.buf_push_byte(b, ','); }
+    json.buf_push_quoted(b, s.uri);
+    json.buf_push(b, ":[");
 
-    var k: WalkSink = sink_init(alloc, qname, nil);
+    var k: WalkSink = sink_init(b, alloc, new_name, nil);
     walk_field_sites(s, ti, t, true, ?k);
-    if (k.count == 0) { json.free_str(quri, alloc); ret nil; }
+    if (k.count == 0) {
+        json.buf_rewind(b, mark);
+        ret false;
+    }
 
-    val open:  str = ":[";
-    val close: str = "]";
-    val total: usize = str_len(quri) + str_len(open) + k.total + str_len(close);
-    val r: Result[*u8, str] = allocate[u8](alloc, total + 1);
-    if (is_err[*u8, str](r)) { json.free_str(quri, alloc); ret nil; }
-    val buf: *u8 = unwrap_ok[*u8, str](r);
-
-    var off: usize = 0;
-    off = append(buf, off, quri);
-    off = append(buf, off, open);
-    k.buf   = buf;
-    k.off   = off;
-    k.count = 0;
-    walk_field_sites(s, ti, t, true, ?k);
-    off = k.off;
-    off = append(buf, off, close);
-    buf[off] = 0;
-    json.free_str(quri, alloc);
-    ret buf::str;
+    json.buf_push_byte(b, ']');
+    ret true;
 }
 
 # answer textDocument/references with every Location resolving to
@@ -1100,7 +1013,7 @@ pub fun references(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Al
 
     var an: Analyzed;
     val off_o: Option[usize] = locate(ws, es, alloc, docs, params, uri, ?an);
-    if (!is_some[usize](off_o)) { reply_empty_array(alloc, id_raw); ret; }
+    if (!is_some[usize](off_o)) { render.reply_empty_array(alloc, id_raw); ret; }
     val offset: usize = unwrap[usize](off_o);
 
     val ro: Option[features.SymbolRef] = features.ref_at(an.a, an.rr, an.own, an.file, offset);
@@ -1109,12 +1022,12 @@ pub fun references(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Al
         # field name yields no SymbolRef - fall through to the type-driven field
         # references before giving up.
         if (field_references(ws, alloc, ?an, uri, offset, id_raw)) { ret; }
-        reply_empty_array(alloc, id_raw); ret;
+        render.reply_empty_array(alloc, id_raw); ret;
     }
     val sr: features.SymbolRef = unwrap[features.SymbolRef](ro);
 
     val so: Option[*res.Symbol] = features.symbol(an.rr, sr.sym_id);
-    if (!is_some[*res.Symbol](so)) { reply_empty_array(alloc, id_raw); ret; }
+    if (!is_some[*res.Symbol](so)) { render.reply_empty_array(alloc, id_raw); ret; }
     val sym: *res.Symbol = unwrap[*res.Symbol](so);
 
     var bind: token.Span;
@@ -1122,7 +1035,7 @@ pub fun references(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Al
 
     val cap: usize = (project.module_count(an.root) + 1)::usize;
     val ra: Result[*XRef, str] = allocate[XRef](alloc, cap);
-    if (is_err[*XRef, str](ra)) { reply_empty_array(alloc, id_raw); ret; }
+    if (is_err[*XRef, str](ra)) { render.reply_empty_array(alloc, id_raw); ret; }
     val refs: *XRef = unwrap_ok[*XRef, str](ra);
 
     val n: usize = build_refs(ws, an, uri, sym, sr.sym_id, false, refs, cap);
@@ -1144,11 +1057,11 @@ pub fun rename(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Alloca
     if (id_raw == nil) { ret; }
 
     val new_name: str = json.text(json.member(params, "newName"), alloc);
-    if (new_name == nil) { reply_null(alloc, id_raw); ret; }
+    if (new_name == nil) { render.reply_null(alloc, id_raw); ret; }
 
     var an: Analyzed;
     val off_o: Option[usize] = locate(ws, es, alloc, docs, params, uri, ?an);
-    if (!is_some[usize](off_o)) { reply_empty_edit(alloc, id_raw); json.free_str(new_name, alloc); ret; }
+    if (!is_some[usize](off_o)) { render.reply_empty_edit(alloc, id_raw); json.free_str(new_name, alloc); ret; }
     val offset: usize = unwrap[usize](off_o);
 
     val ro: Option[features.SymbolRef] = features.ref_at(an.a, an.rr, an.own, an.file, offset);
@@ -1156,19 +1069,19 @@ pub fun rename(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Alloca
         # a cursor on a field name yields no SymbolRef - fall through to the
         # type-driven field rename, which gates on the record's ownership.
         if (field_rename(ws, alloc, ?an, uri, offset, id_raw, new_name)) { json.free_str(new_name, alloc); ret; }
-        reply_empty_edit(alloc, id_raw); json.free_str(new_name, alloc); ret;
+        render.reply_empty_edit(alloc, id_raw); json.free_str(new_name, alloc); ret;
     }
     val sr: features.SymbolRef = unwrap[features.SymbolRef](ro);
 
     val so: Option[*res.Symbol] = features.symbol(an.rr, sr.sym_id);
-    if (!is_some[*res.Symbol](so)) { reply_empty_edit(alloc, id_raw); json.free_str(new_name, alloc); ret; }
+    if (!is_some[*res.Symbol](so)) { render.reply_empty_edit(alloc, id_raw); json.free_str(new_name, alloc); ret; }
     val sym: *res.Symbol = unwrap[*res.Symbol](so);
-    if (!renameable(ws, an.root, sym)) { reply_empty_edit(alloc, id_raw); json.free_str(new_name, alloc); ret; }
+    if (!renameable(ws, an.root, sym)) { render.reply_empty_edit(alloc, id_raw); json.free_str(new_name, alloc); ret; }
 
     # the declared name guards the cross-file walk: only occurrences spelled with
     # it are rewritten, so an aliased import's references are left untouched
     val no: Option[str] = intern.lookup(an.interner, sym.name);
-    if (!is_some[str](no)) { reply_empty_edit(alloc, id_raw); json.free_str(new_name, alloc); ret; }
+    if (!is_some[str](no)) { render.reply_empty_edit(alloc, id_raw); json.free_str(new_name, alloc); ret; }
     val name: str = unwrap[str](no);
 
     var bind: token.Span;
@@ -1184,7 +1097,7 @@ pub fun rename(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Alloca
     var cap: usize = project.module_count(an.root)::usize;
     if (cap == 0) { cap = 1; }
     val ra: Result[*XRef, str] = allocate[XRef](alloc, cap);
-    if (is_err[*XRef, str](ra)) { reply_empty_edit(alloc, id_raw); json.free_str(new_name, alloc); ret; }
+    if (is_err[*XRef, str](ra)) { render.reply_empty_edit(alloc, id_raw); json.free_str(new_name, alloc); ret; }
     val refs: *XRef = unwrap_ok[*XRef, str](ra);
 
     val n: usize = build_refs(ws, an, uri, sym, sr.sym_id, true, refs, cap);
@@ -1229,7 +1142,7 @@ pub fun prepare_rename(ws: *project.Workspace, es: *editor.EditorSession, alloc:
 
     var an: Analyzed;
     val off_o: Option[usize] = locate(ws, es, alloc, docs, params, uri, ?an);
-    if (!is_some[usize](off_o)) { reply_null(alloc, id_raw); ret; }
+    if (!is_some[usize](off_o)) { render.reply_null(alloc, id_raw); ret; }
     val offset: usize = unwrap[usize](off_o);
 
     val ro: Option[features.SymbolRef] = features.ref_at(an.a, an.rr, an.own, an.file, offset);
@@ -1240,28 +1153,17 @@ pub fun prepare_rename(ws: *project.Workspace, es: *editor.EditorSession, alloc:
         if (field_prepare_span(ws, ?an, uri, offset, ?name_span)) {
             reply_range(alloc, id_raw, an.file, name_span); ret;
         }
-        reply_null(alloc, id_raw); ret;
+        render.reply_null(alloc, id_raw); ret;
     }
     val sr: features.SymbolRef = unwrap[features.SymbolRef](ro);
 
     val so: Option[*res.Symbol] = features.symbol(an.rr, sr.sym_id);
-    if (!is_some[*res.Symbol](so)) { reply_null(alloc, id_raw); ret; }
-    if (!renameable(ws, an.root, unwrap[*res.Symbol](so))) { reply_null(alloc, id_raw); ret; }
+    if (!is_some[*res.Symbol](so)) { render.reply_null(alloc, id_raw); ret; }
+    if (!renameable(ws, an.root, unwrap[*res.Symbol](so))) { render.reply_null(alloc, id_raw); ret; }
 
     reply_range(alloc, id_raw, an.file, sr.name_span);
 }
 
-# send a prepareRename success reply carrying the range of `span` in
-# `file`, freeing `id_raw`. shared by the symbol and field prepare paths
-fun reply_range(alloc: *Allocator, id_raw: str, file: *src.SourceFile, span: token.Span) {
-    val rng: str = range_json(positions.range_of(file, span), alloc);
-    val p1: str = "{\"jsonrpc\":\"2.0\",\"id\":";
-    val p2: str = ",\"result\":";
-    val p3: str = "}";
-    send6(alloc, p1, id_raw, p2, rng, p3, nil, nil);
-    json.free_str(rng, alloc);
-    json.free_str(id_raw, alloc);
-}
 
 # answer textDocument/documentSymbol with a flat list of the
 # file's top-level declarations as DocumentSymbol nodes (name, kind, range,
@@ -1271,11 +1173,11 @@ pub fun document_symbol(es: *editor.EditorSession, alloc: *Allocator, docs: *doc
     if (id_raw == nil) { ret; }
 
     val d: *documents.Document = documents.find(docs, uri);
-    if (d == nil) { reply_empty_array(alloc, id_raw); ret; }
+    if (d == nil) { render.reply_empty_array(alloc, id_raw); ret; }
     val ar: Result[*ast.Ast, str] = editor.parse(es, d.file_id);
-    if (is_err[*ast.Ast, str](ar)) { reply_empty_array(alloc, id_raw); ret; }
+    if (is_err[*ast.Ast, str](ar)) { render.reply_empty_array(alloc, id_raw); ret; }
     val fo: Option[*src.SourceFile] = src.get(?es.s.sources, d.file_id);
-    if (!is_some[*src.SourceFile](fo)) { reply_empty_array(alloc, id_raw); ret; }
+    if (!is_some[*src.SourceFile](fo)) { render.reply_empty_array(alloc, id_raw); ret; }
     var an: Analyzed;
     an.a = unwrap_ok[*ast.Ast, str](ar);
     an.file = unwrap[*src.SourceFile](fo);
@@ -1513,41 +1415,44 @@ fun locate(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator,
 # references while references reports them. `count` sequences the separating
 # commas across everything fed to the sink
 rec WalkSink {
-    alloc: *Allocator;
-    buf:   *u8;
-    off:   usize;
-    total: usize;
-    count: usize;
-    qname: str;
-    guard: str;
+    b:        *json.Buf;
+    alloc:    *Allocator;
+    count:    usize;
+    new_text: str;
+    guard:    str;
 }
 
-# a sizing WalkSink; point `buf` at the output (and reset `count`)
-# to switch it to the write pass
-fun sink_init(alloc: *Allocator, qname: str, guard: str) WalkSink {
+# a sink appending into `b`
+#
+# `new_text` nil emits Location entries; non-nil emits TextEdit entries
+# replacing each span with that (unquoted) text. `guard`, when non-nil, drops
+# body spans not spelled exactly `guard`, so rename skips alias-spelled
+# references while references reports them. There is no sizing mode: one walk
+# writes, so the size and the content cannot disagree.
+# ---
+# b:        buffer to append into
+# alloc:    request allocator
+# new_text: replacement text for TextEdit mode, or nil for Locations
+# guard:    required spelling for body spans, or nil to admit all
+# ret:      an empty sink
+fun sink_init(b: *json.Buf, alloc: *Allocator, new_text: str, guard: str) WalkSink {
     var k: WalkSink;
-    k.alloc = alloc;
-    k.buf   = nil;
-    k.off   = 0;
-    k.total = 0;
-    k.count = 0;
-    k.qname = qname;
-    k.guard = guard;
+    k.b        = b;
+    k.alloc    = alloc;
+    k.count    = 0;
+    k.new_text = new_text;
+    k.guard    = guard;
     ret k;
 }
 
-# size or write one Location / TextEdit for `span` in `file` (located
-# at `uri`), per the sink's mode. taking `file` / `uri` rather than a source
-# record lets the symbol walk (XRef) and the field walk (FieldXRef) share it
+# append one Location or TextEdit for `span` in `file` (located at `uri`)
+#
+# Taking `file` / `uri` rather than a source record lets the symbol walk (XRef)
+# and the field walk (FieldXRef) share it.
 fun sink_emit(k: *WalkSink, file: *src.SourceFile, uri: str, span: token.Span) {
-    if (k.qname == nil) {
-        if (k.buf == nil) { k.total = k.total + loc_len(file, uri, span, k.alloc, k.count); }
-        or                { k.off   = put_loc(k.buf, k.off, file, uri, span, k.alloc, k.count); }
-    }
-    or {
-        if (k.buf == nil) { k.total = k.total + edit_len(file, span, k.qname, k.alloc, k.count); }
-        or                { k.off   = put_edit(k.buf, k.off, file, span, k.qname, k.alloc, k.count); }
-    }
+    if (k.count > 0) { json.buf_push_byte(k.b, ','); }
+    if (k.new_text == nil) { render.location(k.b, file, uri, span); }
+    or                     { render.text_edit(k.b, file, span, k.new_text); }
     k.count = k.count + 1;
 }
 
@@ -1595,37 +1500,17 @@ fun guard_admits(s: *XRef, k: *WalkSink, span: token.Span) bool {
 # `refs[0]`'s and is included when `has_bind`. takes ownership of `id_raw` and
 # frees it
 fun emit_locations(alloc: *Allocator, id_raw: str, refs: *XRef, nref: usize, bind: token.Span, has_bind: bool) {
-    val prefix: str = "{\"jsonrpc\":\"2.0\",\"id\":";
-    val mid:    str = ",\"result\":[";
-    val suffix: str = "]}";
-
     var empty: token.Span;
-    var k: WalkSink = sink_init(alloc, nil, nil);
-    var si: usize = 0;
-    for (si < nref) { walk_refs(?refs[si], si == 0 && has_bind, bind, false, empty, ?k); si = si + 1; }
+    var b: json.Buf = json.buf_init(alloc);
+    render.result_begin(?b, id_raw);
+    json.buf_push_byte(?b, '[');
 
-    val total: usize = str_len(prefix) + str_len(id_raw) + str_len(mid) + k.total + str_len(suffix);
-    val br: Result[*u8, str] = allocate[u8](alloc, total + 1);
-    if (is_err[*u8, str](br)) { reply_empty_array(alloc, id_raw); ret; }
-    val buf: *u8 = unwrap_ok[*u8, str](br);
+    var k: WalkSink = sink_init(?b, alloc, nil, nil);
+    var i: usize = 0;
+    for (i < nref) { walk_refs(?refs[i], i == 0 && has_bind, bind, false, empty, ?k); i = i + 1; }
 
-    var off: usize = 0;
-    off = append(buf, off, prefix);
-    off = append(buf, off, id_raw);
-    off = append(buf, off, mid);
-
-    k.buf   = buf;
-    k.off   = off;
-    k.count = 0;
-    var sj: usize = 0;
-    for (sj < nref) { walk_refs(?refs[sj], sj == 0 && has_bind, bind, false, empty, ?k); sj = sj + 1; }
-    off = k.off;
-
-    off = append(buf, off, suffix);
-    buf[off] = 0;
-    transport.send_message(buf::str, alloc);
-    deallocate[u8](alloc, buf, total + 1);
-    json.free_str(id_raw, alloc);
+    json.buf_push_byte(?b, ']');
+    render.send(?b, alloc, id_raw);
 }
 
 # send a WorkspaceEdit renaming the symbol to `new_name` across the
@@ -1636,58 +1521,22 @@ fun emit_locations(alloc: *Allocator, id_raw: str, refs: *XRef, nref: usize, bin
 # owning decl's matching doc-component name token when `has_doc`. takes ownership
 # of `id_raw` and frees it
 fun emit_rename(alloc: *Allocator, id_raw: str, refs: *XRef, nref: usize, new_name: str, name: str, bind: token.Span, has_bind: bool, doc: token.Span, has_doc: bool) {
-    val qname: str = json.quote(new_name, alloc);
-    if (qname == nil) { reply_empty_edit(alloc, id_raw); ret; }
+    var b: json.Buf = json.buf_init(alloc);
+    render.result_begin(?b, id_raw);
+    json.buf_push(?b, "{\"changes\":{");
 
-    val ga: Result[*str, str] = allocate[str](alloc, nref);
-    if (is_err[*str, str](ga)) { json.free_str(qname, alloc); reply_empty_edit(alloc, id_raw); ret; }
-    val groups: *str = unwrap_ok[*str, str](ga);
-
-    val prefix: str = "{\"jsonrpc\":\"2.0\",\"id\":";
-    val mid:    str = ",\"result\":{\"changes\":{";
-    val suffix: str = "}}}";
-    var total: usize = str_len(prefix) + str_len(id_raw) + str_len(mid) + str_len(suffix);
-    var ng: usize = 0;
-    var si: usize = 0;
-    for (si < nref) {
-        val g: str = rename_group_json(?refs[si], si == 0 && has_bind, bind, si == 0 && has_doc, doc, name, qname, alloc);
-        if (g != nil) {
-            if (ng > 0) { total = total + 1; }
-            total = total + str_len(g);
-            groups[ng] = g;
-            ng = ng + 1;
+    var emitted: usize = 0;
+    var i: usize = 0;
+    for (i < nref) {
+        if (push_rename_group(?b, ?refs[i], i == 0 && has_bind, bind, i == 0 && has_doc, doc,
+                              name, new_name, emitted > 0, alloc)) {
+            emitted = emitted + 1;
         }
-        si = si + 1;
+        i = i + 1;
     }
 
-    val br: Result[*u8, str] = allocate[u8](alloc, total + 1);
-    if (is_err[*u8, str](br)) {
-        free_groups(groups, ng, alloc);
-        deallocate[str](alloc, groups, nref);
-        json.free_str(qname, alloc);
-        reply_empty_edit(alloc, id_raw); ret;
-    }
-    val buf: *u8 = unwrap_ok[*u8, str](br);
-
-    var off: usize = 0;
-    off = append(buf, off, prefix);
-    off = append(buf, off, id_raw);
-    off = append(buf, off, mid);
-    var gi: usize = 0;
-    for (gi < ng) {
-        if (gi > 0) { buf[off] = ','; off = off + 1; }
-        off = append(buf, off, groups[gi]);
-        gi = gi + 1;
-    }
-    off = append(buf, off, suffix);
-    buf[off] = 0;
-    transport.send_message(buf::str, alloc);
-    deallocate[u8](alloc, buf, total + 1);
-
-    free_groups(groups, ng, alloc);
-    deallocate[str](alloc, groups, nref);
-    json.free_str(qname, alloc);
-    json.free_str(id_raw, alloc);
+    json.buf_push(?b, "}}");
+    render.send(?b, alloc, id_raw);
 }
 
 # the `changes`-map entry `"<uri>":[<edits>]` for source `s`,
@@ -1696,41 +1545,29 @@ fun emit_rename(alloc: *Allocator, id_raw: str, refs: *XRef, nref: usize, new_na
 # nil when `s` contributes no edit. the active buffer's param / generic binding is
 # included when `include_bind` and its owning decl's doc-component name token when
 # `include_doc`
-fun rename_group_json(s: *XRef, include_bind: bool, bind: token.Span, include_doc: bool, doc: token.Span, name: str, qname: str, alloc: *Allocator) str {
-    if (s.target == res.SYMBOL_NIL) { ret nil; }
-    val quri: str = json.quote(s.uri, alloc);
-    if (quri == nil) { ret nil; }
+fun push_rename_group(b: *json.Buf, s: *XRef, include_bind: bool, bind: token.Span,
+                      include_doc: bool, doc: token.Span, name: str, new_name: str,
+                      comma: bool, alloc: *Allocator) bool {
+    if (s.target == res.SYMBOL_NIL) { ret false; }
 
-    var k: WalkSink = sink_init(alloc, qname, name);
+    # a file's edits are only known to be empty once walked, so open the entry
+    # speculatively and roll the buffer back when the walk contributes nothing
+    val mark: usize = json.buf_len(b);
+    if (comma) { json.buf_push_byte(b, ','); }
+    json.buf_push_quoted(b, s.uri);
+    json.buf_push(b, ":[");
+
+    var k: WalkSink = sink_init(b, alloc, new_name, name);
     walk_refs(s, include_bind, bind, include_doc, doc, ?k);
-    if (k.count == 0) { json.free_str(quri, alloc); ret nil; }
+    if (k.count == 0) {
+        json.buf_rewind(b, mark);
+        ret false;
+    }
 
-    val open:  str = ":[";
-    val close: str = "]";
-    val total: usize = str_len(quri) + str_len(open) + k.total + str_len(close);
-    val r: Result[*u8, str] = allocate[u8](alloc, total + 1);
-    if (is_err[*u8, str](r)) { json.free_str(quri, alloc); ret nil; }
-    val buf: *u8 = unwrap_ok[*u8, str](r);
-
-    var off: usize = 0;
-    off = append(buf, off, quri);
-    off = append(buf, off, open);
-    k.buf   = buf;
-    k.off   = off;
-    k.count = 0;
-    walk_refs(s, include_bind, bind, include_doc, doc, ?k);
-    off = k.off;
-    off = append(buf, off, close);
-    buf[off] = 0;
-    json.free_str(quri, alloc);
-    ret buf::str;
+    json.buf_push_byte(b, ']');
+    ret true;
 }
 
-# free the first `n` owned changes-map entry strings in `groups`
-fun free_groups(groups: *str, n: usize, alloc: *Allocator) {
-    var i: usize = 0;
-    for (i < n) { json.free_str(groups[i], alloc); i = i + 1; }
-}
 
 # send a DocumentSymbol[] of the file's top-level decls.
 # takes ownership of `id_raw` and frees it
@@ -1753,7 +1590,7 @@ fun emit_document_symbols(an: Analyzed, alloc: *Allocator, id_raw: str) {
     json.buf_push(?b, "]}");
     val msg: str = json.buf_str(?b);
     if (msg != nil) { transport.send_message(msg, alloc); }
-    or { reply_empty_array(alloc, id_raw); json.buf_dnit(?b); ret; }
+    or { render.reply_empty_array(alloc, id_raw); json.buf_dnit(?b); ret; }
     json.buf_dnit(?b);
     json.free_str(id_raw, alloc);
 }
@@ -1792,9 +1629,9 @@ fun push_doc_symbol(b: *json.Buf, an: Analyzed, did: id.DeclId, comma: bool, all
     json.buf_push(b, ",\"kind\":");
     json.buf_push_i64(b, decl_lsp_kind(d.kind));
     json.buf_push(b, ",\"range\":");
-    push_range_value(b, positions.range_of(an.file, d.span));
+    render.span_range(b, an.file, d.span);
     json.buf_push(b, ",\"selectionRange\":");
-    push_range_value(b, positions.range_of(an.file, name_span));
+    render.span_range(b, an.file, name_span);
     push_doc_symbol_children(b, an, d, alloc);
     json.buf_push_byte(b, '}');
     ret true;
@@ -1887,25 +1724,13 @@ fun push_member_symbol(b: *json.Buf, an: Analyzed, name_span: token.Span, ty: id
     json.buf_push(b, ",\"kind\":");
     json.buf_push_i64(b, kind);
     json.buf_push(b, ",\"range\":");
-    push_range_value(b, positions.range_of(an.file, name_span));
+    render.span_range(b, an.file, name_span);
     json.buf_push(b, ",\"selectionRange\":");
-    push_range_value(b, positions.range_of(an.file, name_span));
+    render.span_range(b, an.file, name_span);
     json.buf_push_byte(b, '}');
     ret true;
 }
 
-# append a `{start,end}` LSP Range object
-fun push_range_value(b: *json.Buf, range: positions.LspRange) {
-    json.buf_push(b, "{\"start\":{\"line\":");
-    json.buf_push_usize(b, range.start_line);
-    json.buf_push(b, ",\"character\":");
-    json.buf_push_usize(b, range.start_char);
-    json.buf_push(b, "},\"end\":{\"line\":");
-    json.buf_push_usize(b, range.end_line);
-    json.buf_push(b, ",\"character\":");
-    json.buf_push_usize(b, range.end_char);
-    json.buf_push(b, "}}");
-}
 
 # LSP CompletionItemKind for a record or union field
 val LSP_COMPLETION_FIELD: i64 = 5;
@@ -2127,238 +1952,17 @@ fun completion_first(an: Analyzed, sid: res.SymbolId) bool {
     ret true;
 }
 
-# render symbol `sid` as a CompletionItem, or nil
-fun completion_json(an: Analyzed, sid: res.SymbolId, alloc: *Allocator) str {
-    val sym: *res.Symbol = ?an.rr.symbols[sid];
-    val no: Option[str] = intern.lookup(an.interner, sym.name);
-    if (!is_some[str](no)) { ret nil; }
-    val qname: str = json.quote(unwrap[str](no), alloc);
-    if (qname == nil) { ret nil; }
 
-    val kind: i64 = features.lsp_completion_kind(sym.kind);
-    val kstr: str = json.format_i64(kind, alloc);
-    val qdetail: str = json.quote(features.kind_label(sym.kind), alloc);
 
-    val p1: str = "{\"label\":";
-    val p2: str = ",\"kind\":";
-    val p3: str = ",\"detail\":";
-    val p4: str = "}";
-    val total: usize = str_len(p1) + slen(qname) + str_len(p2) + slen(kstr) + str_len(p3) + slen(qdetail) + str_len(p4);
 
-    val r: Result[*u8, str] = allocate[u8](alloc, total + 1);
-    if (is_err[*u8, str](r)) {
-        json.free_str(qname, alloc); json.free_str(kstr, alloc); json.free_str(qdetail, alloc);
-        ret nil;
-    }
-    val buf: *u8 = unwrap_ok[*u8, str](r);
-    var off: usize = 0;
-    off = append(buf, off, p1);
-    off = append(buf, off, qname);
-    off = append(buf, off, p2);
-    off = append(buf, off, kstr);
-    off = append(buf, off, p3);
-    off = append(buf, off, qdetail);
-    off = append(buf, off, p4);
-    buf[off] = 0;
 
-    json.free_str(qname, alloc);
-    json.free_str(kstr, alloc);
-    json.free_str(qdetail, alloc);
-    ret buf::str;
-}
 
-# a Location object `{ uri, range }` for a span, or nil
-fun location_json(file: *src.SourceFile, uri: str, span: token.Span, alloc: *Allocator) str {
-    val quri: str = json.quote(uri, alloc);
-    if (quri == nil) { ret nil; }
-    val rng: str = range_json(positions.range_of(file, span), alloc);
 
-    val p1: str = "{\"uri\":";
-    val p2: str = ",\"range\":";
-    val p3: str = "}";
-    val total: usize = str_len(p1) + slen(quri) + str_len(p2) + slen(rng) + str_len(p3);
 
-    val r: Result[*u8, str] = allocate[u8](alloc, total + 1);
-    if (is_err[*u8, str](r)) { json.free_str(quri, alloc); json.free_str(rng, alloc); ret nil; }
-    val buf: *u8 = unwrap_ok[*u8, str](r);
-    var off: usize = 0;
-    off = append(buf, off, p1);
-    off = append(buf, off, quri);
-    off = append(buf, off, p2);
-    off = append(buf, off, rng);
-    off = append(buf, off, p3);
-    buf[off] = 0;
 
-    json.free_str(quri, alloc);
-    json.free_str(rng, alloc);
-    ret buf::str;
-}
 
-# a `{ start: {...}, end: {...} }` range object, or nil
-fun range_json(range: positions.LspRange, alloc: *Allocator) str {
-    val sl: str = json.format_usize(range.start_line, alloc);
-    val sc: str = json.format_usize(range.start_char, alloc);
-    val el: str = json.format_usize(range.end_line, alloc);
-    val ec: str = json.format_usize(range.end_char, alloc);
 
-    val p1: str = "{\"start\":{\"line\":";
-    val p2: str = ",\"character\":";
-    val p3: str = "},\"end\":{\"line\":";
-    val p4: str = ",\"character\":";
-    val p5: str = "}}";
-    val total: usize = str_len(p1) + slen(sl) + str_len(p2) + slen(sc) + str_len(p3) + slen(el) + str_len(p4) + slen(ec) + str_len(p5);
 
-    val r: Result[*u8, str] = allocate[u8](alloc, total + 1);
-    if (is_err[*u8, str](r)) { free4(sl, sc, el, ec, alloc); ret nil; }
-    val buf: *u8 = unwrap_ok[*u8, str](r);
-    var off: usize = 0;
-    off = append(buf, off, p1);
-    off = append(buf, off, sl);
-    off = append(buf, off, p2);
-    off = append(buf, off, sc);
-    off = append(buf, off, p3);
-    off = append(buf, off, el);
-    off = append(buf, off, p4);
-    off = append(buf, off, ec);
-    off = append(buf, off, p5);
-    buf[off] = 0;
 
-    free4(sl, sc, el, ec, alloc);
-    ret buf::str;
-}
 
-# the JSON length one Location entry adds (plus a separating comma when
-# it is not the first), without retaining the rendering
-fun loc_len(file: *src.SourceFile, uri: str, span: token.Span, alloc: *Allocator, index: usize) usize {
-    val loc: str = location_json(file, uri, span, alloc);
-    if (loc == nil) { ret 0; }
-    var n: usize = str_len(loc);
-    if (index > 0) { n = n + 1; }
-    json.free_str(loc, alloc);
-    ret n;
-}
 
-# write one Location entry (comma-separated) into `buf`, returning the
-# new offset
-fun put_loc(buf: *u8, off: usize, file: *src.SourceFile, uri: str, span: token.Span, alloc: *Allocator, index: usize) usize {
-    val loc: str = location_json(file, uri, span, alloc);
-    if (loc == nil) { ret off; }
-    var o: usize = off;
-    if (index > 0) { buf[o] = ','; o = o + 1; }
-    o = append(buf, o, loc);
-    json.free_str(loc, alloc);
-    ret o;
-}
-
-# the JSON length one TextEdit adds (plus a separating comma when not
-# first), without retaining the rendering
-fun edit_len(file: *src.SourceFile, span: token.Span, qname: str, alloc: *Allocator, index: usize) usize {
-    val ed: str = text_edit_json(file, span, qname, alloc);
-    if (ed == nil) { ret 0; }
-    var n: usize = str_len(ed);
-    if (index > 0) { n = n + 1; }
-    json.free_str(ed, alloc);
-    ret n;
-}
-
-# write one TextEdit entry (comma-separated) into `buf`
-fun put_edit(buf: *u8, off: usize, file: *src.SourceFile, span: token.Span, qname: str, alloc: *Allocator, index: usize) usize {
-    val ed: str = text_edit_json(file, span, qname, alloc);
-    if (ed == nil) { ret off; }
-    var o: usize = off;
-    if (index > 0) { buf[o] = ','; o = o + 1; }
-    o = append(buf, o, ed);
-    json.free_str(ed, alloc);
-    ret o;
-}
-
-# a `{ range, newText }` TextEdit replacing a span's range with
-# the already-quoted `qname`, or nil
-fun text_edit_json(file: *src.SourceFile, span: token.Span, qname: str, alloc: *Allocator) str {
-    val rng: str = range_json(positions.range_of(file, span), alloc);
-    if (rng == nil) { ret nil; }
-
-    val p1: str = "{\"range\":";
-    val p2: str = ",\"newText\":";
-    val p3: str = "}";
-    val total: usize = str_len(p1) + slen(rng) + str_len(p2) + slen(qname) + str_len(p3);
-
-    val r: Result[*u8, str] = allocate[u8](alloc, total + 1);
-    if (is_err[*u8, str](r)) { json.free_str(rng, alloc); ret nil; }
-    val buf: *u8 = unwrap_ok[*u8, str](r);
-    var off: usize = 0;
-    off = append(buf, off, p1);
-    off = append(buf, off, rng);
-    off = append(buf, off, p2);
-    off = append(buf, off, qname);
-    off = append(buf, off, p3);
-    buf[off] = 0;
-
-    json.free_str(rng, alloc);
-    ret buf::str;
-}
-
-# send a `result: null` response for the request id
-fun reply_null(alloc: *Allocator, id_raw: str) {
-    val p1: str = "{\"jsonrpc\":\"2.0\",\"id\":";
-    val p2: str = ",\"result\":null}";
-    send6(alloc, p1, id_raw, p2, nil, nil, nil, nil);
-    json.free_str(id_raw, alloc);
-}
-
-# send a `result: []` response for the request id
-fun reply_empty_array(alloc: *Allocator, id_raw: str) {
-    val p1: str = "{\"jsonrpc\":\"2.0\",\"id\":";
-    val p2: str = ",\"result\":[]}";
-    send6(alloc, p1, id_raw, p2, nil, nil, nil, nil);
-    json.free_str(id_raw, alloc);
-}
-
-# send an empty WorkspaceEdit (`changes: {}`) for the id
-fun reply_empty_edit(alloc: *Allocator, id_raw: str) {
-    val p1: str = "{\"jsonrpc\":\"2.0\",\"id\":";
-    val p2: str = ",\"result\":{\"changes\":{}}}";
-    send6(alloc, p1, id_raw, p2, nil, nil, nil, nil);
-    json.free_str(id_raw, alloc);
-}
-
-# frame and send the concatenation of up to six fragments (nil skipped)
-fun send6(alloc: *Allocator, a: str, b: str, c: str, d: str, e: str, f: str, g: str) {
-    val total: usize = slen(a) + slen(b) + slen(c) + slen(d) + slen(e) + slen(f) + slen(g);
-    val r: Result[*u8, str] = allocate[u8](alloc, total + 1);
-    if (is_err[*u8, str](r)) { ret; }
-    val buf: *u8 = unwrap_ok[*u8, str](r);
-    var off: usize = 0;
-    off = append(buf, off, a);
-    off = append(buf, off, b);
-    off = append(buf, off, c);
-    off = append(buf, off, d);
-    off = append(buf, off, e);
-    off = append(buf, off, f);
-    off = append(buf, off, g);
-    buf[off] = 0;
-    transport.send_message(buf::str, alloc);
-    deallocate[u8](alloc, buf, total + 1);
-}
-
-# length of `s`, treating nil as 0
-fun slen(s: str) usize {
-    if (s == nil) { ret 0; }
-    ret str_len(s);
-}
-
-# copy `s` into `buf` at `offset`, returning the new offset
-fun append(buf: *u8, offset: usize, s: str) usize {
-    if (s == nil) { ret offset; }
-    val n: usize = str_len(s);
-    if (n > 0) { mem.raw_copy((buf::usize + offset)::ptr, s::ptr, n); }
-    ret offset + n;
-}
-
-# free four owned strings
-fun free4(a: str, b: str, c: str, d: str, alloc: *Allocator) {
-    json.free_str(a, alloc);
-    json.free_str(b, alloc);
-    json.free_str(c, alloc);
-    json.free_str(d, alloc);
-}

--- a/src/render.mach
+++ b/src/render.mach
@@ -1,0 +1,243 @@
+# the LSP value emit layer: one spelling per protocol value
+#
+# Every feature answers with the same handful of LSP shapes - a Range, a
+# Location, a TextEdit, a response envelope - and each one used to be spelled
+# wherever it was needed. That produced two problems worth naming.
+#
+# The first is duplication: a Location was rendered by `location_json` for
+# definition, again inside `loc_len` to measure a references entry, and a third
+# time inside `put_loc` to write it. The second is the pattern that duplication
+# forced. A payload whose shape is data-dependent cannot be sized by summing
+# constants, so the emitters ran the whole traversal twice - once with the
+# output pointer nil to total lengths, once pointed at an exact allocation to
+# fill it - and the two passes had to agree exactly. When they did not, the
+# buffer was under-filled, `str_len` truncated the frame at the resulting NUL,
+# and the client saw a valid Content-Length over a body that stopped mid-token.
+# Silent, and shaped like a transport fault rather than a rendering one.
+#
+# `json.Buf` removes the sizing pass, so these are all single-traversal
+# appenders. A failed allocation latches on the buffer and `json.buf_str`
+# answers nil, so a response is either complete or absent - never truncated.
+
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.size.usize;
+use std.types.string.str;
+
+use std.allocator.Allocator;
+
+use src:   mach.lang.source;
+use token: mach.lang.fe.token;
+
+use json:      mls.json;
+use positions: mls.positions;
+use transport: mls.transport;
+
+# append an LSP Range
+# ---
+# b: output buffer
+# r: the range to emit
+pub fun range(b: *json.Buf, r: positions.LspRange) {
+    json.buf_push(b, "{\"start\":{\"line\":");
+    json.buf_push_usize(b, r.start_line);
+    json.buf_push(b, ",\"character\":");
+    json.buf_push_usize(b, r.start_char);
+    json.buf_push(b, "},\"end\":{\"line\":");
+    json.buf_push_usize(b, r.end_line);
+    json.buf_push(b, ",\"character\":");
+    json.buf_push_usize(b, r.end_char);
+    json.buf_push(b, "}}");
+}
+
+# append an LSP Range for a byte span in `file`
+# ---
+# b:    output buffer
+# file: source file the span indexes
+# span: byte span to convert
+pub fun span_range(b: *json.Buf, file: *src.SourceFile, span: token.Span) {
+    range(b, positions.range_of(file, span));
+}
+
+# append an LSP Location: a document URI and a range within it
+# ---
+# b:    output buffer
+# file: source file backing the span
+# uri:  document URI of `file`
+# span: byte span to report
+pub fun location(b: *json.Buf, file: *src.SourceFile, uri: str, span: token.Span) {
+    json.buf_push(b, "{\"uri\":");
+    json.buf_push_quoted(b, uri);
+    json.buf_push(b, ",\"range\":");
+    span_range(b, file, span);
+    json.buf_push_byte(b, '}');
+}
+
+# append an LSP TextEdit replacing `span` with `new_text`
+# ---
+# b:        output buffer
+# file:     source file backing the span
+# span:     byte span to replace
+# new_text: replacement text, quoted and escaped here
+pub fun text_edit(b: *json.Buf, file: *src.SourceFile, span: token.Span, new_text: str) {
+    json.buf_push(b, "{\"range\":");
+    span_range(b, file, span);
+    json.buf_push(b, ",\"newText\":");
+    json.buf_push_quoted(b, new_text);
+    json.buf_push_byte(b, '}');
+}
+
+# begin a successful JSON-RPC response, leaving `result` open for the caller
+#
+# `id_raw` is the request's id token, already spelled with its wire type.
+# ---
+# b:      output buffer
+# id_raw: the request id token
+pub fun result_begin(b: *json.Buf, id_raw: str) {
+    json.buf_push(b, "{\"jsonrpc\":\"2.0\",\"id\":");
+    json.buf_push(b, id_raw);
+    json.buf_push(b, ",\"result\":");
+}
+
+# close a response, frame and send it, then release the buffer and the id
+#
+# A buffer that latched an allocation failure sends nothing rather than a
+# partial frame; the request then goes unanswered, which the caller must avoid
+# by checking `json.buf_str` itself when it needs a guaranteed reply.
+# ---
+# b:      the buffer holding a complete response
+# alloc:  allocator backing the buffer and the id
+# id_raw: the request id token, released here
+pub fun send(b: *json.Buf, alloc: *Allocator, id_raw: str) {
+    json.buf_push_byte(b, '}');
+    val msg: str = json.buf_str(b);
+    if (msg != nil) { transport.send_message(msg, alloc); }
+    json.buf_dnit(b);
+    json.free_str(id_raw, alloc);
+}
+
+# reply with a bare `result` value already spelled as JSON text
+# ---
+# alloc:  request allocator
+# id_raw: the request id token, consumed
+# value:  the literal result text, e.g. `null` or `[]`
+pub fun reply_literal(alloc: *Allocator, id_raw: str, value: str) {
+    var b: json.Buf = json.buf_init(alloc);
+    result_begin(?b, id_raw);
+    json.buf_push(?b, value);
+    send(?b, alloc, id_raw);
+}
+
+# reply `null`, the LSP "nothing here" answer for a positional request
+pub fun reply_null(alloc: *Allocator, id_raw: str) {
+    reply_literal(alloc, id_raw, "null");
+}
+
+# reply with an empty array
+pub fun reply_empty_array(alloc: *Allocator, id_raw: str) {
+    reply_literal(alloc, id_raw, "[]");
+}
+
+# reply with a WorkspaceEdit that changes nothing
+#
+# An empty `changes` map rather than null: a rename that finds nothing to
+# rewrite has succeeded at renaming nothing, and null would read as an error.
+pub fun reply_empty_edit(alloc: *Allocator, id_raw: str) {
+    reply_literal(alloc, id_raw, "{\"changes\":{}}");
+}
+
+use page: std.allocator.page;
+use std.types.string.str_equals;
+
+# a SourceFile over `text` with a real line index
+#
+# `src.position` binary-searches `line_starts` and reads `line_starts[lo - 1]`,
+# so a stub without one is a nil dereference rather than a degenerate result.
+# `starts` must hold the byte offset of every line, `0` first.
+fun stub_file(text: str, starts: *usize, nlines: usize) src.SourceFile {
+    var f: src.SourceFile;
+    f.path        = "stub.mach";
+    f.text        = text;
+    f.line_starts = starts;
+    f.line_len    = nlines;
+    ret f;
+}
+
+fun span_at(offset: usize, len: usize) token.Span {
+    var s: token.Span;
+    s.offset = offset;
+    s.len    = len;
+    ret s;
+}
+
+test "render: a range spells both endpoints" {
+    var pa: Allocator;
+    page.make(?pa);
+    var b: json.Buf = json.buf_init(?pa);
+    var r: positions.LspRange;
+    r.start_line = 2; r.start_char = 4; r.end_line = 2; r.end_char = 9;
+    range(?b, r);
+    var fail: bool = false;
+    if (!str_equals(json.buf_str(?b),
+        "{\"start\":{\"line\":2,\"character\":4},\"end\":{\"line\":2,\"character\":9}}")) { fail = true; }
+    json.buf_dnit(?b);
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+test "render: a location carries an escaped uri" {
+    var pa: Allocator;
+    page.make(?pa);
+    var starts: [3]usize;
+    starts[0] = 0; starts[1] = 3; starts[2] = 6;
+    var f: src.SourceFile = stub_file("ab\ncd\n", ?starts[0], 3);
+    var b: json.Buf = json.buf_init(?pa);
+    location(?b, ?f, "file:///a b.mach", span_at(3, 2));
+    var fail: bool = false;
+    val got: str = json.buf_str(?b);
+    if (got == nil) { fail = true; }
+    or {
+        if (!str_equals(got,
+            "{\"uri\":\"file:///a b.mach\",\"range\":{\"start\":{\"line\":1,\"character\":0},\"end\":{\"line\":1,\"character\":2}}}")) { fail = true; }
+    }
+    json.buf_dnit(?b);
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+# newText is user-supplied and must survive the trip; the old hand-rolled
+# escaper replaced control bytes with `?`
+test "render: a text edit escapes its replacement" {
+    var pa: Allocator;
+    page.make(?pa);
+    var starts: [1]usize;
+    starts[0] = 0;
+    var f: src.SourceFile = stub_file("abcd", ?starts[0], 1);
+    var b: json.Buf = json.buf_init(?pa);
+    text_edit(?b, ?f, span_at(0, 2), "x\"y\nz");
+    var fail: bool = false;
+    val got: str = json.buf_str(?b);
+    if (got == nil) { fail = true; }
+    or {
+        if (!str_equals(got,
+            "{\"range\":{\"start\":{\"line\":0,\"character\":0},\"end\":{\"line\":0,\"character\":2}},\"newText\":\"x\\\"y\\nz\"}")) { fail = true; }
+    }
+    json.buf_dnit(?b);
+    if (fail) { ret 1; }
+    ret 0;
+}
+
+test "render: a response envelope preserves the id's wire type" {
+    var pa: Allocator;
+    page.make(?pa);
+    var b: json.Buf = json.buf_init(?pa);
+    result_begin(?b, "\"abc\"");
+    json.buf_push(?b, "null");
+    json.buf_push_byte(?b, '}');
+    var fail: bool = false;
+    if (!str_equals(json.buf_str(?b),
+        "{\"jsonrpc\":\"2.0\",\"id\":\"abc\",\"result\":null}")) { fail = true; }
+    json.buf_dnit(?b);
+    if (fail) { ret 1; }
+    ret 0;
+}


### PR DESCRIPTION
Closes #171.

Cleanup ahead of Tier 2 rather than tidying: six more features are queued (#165–#170), every one of them needs these same renderers, and semanticTokens and inlayHint emit large data-dependent arrays — exactly where the old pattern was worst.

## The pattern being removed

A payload whose shape is data-dependent can't be sized by summing constants, so the emitters ran the whole traversal **twice** — once with the output pointer nil to total lengths, once pointed at an exact allocation to fill it — and the two passes had to agree exactly. When they didn't, the buffer was under-filled, `str_len` truncated the frame at the resulting NUL, and the client saw a valid `Content-Length` over a body that stopped mid-token. Silent, and shaped like a transport fault rather than a rendering one.

It also forced duplication: a Location was rendered by `location_json` for definition, again inside `loc_len` to measure a references entry, and a third time inside `put_loc` to write it.

`mls.render` is now the only place that knows how an LSP value is spelled. `WalkSink` loses its size/write duality and becomes a plain appender.

The one case needing more than a buffer is a rename group, only known to be empty once walked. `json.buf_len` / `buf_rewind` let the emitter open the entry speculatively and roll back when a file contributes no edit.

| | before | after |
|---|---|---|
| `language.mach` | 2364 lines, 91 fns | 1968 lines, 75 fns |
| two-pass emitters | 4 | **0** |
| manual `allocate[u8]` | 22 | 4 |

`completion_json` turned out to be dead already — left behind by the completion rewrite.

## Behaviour checked, not assumed

Hover, definition, documentSymbol, completion, references, rename and prepareRename responses captured before and after and compared — references and rename by **content hash over their full result sets** (e.g. `Server`: 27 references, 26 rename edits, same hash).

Everything identical except one line: `json.` module completion returns 34 items where it returned 32. That is `buf_len` and `buf_rewind`, the two functions this PR adds to `mls.json` — the delta is exactly +2 and both match the `buf_` prefix filter.

63 unit tests (4 new in `mls.render`), full protocol suite green.