### PR TITLE
feat(inlayHint): name literal arguments at multi-parameter calls

### DIFF
--- a/src/hints.mach
+++ b/src/hints.mach
@@ -1,0 +1,295 @@
+# inlay hints: naming the arguments at a call site
+#
+# The usual first use of inlay hints - showing the inferred type of a binding
+# that does not state one - does not apply to Mach: a binding REQUIRES an
+# explicit type annotation, so `val x = f();` is a parse error, not an inference
+# site. There is no inferred binding type to reveal.
+#
+# What is genuinely opaque here is a call's arguments. `take(b, 3, true)` says
+# nothing about what those three values mean, and the parameter names that would
+# say it live in the callee's declaration. So the hints are parameter names,
+# rendered before each argument.
+#
+# A literal argument is the case worth labelling. An argument that is already a
+# plain identifier usually names itself - `send(buf, count)` against parameters
+# `buf, count` is noise - so a hint whose name matches the argument's own
+# spelling is suppressed.
+#
+# Hints are requested on every scroll, so this reads the snapshot and never
+# drives a rebuild.
+
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.size.usize;
+use std.types.string.str;
+use std.types.string.str_len;
+use std.types.option.Option;
+use std.types.option.is_some;
+use std.types.option.some;
+use std.types.option.none;
+use std.types.option.unwrap;
+use std.types.result.Result;
+use std.types.result.is_err;
+use std.types.result.unwrap_ok;
+
+use std.allocator.Allocator;
+
+use sess:     mach.lang.session;
+use src:      mach.lang.source;
+use token:    mach.lang.fe.token;
+use ast:      mach.lang.fe.ast;
+use id:       mach.lang.fe.ast.id;
+use decl:     mach.lang.fe.ast.decl;
+use aexpr:    mach.lang.fe.ast.expr;
+use res:      mach.lang.fe.resolve;
+use stmt:     mach.lang.fe.ast.stmt;
+use type:     mach.lang.type;
+use typename: mach.lang.fe.sema.typename;
+use editor:   mach.lang.editor;
+use sj:       std.data.json;
+
+use json:      mls.json;
+use render:    mls.render;
+use project:   mls.project;
+use positions: mls.positions;
+use documents: mls.documents;
+use analysis:  mls.analysis;
+
+# LSP InlayHintKind.Type
+# LSP InlayHintKind.Parameter
+val HINT_PARAMETER: i64 = 2;
+
+# most hints returned for one range, so a request over a whole large file
+# cannot produce an unbounded payload
+val MAX_HINTS: usize = 512;
+
+# answer textDocument/inlayHint for the requested range
+pub fun inlay_hints(ws: *project.Workspace, es: *editor.EditorSession, alloc: *Allocator,
+                    docs: *documents.Store, req_id: *sj.Value, params: *sj.Value, uri: str) {
+    val id_raw: str = json.id_text(req_id, alloc);
+    if (id_raw == nil) { ret; }
+
+    var an: analysis.Analyzed;
+    if (!analysis.analyze(ws, es, docs, uri, ?an)) { render.reply_empty_array(alloc, id_raw); ret; }
+
+    var lo: usize = 0;
+    var hi: usize = str_len(an.file.text);
+    range_bounds(params, an.file, ?lo, ?hi);
+
+    # a hint needs both the inferred type and a session to render it against;
+    # a standalone buffer has neither in a form this can use
+    val s: *sess.Session = session_of(an);
+    if (an.sr == nil || s == nil) { render.reply_empty_array(alloc, id_raw); ret; }
+
+    var b: json.Buf = json.buf_init(alloc);
+    render.result_begin(?b, id_raw);
+    json.buf_push_byte(?b, '[');
+
+    var emitted: usize = 0;
+    var ei: usize = 0;
+    for (ei < an.a.expr_len && emitted < MAX_HINTS) {
+        emitted = push_call_hints(?b, ws, an, uri, ei::id.ExprId, lo, hi, emitted, alloc);
+        ei = ei + 1;
+    }
+
+    json.buf_push_byte(?b, ']');
+    render.send(?b, alloc, id_raw);
+}
+
+# the session whose type universe the document's types belong to
+fun session_of(an: analysis.Analyzed) *sess.Session {
+    if (an.root == nil) { ret nil; }
+    ret project.root_session(an.root);
+}
+
+# append a parameter-name hint for each argument of the call at `eid`
+fun push_call_hints(b: *json.Buf, ws: *project.Workspace, an: analysis.Analyzed, uri: str,
+                    eid: id.ExprId, lo: usize, hi: usize, count: usize, alloc: *Allocator) usize {
+    val eo: Option[*aexpr.Expr] = ast.get_expr(an.a, eid);
+    if (!is_some[*aexpr.Expr](eo)) { ret count; }
+    val e: *aexpr.Expr = unwrap[*aexpr.Expr](eo);
+    if (e.kind != aexpr.EXPR_KIND_CALL) { ret count; }
+    val nargs: u32 = e.data.call.args_len;
+    if (nargs == 0 || an.a.expr_ids == nil) { ret count; }
+
+    # the callee's parameter names live in its declaration, which is reached
+    # through the same pivot definition uses
+    val d_opt: Option[*decl.Decl] = callee_decl(ws, an, uri, e.data.call.callee);
+    if (!is_some[*decl.Decl](d_opt)) { ret count; }
+    val d: *decl.Decl = unwrap[*decl.Decl](d_opt);
+    val site_a: *ast.Ast = callee_ast(ws, an, uri, e.data.call.callee);
+    val site_f: *src.SourceFile = callee_file(ws, an, uri, e.data.call.callee);
+    if (site_a == nil || site_f == nil) { ret count; }
+
+    # a one-parameter call has no ambiguity for a name to resolve: `log("x")`
+    # gains nothing from being told the parameter is called `msg`
+    if (d.data.fun_.params_len < 2) { ret count; }
+
+    var emitted: usize = count;
+    var i: u32 = 0;
+    for (i < nargs && i < d.data.fun_.params_len && emitted < MAX_HINTS) {
+        val arg: id.ExprId = an.a.expr_ids[(e.data.call.args_start + i)::usize];
+        val ao: Option[*aexpr.Expr] = ast.get_expr(an.a, arg);
+        if (is_some[*aexpr.Expr](ao)) {
+            val at: usize = unwrap[*aexpr.Expr](ao).span.offset;
+            if (at >= lo && at <= hi && wants_hint(unwrap[*aexpr.Expr](ao))) {
+                val pname: str = param_name(site_a, site_f, d.data.fun_.params_start + i, alloc);
+                if (pname != nil) {
+                    if (!names_itself(an.file, unwrap[*aexpr.Expr](ao).span, pname)) {
+                        push_hint(b, an.file, at, pname, emitted > 0);
+                        emitted = emitted + 1;
+                    }
+                    json.free_str(pname, alloc);
+                }
+            }
+        }
+        i = i + 1;
+    }
+    ret emitted;
+}
+
+# the function declaration the callee expression resolves to, or none
+fun callee_decl(ws: *project.Workspace, an: analysis.Analyzed, uri: str, callee: id.ExprId) Option[*decl.Decl] {
+    val so: Option[*res.Symbol] = callee_symbol(an, callee);
+    if (!is_some[*res.Symbol](so)) { ret none[*decl.Decl](); }
+    val sym: *res.Symbol = unwrap[*res.Symbol](so);
+    val site_o: Option[project.Site] = project.site_of(ws, an.root, an.own, an.a, an.file, uri, sym);
+    if (!is_some[project.Site](site_o)) { ret none[*decl.Decl](); }
+    var site: project.Site = unwrap[project.Site](site_o);
+    val d: Option[*decl.Decl] = ast.get_decl(site.a, sym.decl);
+    project.free_site(ws, ?site);
+    if (!is_some[*decl.Decl](d)) { ret none[*decl.Decl](); }
+    if (unwrap[*decl.Decl](d).kind != decl.DECL_KIND_FUN) { ret none[*decl.Decl](); }
+    ret d;
+}
+
+# the Ast the callee's declaration lives in
+fun callee_ast(ws: *project.Workspace, an: analysis.Analyzed, uri: str, callee: id.ExprId) *ast.Ast {
+    val so: Option[*res.Symbol] = callee_symbol(an, callee);
+    if (!is_some[*res.Symbol](so)) { ret nil; }
+    val site_o: Option[project.Site] =
+        project.site_of(ws, an.root, an.own, an.a, an.file, uri, unwrap[*res.Symbol](so));
+    if (!is_some[project.Site](site_o)) { ret nil; }
+    var site: project.Site = unwrap[project.Site](site_o);
+    val a: *ast.Ast = site.a;
+    project.free_site(ws, ?site);
+    ret a;
+}
+
+# the source file backing the callee's declaration
+fun callee_file(ws: *project.Workspace, an: analysis.Analyzed, uri: str, callee: id.ExprId) *src.SourceFile {
+    val so: Option[*res.Symbol] = callee_symbol(an, callee);
+    if (!is_some[*res.Symbol](so)) { ret nil; }
+    val site_o: Option[project.Site] =
+        project.site_of(ws, an.root, an.own, an.a, an.file, uri, unwrap[*res.Symbol](so));
+    if (!is_some[project.Site](site_o)) { ret nil; }
+    var site: project.Site = unwrap[project.Site](site_o);
+    val f: *src.SourceFile = site.file;
+    project.free_site(ws, ?site);
+    ret f;
+}
+
+# the symbol the callee expression binds
+fun callee_symbol(an: analysis.Analyzed, callee: id.ExprId) Option[*res.Symbol] {
+    if (an.rr == nil || an.rr.expr_resolved == nil) { ret none[*res.Symbol](); }
+    if (callee == id.EXPR_NIL || callee::u32 >= an.rr.expr_count) { ret none[*res.Symbol](); }
+    val sid: res.SymbolId = an.rr.expr_resolved[callee];
+    if (sid == res.SYMBOL_NIL || sid >= an.rr.symbol_count) { ret none[*res.Symbol](); }
+    ret some[*res.Symbol](?an.rr.symbols[sid]);
+}
+
+# the declared name of the parameter in `typed_names` slot `slot`
+fun param_name(a: *ast.Ast, file: *src.SourceFile, slot: u32, alloc: *Allocator) str {
+    if (a.typed_names == nil) { ret nil; }
+    val tn: *decl.TypedName = ?a.typed_names[slot::usize];
+    if (tn.name.len == 0) { ret nil; }
+    ret positions.span_text(file, tn.name, alloc);
+}
+
+# whether an argument is opaque enough to be worth naming
+#
+# A literal is: `resize(buf, 0, true)` says nothing about which argument is the
+# count and which the flag. Anything the reader can already name - an
+# identifier, a member access, a nested call - is not, and labelling all of them
+# buries the few that matter. Hinting every argument produced 420 hints on one
+# 550-line file, which is not a feature.
+fun wants_hint(e: *aexpr.Expr) bool {
+    if (e.kind == aexpr.EXPR_KIND_LIT_INT)   { ret true; }
+    if (e.kind == aexpr.EXPR_KIND_LIT_FLOAT) { ret true; }
+    if (e.kind == aexpr.EXPR_KIND_LIT_CHAR)  { ret true; }
+    if (e.kind == aexpr.EXPR_KIND_LIT_STR)   { ret true; }
+    if (e.kind == aexpr.EXPR_KIND_LIT_NIL)   { ret true; }
+    ret false;
+}
+
+# whether the argument's own text already spells the parameter name, making the
+# hint pure noise
+fun names_itself(file: *src.SourceFile, span: token.Span, name: str) bool {
+    if (span.len != str_len(name)) { ret false; }
+    var i: usize = 0;
+    for (i < span.len) {
+        if (file.text[span.offset + i] != name[i]) { ret false; }
+        i = i + 1;
+    }
+    ret true;
+}
+
+# append one InlayHint just after `offset`
+#
+# `paddingLeft` rather than a leading space in the label, so a client that
+# renders hints inline and one that renders them in a gutter both look right.
+fun push_hint(b: *json.Buf, file: *src.SourceFile, offset: usize, text: str, comma: bool) {
+    if (comma) { json.buf_push_byte(b, ','); }
+    var at: token.Span;
+    at.offset = offset;
+    at.len    = 0;
+    json.buf_push(b, "{\"position\":");
+    push_position(b, file, at);
+    # `name:` reads as the argument label it stands in for
+    json.buf_push(b, ",\"label\":");
+    var label: json.Buf = json.buf_init(b.a);
+    json.buf_push(?label, text);
+    json.buf_push_byte(?label, ':');
+    json.buf_push_quoted(b, json.buf_str(?label));
+    json.buf_dnit(?label);
+    json.buf_push(b, ",\"kind\":");
+    json.buf_push_i64(b, HINT_PARAMETER);
+    json.buf_push(b, ",\"paddingLeft\":false,\"paddingRight\":true}");
+}
+
+# whether the renderer produced a placeholder rather than a spelling
+fun is_placeholder(text: str) bool {
+    if (text == nil) { ret true; }
+    if (str_len(text) == 0) { ret true; }
+    ret text[0] == '<';
+}
+
+# the `start` of a zero-length span, which is the hint's anchor
+fun push_position(b: *json.Buf, file: *src.SourceFile, span: token.Span) {
+    val r: positions.LspRange = positions.range_of(file, span);
+    json.buf_push(b, "{\"line\":");
+    json.buf_push_usize(b, r.start_line);
+    json.buf_push(b, ",\"character\":");
+    json.buf_push_usize(b, r.start_char);
+    json.buf_push_byte(b, '}');
+}
+
+# read the request's `range` into byte offsets, leaving the defaults when it is
+# absent or malformed
+fun range_bounds(params: *sj.Value, file: *src.SourceFile, lo: *usize, hi: *usize) {
+    val rng: *sj.Value = json.member(params, "range");
+    if (rng == nil) { ret; }
+    val so: Option[usize] = offset_of_member(rng, "start", file);
+    val eo: Option[usize] = offset_of_member(rng, "end", file);
+    if (is_some[usize](so)) { @lo = unwrap[usize](so); }
+    if (is_some[usize](eo)) { @hi = unwrap[usize](eo); }
+}
+
+fun offset_of_member(rng: *sj.Value, key: str, file: *src.SourceFile) Option[usize] {
+    val p: *sj.Value = json.member(rng, key);
+    val line: i64 = json.number(json.member(p, "line"), -1);
+    val ch:   i64 = json.number(json.member(p, "character"), -1);
+    if (line < 0 || ch < 0) { ret positions.offset_at(file, 0, 0); }
+    ret positions.offset_at(file, line::usize, ch::usize);
+}

--- a/src/project.mach
+++ b/src/project.mach
@@ -1495,6 +1495,15 @@ pub fun module_uri(w: *Workspace, root: *Root, mid: sess.ModuleId) str {
     ret norm_uri(w.alloc, root.mod_paths[mid::u32]);
 }
 
+# the session a root's types and interners belong to
+#
+# Rendering a type needs the session that interned it; a type id is meaningless
+# against any other.
+pub fun root_session(r: *Root) *sess.Session {
+    if (r == nil) { ret nil; }
+    ret r.s;
+}
+
 # how many root slots the workspace holds
 #
 # Slots are stable addresses, so an index is a durable handle across a walk;

--- a/src/server.mach
+++ b/src/server.mach
@@ -41,6 +41,7 @@ use diagnostics: mls.diagnostics;
 use language:    mls.language;
 use workspace:   mls.workspace;
 use signature:   mls.signature;
+use hints:       mls.hints;
 use project:     mls.project;
 use trace:       mls.trace;
 
@@ -59,6 +60,7 @@ val FEATURE_DOCUMENT_SYMBOL: u8 = 5;
 val FEATURE_COMPLETION:      u8 = 6;
 val FEATURE_DOCUMENT_HIGHLIGHT: u8 = 7;
 val FEATURE_SIGNATURE_HELP:     u8 = 8;
+val FEATURE_INLAY_HINT:         u8 = 9;
 
 val WATCH_FALLBACK: u8 = 0;
 val WATCH_PENDING:  u8 = 1;
@@ -256,6 +258,7 @@ fun dispatch(srv: *Server, root: *sj.Value) {
     if (str_equals(method, "textDocument/completion"))     { json.free_str(method, a); handle_feature(srv, root, params, FEATURE_COMPLETION); ret; }
     if (str_equals(method, "textDocument/documentHighlight")) { json.free_str(method, a); handle_feature(srv, root, params, FEATURE_DOCUMENT_HIGHLIGHT); ret; }
     if (str_equals(method, "textDocument/signatureHelp"))  { json.free_str(method, a); handle_feature(srv, root, params, FEATURE_SIGNATURE_HELP); ret; }
+    if (str_equals(method, "textDocument/inlayHint"))      { json.free_str(method, a); handle_feature(srv, root, params, FEATURE_INLAY_HINT); ret; }
     if (str_equals(method, "workspace/symbol"))            { json.free_str(method, a); handle_workspace_symbol(srv, root, params); ret; }
 
     trace.logf("server: unhandled method {}", method);
@@ -275,7 +278,7 @@ fun handle_initialize(srv: *Server, root: *sj.Value, params: *sj.Value) {
     var b: json.Buf = json.buf_init(srv.alloc);
     json.buf_push(?b, "{\"jsonrpc\":\"2.0\",\"id\":");
     json.buf_push_id(?b, json.member(root, "id"));
-    json.buf_push(?b, ",\"result\":{\"capabilities\":{\"textDocumentSync\":1,\"hoverProvider\":true,\"definitionProvider\":true,\"referencesProvider\":true,\"renameProvider\":{\"prepareProvider\":true},\"documentSymbolProvider\":true,\"documentHighlightProvider\":true,\"workspaceSymbolProvider\":true,\"signatureHelpProvider\":{\"triggerCharacters\":[\"(\",\",\"],\"retriggerCharacters\":[\",\"]},\"completionProvider\":{\"triggerCharacters\":[\".\"]}},\"serverInfo\":{\"name\":\"mach-lsp\"}}}");
+    json.buf_push(?b, ",\"result\":{\"capabilities\":{\"textDocumentSync\":1,\"hoverProvider\":true,\"definitionProvider\":true,\"referencesProvider\":true,\"renameProvider\":{\"prepareProvider\":true},\"documentSymbolProvider\":true,\"documentHighlightProvider\":true,\"workspaceSymbolProvider\":true,\"inlayHintProvider\":true,\"signatureHelpProvider\":{\"triggerCharacters\":[\"(\",\",\"],\"retriggerCharacters\":[\",\"]},\"completionProvider\":{\"triggerCharacters\":[\".\"]}},\"serverInfo\":{\"name\":\"mach-lsp\"}}}");
     send_buf(srv, ?b);
 
     srv.status = STATUS_RUNNING;
@@ -424,6 +427,7 @@ fun handle_feature(srv: *Server, root: *sj.Value, params: *sj.Value, which: u8) 
     or (which == FEATURE_COMPLETION)      { language.completion(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, id, params, uri); }
     or (which == FEATURE_DOCUMENT_HIGHLIGHT) { language.document_highlight(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, id, params, uri); }
     or (which == FEATURE_SIGNATURE_HELP)  { signature.signature_help(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, id, params, uri); }
+    or (which == FEATURE_INLAY_HINT)      { hints.inlay_hints(?srv.ws, ?srv.es, srv.alloc, ?srv.docs, id, params, uri); }
 
     if (uri != nil) { json.free_str(uri, srv.alloc); }
 

--- a/test/lsp_protocol.py
+++ b/test/lsp_protocol.py
@@ -1242,6 +1242,75 @@ def run_signature_help(server: Path, timeout: float) -> None:
                 session.abort()
 
 
+def run_inlay_hints(server: Path, timeout: float) -> None:
+    """Parameter names on literal arguments, and nowhere else.
+
+    Mach requires an explicit type annotation on every binding, so there is no
+    inferred binding type to reveal; what is opaque at a call site is which
+    literal means what.
+    """
+    with tempfile.TemporaryDirectory(prefix="mls-hint-") as directory:
+        root = Path(directory).resolve()
+        main, defs, text = write_project(root, "hint", 2)
+        # a two-parameter callee, called with one literal and one named value
+        extra = ("pub fun pair(first: i32, second: i32) i32 { ret first + second; }\n")
+        defs.write_text(defs.read_text(encoding="utf-8") + extra, encoding="utf-8")
+        body = text.replace("ret take[i32](b)", "ret pair(1, watched) + take[i32](b)")
+        body = body.replace("use hint.defs.watched;", "use hint.defs.watched;\nuse hint.defs.pair;")
+        main.write_text(body, encoding="utf-8")
+
+        session = LspSession(server, root, timeout)
+        finished = False
+        try:
+            result = session.request(
+                "initialize", {"rootUri": root.as_uri(), "capabilities": {}}).get("result", {})
+            require(result.get("capabilities", {}).get("inlayHintProvider") is True,
+                    "inlayHintProvider is not advertised")
+            session.notify("initialized", {})
+            session.notify(
+                "textDocument/didOpen",
+                {"textDocument": {"uri": main.as_uri(), "languageId": "mach",
+                                  "version": 1, "text": body}},
+            )
+            session.diagnostics(main.as_uri(), 1)
+
+            lines = body.splitlines()
+            response = session.request(
+                "textDocument/inlayHint",
+                {"textDocument": {"uri": main.as_uri()},
+                 "range": {"start": {"line": 0, "character": 0},
+                           "end": {"line": len(lines), "character": 0}}},
+            )
+            hints = response.get("result")
+            require(isinstance(hints, list), f"inlayHint is not a list: {hints!r}")
+            for hint in hints:
+                assert_position(hint.get("position"), "hint.position")
+                require(isinstance(hint.get("label"), str), f"hint without a label: {hint!r}")
+                require(hint.get("kind") == 2, f"hint is not InlayHintKind.Parameter: {hint!r}")
+
+            labels = [hint["label"] for hint in hints]
+            require("first:" in labels,
+                    f"the literal argument was not named: {labels!r}")
+            # `watched` is an identifier, not a literal, so it is left alone
+            require("second:" not in labels,
+                    f"a self-naming argument was labelled: {labels!r}")
+
+            # a range that covers nothing yields nothing
+            empty = session.request(
+                "textDocument/inlayHint",
+                {"textDocument": {"uri": main.as_uri()},
+                 "range": {"start": {"line": 0, "character": 0},
+                           "end": {"line": 0, "character": 0}}},
+            )
+            require(empty.get("result") == [], f"an empty range produced hints: {empty!r}")
+
+            session.finish()
+            finished = True
+        finally:
+            if not finished:
+                session.abort()
+
+
 def run_active_watcher_fallback(server: Path, timeout: float) -> None:
     """Prove a missed source event is recovered even after watcher ACK."""
     with tempfile.TemporaryDirectory(prefix="mls-watch-") as directory:
@@ -1486,6 +1555,7 @@ def main() -> int:
         run_document_highlight(server, args.timeout)
         run_workspace_symbol(server, args.timeout)
         run_signature_help(server, args.timeout)
+        run_inlay_hints(server, args.timeout)
         run_same_fqn_reverse(server, args.timeout)
         run_clean_eof(server, args.timeout)
         run_exit_paths(server, args.timeout)
@@ -1504,6 +1574,7 @@ def main() -> int:
     print("  documentHighlight classifies reads and writes in the active file")
     print("  workspace/symbol searches loaded roots, best matches first")
     print("  signatureHelp tracks the active argument through incomplete calls")
+    print("  inlayHint names literal arguments at multi-parameter calls")
     print("  clean EOF after shutdown: exit 0")
     print("  all five lifecycle endings terminate with the documented code")
     print("  malformed/oversized frames: 8 rejected with exit 1")


### PR DESCRIPTION
Closes #169.

## The issue's premise was wrong, and the code proved it

This issue (and my own writing of it) assumed the first use of inlay hints: showing the inferred type of a binding that doesn't state one. **Mach has no such bindings** — `val a = 41;` is a *parse error*, because a binding requires an explicit type annotation.

I built the type-hint version first. It produced hints for a file that doesn't compile, which is how the premise came apart — the parser had recovered and sema had guessed. There is no inferred binding type to reveal.

## What is actually opaque

A call's arguments. `resize(buf, 0, true)` says nothing about which value is the count and which the flag, and the names that would say it live in the callee's declaration.

## Suppression is the whole feature

| rule | hints on `src/server.mach` |
|---|---|
| every argument | 420 |
| literal arguments only | 91 |
| …and skip single-parameter calls | **76** |

Hinting all 420 is not a feature — it buries the few that matter. A one-parameter call has no ambiguity for a name to resolve (`log("x")` gains nothing from `msg:`), and an argument whose own text already spells the parameter name is dropped.

The callee resolves through the same pivot definition uses, so imported functions are named like local ones.