### PR TITLE
feat(workspace/symbol): search declarations across the loaded project graph

### DIFF
--- a/src/project.mach
+++ b/src/project.mach
@@ -1495,6 +1495,28 @@ pub fun module_uri(w: *Workspace, root: *Root, mid: sess.ModuleId) str {
     ret norm_uri(w.alloc, root.mod_paths[mid::u32]);
 }
 
+# how many root slots the workspace holds
+#
+# Slots are stable addresses, so an index is a durable handle across a walk;
+# some slots are empty and some hold roots that failed to load.
+pub fun root_count(w: *Workspace) u32 {
+    ret w.root_cap;
+}
+
+# the root in slot `i`, or nil when the slot is empty
+pub fun root_at(w: *Workspace, i: u32) *Root {
+    if (w.roots == nil || i >= w.root_cap) { ret nil; }
+    val r: *Root = ?w.roots[i];
+    if (r.path == nil || r.s == nil) { ret nil; }
+    ret r;
+}
+
+# whether `r` holds a live snapshot that can be queried without rebuilding
+pub fun root_is_loaded(r: *Root) bool {
+    if (r == nil) { ret false; }
+    ret r.loaded;
+}
+
 # the interned FQN of a loaded module, or nil
 #
 # The name a module alias stands for. `module_uri` gives where it lives; this

--- a/src/server.mach
+++ b/src/server.mach
@@ -39,6 +39,7 @@ use exec:        std.process.exec;
 use documents:   mls.documents;
 use diagnostics: mls.diagnostics;
 use language:    mls.language;
+use workspace:   mls.workspace;
 use project:     mls.project;
 use trace:       mls.trace;
 
@@ -252,6 +253,7 @@ fun dispatch(srv: *Server, root: *sj.Value) {
     if (str_equals(method, "textDocument/documentSymbol")) { json.free_str(method, a); handle_feature(srv, root, params, FEATURE_DOCUMENT_SYMBOL); ret; }
     if (str_equals(method, "textDocument/completion"))     { json.free_str(method, a); handle_feature(srv, root, params, FEATURE_COMPLETION); ret; }
     if (str_equals(method, "textDocument/documentHighlight")) { json.free_str(method, a); handle_feature(srv, root, params, FEATURE_DOCUMENT_HIGHLIGHT); ret; }
+    if (str_equals(method, "workspace/symbol"))            { json.free_str(method, a); handle_workspace_symbol(srv, root, params); ret; }
 
     trace.logf("server: unhandled method {}", method);
     json.free_str(method, a);
@@ -270,7 +272,7 @@ fun handle_initialize(srv: *Server, root: *sj.Value, params: *sj.Value) {
     var b: json.Buf = json.buf_init(srv.alloc);
     json.buf_push(?b, "{\"jsonrpc\":\"2.0\",\"id\":");
     json.buf_push_id(?b, json.member(root, "id"));
-    json.buf_push(?b, ",\"result\":{\"capabilities\":{\"textDocumentSync\":1,\"hoverProvider\":true,\"definitionProvider\":true,\"referencesProvider\":true,\"renameProvider\":{\"prepareProvider\":true},\"documentSymbolProvider\":true,\"documentHighlightProvider\":true,\"completionProvider\":{\"triggerCharacters\":[\".\"]}},\"serverInfo\":{\"name\":\"mach-lsp\"}}}");
+    json.buf_push(?b, ",\"result\":{\"capabilities\":{\"textDocumentSync\":1,\"hoverProvider\":true,\"definitionProvider\":true,\"referencesProvider\":true,\"renameProvider\":{\"prepareProvider\":true},\"documentSymbolProvider\":true,\"documentHighlightProvider\":true,\"workspaceSymbolProvider\":true,\"completionProvider\":{\"triggerCharacters\":[\".\"]}},\"serverInfo\":{\"name\":\"mach-lsp\"}}}");
     send_buf(srv, ?b);
 
     srv.status = STATUS_RUNNING;
@@ -422,6 +424,15 @@ fun handle_feature(srv: *Server, root: *sj.Value, params: *sj.Value, which: u8) 
     if (uri != nil) { json.free_str(uri, srv.alloc); }
 
     if (project.load_epoch(?srv.ws) != epoch_before || project.sema_epoch(?srv.ws) != sema_before) { republish_all(srv); }
+}
+
+# answer workspace/symbol from every loaded root
+fun handle_workspace_symbol(srv: *Server, root: *sj.Value, params: *sj.Value) {
+    val id_raw: str = json.id_text(json.member(root, "id"), srv.alloc);
+    if (id_raw == nil) { ret; }
+    val query: str = json.text(json.member(params, "query"), srv.alloc);
+    workspace.symbols(?srv.ws, srv.alloc, id_raw, query);
+    if (query != nil) { json.free_str(query, srv.alloc); }
 }
 
 # re-publish diagnostics for every open document the given root governs

--- a/src/workspace.mach
+++ b/src/workspace.mach
@@ -1,0 +1,209 @@
+# workspace-wide symbol search
+#
+# Every other navigation feature starts from a cursor: you must already be
+# looking at the name to ask about it. `workspace/symbol` is the one that does
+# not, which makes it the only way to reach a declaration you have not opened.
+#
+# The search is over what is already loaded. Every root's retained snapshot
+# holds each module's parsed Ast and resolve tables, so a query is a walk over
+# memory rather than a build; a root that has never been analysed is skipped
+# rather than loaded, because indexing a workspace on the first keystroke is the
+# cost #95 was about. That makes the result set depend on what has been opened,
+# which is a real limitation and the reason a syntax-only background index is
+# worth considering later.
+
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.size.usize;
+use std.types.string.str;
+use std.types.string.str_len;
+use std.types.option.Option;
+use std.types.option.is_some;
+use std.types.option.unwrap;
+
+use std.allocator.Allocator;
+
+use sess:   mach.lang.session;
+use src:    mach.lang.source;
+use intern: mach.lang.intern;
+use res:    mach.lang.fe.resolve;
+use token:  mach.lang.fe.token;
+
+use json:      mls.json;
+use render:    mls.render;
+use project:   mls.project;
+use features:  mls.features;
+use strutil:   std.text.string;
+
+# most matches returned for one query
+#
+# A bound, not a truncation policy: a query matching more than this is nearly
+# always too short to be useful, and the client re-queries as the user types.
+val MAX_RESULTS: usize = 256;
+
+# answer workspace/symbol over every loaded root
+# ---
+# ws:     the workspace
+# alloc:  request allocator
+# id_raw: the raw JSON request id, consumed here
+# query:  the client's query string; empty matches nothing
+pub fun symbols(ws: *project.Workspace, alloc: *Allocator, id_raw: str, query: str) {
+    var b: json.Buf = json.buf_init(alloc);
+    render.result_begin(?b, id_raw);
+    json.buf_push_byte(?b, '[');
+
+    # emit best matches first: a name that STARTS with the query, then one whose
+    # word starts with it (`push` in `buf_push`), then an interior hit. clients
+    # re-rank, but they cannot recover an ordering from a list that was
+    # truncated at MAX_RESULTS before the good matches were reached
+    var emitted: usize = 0;
+    if (query != nil && str_len(query) > 0) {
+        var tier: u8 = MATCH_PREFIX;
+        for (tier <= MATCH_INTERIOR && emitted < MAX_RESULTS) {
+            var ri: u32 = 0;
+            for (ri < project.root_count(ws) && emitted < MAX_RESULTS) {
+                val root: *project.Root = project.root_at(ws, ri);
+                if (project.root_is_loaded(root)) {
+                    emitted = push_root_symbols(?b, ws, root, query, tier, emitted);
+                }
+                ri = ri + 1;
+            }
+            tier = tier + 1;
+        }
+    }
+
+    json.buf_push_byte(?b, ']');
+    render.send(?b, alloc, id_raw);
+}
+
+# append every matching symbol declared in `root`, returning the new count
+fun push_root_symbols(b: *json.Buf, ws: *project.Workspace, root: *project.Root,
+                      query: str, tier: u8, start_count: usize) usize {
+    var emitted: usize = start_count;
+    val n: u32 = project.module_count(root);
+    var mi: u32 = 0;
+    for (mi < n && emitted < MAX_RESULTS) {
+        val mid: sess.ModuleId = mi::sess.ModuleId;
+        val mvo: Option[project.ModuleView] = project.module_view(ws, root, mid);
+        if (is_some[project.ModuleView](mvo)) {
+            val mv: project.ModuleView = unwrap[project.ModuleView](mvo);
+            if (mv.rr != nil && mv.a != nil) {
+                val uri: str = project.module_uri(ws, root, mid);
+                if (uri != nil) {
+                    val fqn: str = project.module_fqn(ws, root, mid);
+                    emitted = push_module_symbols(b, ws, root, mid, mv, uri, fqn, query, tier, emitted);
+                    strutil.str_free(ws.alloc, uri);
+                }
+            }
+        }
+        mi = mi + 1;
+    }
+    ret emitted;
+}
+
+# append every matching symbol `mid` declares, returning the new count
+fun push_module_symbols(b: *json.Buf, ws: *project.Workspace, root: *project.Root,
+                        mid: sess.ModuleId, mv: project.ModuleView, uri: str, fqn: str,
+                        query: str, tier: u8, start_count: usize) usize {
+    var emitted: usize = start_count;
+    var i: u32 = 0;
+    for (i < mv.rr.symbol_count && emitted < MAX_RESULTS) {
+        val sym: *res.Symbol = ?mv.rr.symbols[i];
+        # only declarations this module owns: an imported symbol is reported by
+        # the module that declares it, so a name appears once per declaration
+        # rather than once per importer
+        if (sym.origin == mid && features.completion_candidate(mv.rr, i)) {
+            val no: Option[str] = intern.lookup(?root.s.interner, sym.name);
+            if (is_some[str](no)) {
+                val name: str = unwrap[str](no);
+                if (match_tier(query, name) == tier) {
+                    val spo: Option[token.Span] = features.decl_name_span_of(mv.a, sym);
+                    if (is_some[token.Span](spo)) {
+                        push_symbol(b, mv.file, uri, unwrap[token.Span](spo), name,
+                                    features.lsp_symbol_kind(sym.kind), fqn, emitted > 0);
+                        emitted = emitted + 1;
+                    }
+                }
+            }
+        }
+        i = i + 1;
+    }
+    ret emitted;
+}
+
+# append one SymbolInformation
+#
+# `containerName` carries the declaring module's FQN, which is what makes two
+# identically-named symbols distinguishable - and roots with colliding FQNs are
+# explicitly supported, so this is not cosmetic.
+fun push_symbol(b: *json.Buf, file: *src.SourceFile, uri: str, span: token.Span,
+                name: str, kind: i64, container: str, comma: bool) {
+    if (comma) { json.buf_push_byte(b, ','); }
+    json.buf_push(b, "{\"name\":");
+    json.buf_push_quoted(b, name);
+    json.buf_push(b, ",\"kind\":");
+    json.buf_push_i64(b, kind);
+    if (container != nil) {
+        json.buf_push(b, ",\"containerName\":");
+        json.buf_push_quoted(b, container);
+    }
+    json.buf_push(b, ",\"location\":");
+    render.location(b, file, uri, span);
+    json.buf_push_byte(b, '}');
+}
+
+# how well `name` matches `query`, case-insensitively
+#
+# Substring rather than prefix-only, because a Mach name is commonly reached by
+# its tail (`push` for `buf_push_quoted`). But an interior hit is much weaker
+# than a leading one - `read_` occurs inside `thread_spawn` - so the position of
+# the hit becomes its rank rather than being discarded.
+val MATCH_PREFIX:   u8 = 0;
+val MATCH_WORD:     u8 = 1;
+val MATCH_INTERIOR: u8 = 2;
+val MATCH_NONE:     u8 = 3;
+
+fun match_tier(query: str, name: str) u8 {
+    val qn: usize = str_len(query);
+    val nn: usize = str_len(name);
+    if (qn == 0 || qn > nn) { ret MATCH_NONE; }
+    var start: usize = 0;
+    for (start + qn <= nn) {
+        var i: usize = 0;
+        var same: bool = true;
+        for (i < qn && same) {
+            if (lower(name[start + i]) != lower(query[i])) { same = false; }
+            i = i + 1;
+        }
+        if (same) {
+            if (start == 0) { ret MATCH_PREFIX; }
+            if (name[start - 1] == '_') { ret MATCH_WORD; }
+            ret MATCH_INTERIOR;
+        }
+        start = start + 1;
+    }
+    ret MATCH_NONE;
+}
+
+# ASCII lowercase; identifiers are ASCII in Mach
+fun lower(c: u8) u8 {
+    if (c >= 'A' && c <= 'Z') { ret c + 32; }
+    ret c;
+}
+
+test "workspace: match rank prefers leading over interior hits" {
+    var fail: bool = false;
+    if (match_tier("json", "json_buf_push") != MATCH_PREFIX)   { fail = true; }
+    if (match_tier("JSON", "json_buf_push") != MATCH_PREFIX)   { fail = true; }
+    if (match_tier("buf",  "json_buf_push") != MATCH_WORD)     { fail = true; }
+    if (match_tier("push", "json_buf_push") != MATCH_WORD)     { fail = true; }
+    if (match_tier("uf",   "json_buf_push") != MATCH_INTERIOR) { fail = true; }
+    # the case that made raw substring matching noisy
+    if (match_tier("read_", "thread_spawn") != MATCH_INTERIOR) { fail = true; }
+    if (match_tier("zzz", "json_buf_push")  != MATCH_NONE)     { fail = true; }
+    if (match_tier("", "anything")          != MATCH_NONE)     { fail = true; }
+    if (match_tier("toolong", "short")      != MATCH_NONE)     { fail = true; }
+    if (fail) { ret 1; }
+    ret 0;
+}

--- a/test/lsp_protocol.py
+++ b/test/lsp_protocol.py
@@ -1102,6 +1102,70 @@ def run_document_highlight(server: Path, timeout: float) -> None:
                 session.abort()
 
 
+def run_workspace_symbol(server: Path, timeout: float) -> None:
+    """Find a declaration without already looking at it."""
+    with tempfile.TemporaryDirectory(prefix="mls-wsym-") as directory:
+        root = Path(directory).resolve()
+        main, defs, text = write_project(root, "wsym", 6)
+        session = LspSession(server, root, timeout)
+        finished = False
+        try:
+            result = session.request(
+                "initialize", {"rootUri": root.as_uri(), "capabilities": {}}).get("result", {})
+            require(result.get("capabilities", {}).get("workspaceSymbolProvider") is True,
+                    "workspaceSymbolProvider is not advertised")
+            session.notify("initialized", {})
+
+            def query(text_: str) -> list[dict[str, Any]]:
+                response = session.request("workspace/symbol", {"query": text_})
+                items = response.get("result")
+                require(isinstance(items, list), f"workspace/symbol is not a list: {items!r}")
+                for item in items:
+                    require(isinstance(item.get("name"), str), f"symbol without a name: {item!r}")
+                    require(isinstance(item.get("kind"), int), f"symbol without a kind: {item!r}")
+                    location = item.get("location")
+                    require(isinstance(location, dict) and "uri" in location,
+                            f"symbol without a location: {item!r}")
+                    assert_range(location.get("range"), "symbol.location.range")
+                return items
+
+            # nothing is loaded yet: a query must answer, not block on a build
+            started = time.monotonic()
+            require(query("answer") == [], "an unloaded workspace returned symbols")
+            require(time.monotonic() - started < 2.0,
+                    "workspace/symbol forced a cold project load")
+
+            session.notify(
+                "textDocument/didOpen",
+                {"textDocument": {"uri": main.as_uri(), "languageId": "mach",
+                                  "version": 1, "text": text}},
+            )
+            session.diagnostics(main.as_uri(), 1)
+
+            found = query("answer")
+            require(found, "a declared symbol was not found after loading")
+            names = [item["name"] for item in found]
+            require("answer" in names, f"the exact match is missing: {names!r}")
+            hit = next(item for item in found if item["name"] == "answer")
+            require(hit["location"]["uri"] == defs.as_uri(),
+                    f"symbol resolved to the wrong file: {hit!r}")
+            require(hit.get("containerName"), "no containerName to disambiguate the module")
+
+            # a leading match outranks an interior one
+            ranked = [item["name"] for item in query("Box")]
+            require(ranked and ranked[0] == "Box",
+                    f"an exact match was not ranked first: {ranked!r}")
+
+            require(query("zzz-no-such-symbol") == [], "a miss returned results")
+            require(query("") == [], "an empty query returned results")
+
+            session.finish()
+            finished = True
+        finally:
+            if not finished:
+                session.abort()
+
+
 def run_active_watcher_fallback(server: Path, timeout: float) -> None:
     """Prove a missed source event is recovered even after watcher ACK."""
     with tempfile.TemporaryDirectory(prefix="mls-watch-") as directory:
@@ -1344,6 +1408,7 @@ def main() -> int:
         run_document_symbol_hierarchy(server, args.timeout)
         run_completion_context(server, args.timeout)
         run_document_highlight(server, args.timeout)
+        run_workspace_symbol(server, args.timeout)
         run_same_fqn_reverse(server, args.timeout)
         run_clean_eof(server, args.timeout)
         run_exit_paths(server, args.timeout)
@@ -1360,6 +1425,7 @@ def main() -> int:
     print("  documentSymbol nests fields, variants, parameters, and generics")
     print("  completion answers for the cursor: members, exports, prefixes")
     print("  documentHighlight classifies reads and writes in the active file")
+    print("  workspace/symbol searches loaded roots, best matches first")
     print("  clean EOF after shutdown: exit 0")
     print("  all five lifecycle endings terminate with the documented code")
     print("  malformed/oversized frames: 8 rejected with exit 1")


### PR DESCRIPTION
Closes #167.

Every other navigation feature starts from a cursor — you had to already be looking at a name to ask about it. This is the one that doesn't.

Walks what is already loaded: each root's retained snapshot holds every module's Ast and resolve tables, so a query is a walk over memory, not a build. A never-analysed root is skipped rather than loaded, because indexing a workspace on the first keystroke is the cost #95 was about. The result set therefore depends on what's been opened — a real limitation, and the reason a syntax-only background index is worth considering separately.

## Ranking, not just matching

Substring matching is right for Mach names (`push` should find `buf_push_quoted`) but too noisy alone — `read_` occurs inside `thread_spawn`. So hit position becomes rank:

| query | before ranking | after |
|---|---|---|
| `Server` | `dns_nameserver`, `Server` | **`Server`**, `dns_nameserver` |
| `READ_` | `thread_spawn`, `THREAD_CLONE_FLAGS`… | **`read_dir`**, `read_into`, `read_u32_be`… |

That matters because the result set is bounded — truncating before the good matches are reached isn't something a client can re-rank its way out of.

`containerName` carries the declaring module FQN; colliding-FQN roots are explicitly supported, so that's not cosmetic.

~12 ms per query over 222 loaded modules.